### PR TITLE
Replace event.encoding by event.isBase64Encoded in node bridge

### DIFF
--- a/now-node-bridge/bridge.js
+++ b/now-node-bridge/bridge.js
@@ -25,8 +25,8 @@ class Bridge {
         path = event.path;
         headers = event.headers;
         if (event.body) {
-          assert(event.encoding === 'base64'); // do we support anything else?
-          body = Buffer.from(event.body, event.encoding);
+          assert(event.isBase64Encoded); // do we support anything else?
+          body = Buffer.from(event.body, 'base64');
         }
       } else {
         method = event.httpMethod;


### PR DESCRIPTION
I get this error when using @now/node : 

```json
{"errorMessage":"false == true","errorType":"AssertionError [ERR_ASSERTION]","stackTrace":["Promise (/var/task/bridge.js:28:11)","new Promise (<anonymous>)","Bridge.launcher (/var/task/bridge.js:10:12)"]}
```

This is the code I'm trying to deploy : https://github.com/lucleray/lucleray.me/blob/analytics/analytics/index.js
It fails when sending a POST request to the lambda, with a json object as a body.

`event.encoding` doesn't seem to exist on aws lambda (with api gateway events), isn't it supposed to be `event.isBase64Encoded` ?