### PR TITLE
Don’t download package-lock.json in @now/next

### DIFF
--- a/now-next/index.js
+++ b/now-next/index.js
@@ -36,6 +36,14 @@ exports.build = async ({ files, workPath, entrypoint }) => {
       return true
     }
 
+    if(file === 'package-lock.json') {
+      return true
+    }
+
+    if(file === 'yarn.lock') {
+      return true
+    }
+
     return false
   })
   files = await download(rename(filesToDownload, (file) => {
@@ -168,7 +176,6 @@ exports.prepareCache = async ({ files, cachePath, workPath }) => {
     ...await glob('.next/records.json', cachePath),
     ...await glob('.next/server/records.json', cachePath),
     ...await glob('node_modules/**', cachePath),
-    ...await glob('package-lock.json', cachePath),
     ...await glob('yarn.lock', cachePath)
   };
 };


### PR DESCRIPTION
Since we currently manipulate the package.json and `npm` will disregard it.

Fixes https://spectrum.chat/thread/517bce9b-06f0-48fc-9e98-23754fe36af2
Fixes https://spectrum.chat/thread/9b0a6966-74e2-4d70-8d24-f919eecd99c3

Most likely https://github.com/zeit/now-examples/issues/121 too