### PR TITLE
feat(now-static-build): add a `distDir` option

### DIFF
--- a/packages/now-static-build/index.js
+++ b/packages/now-static-build/index.js
@@ -2,11 +2,12 @@ const download = require('@now/build-utils/fs/download.js');
 const glob = require('@now/build-utils/fs/glob.js');
 const path = require('path');
 const {
-  runNpmInstall, runPackageJsonScript,
-  runShellScript,
+  runNpmInstall, runPackageJsonScript, runShellScript,
 } = require('@now/build-utils/fs/run-user-scripts.js');
 
-exports.build = async ({ files, entrypoint, workPath, config }) => {
+exports.build = async ({
+  files, entrypoint, workPath, config,
+}) => {
   console.log('downloading user files...');
   await download(files, workPath);
   console.log('running user scripts...');
@@ -15,7 +16,7 @@ exports.build = async ({ files, entrypoint, workPath, config }) => {
   const distPath = path.join(
     workPath,
     path.dirname(entrypoint),
-    config && config.distDir || 'dist'
+    (config && config.distDir) || 'dist',
   );
 
   if (path.basename(entrypoint) === 'package.json') {

--- a/packages/now-static-build/index.js
+++ b/packages/now-static-build/index.js
@@ -6,13 +6,17 @@ const {
   runShellScript,
 } = require('@now/build-utils/fs/run-user-scripts.js');
 
-exports.build = async ({ files, entrypoint, workPath }) => {
+exports.build = async ({ files, entrypoint, workPath, config }) => {
   console.log('downloading user files...');
   await download(files, workPath);
   console.log('running user scripts...');
   const mountpoint = path.dirname(entrypoint);
   const entrypointFsDirname = path.join(workPath, mountpoint);
-  const distPath = path.join(workPath, path.dirname(entrypoint), 'dist');
+  const distPath = path.join(
+    workPath,
+    path.dirname(entrypoint),
+    config && config.distDir || 'dist'
+  );
 
   if (path.basename(entrypoint) === 'package.json') {
     await runNpmInstall(entrypointFsDirname, ['--prefer-offline']);


### PR DESCRIPTION
Adds an optional `distDir` config option to now-static-build.

To be used in `now.json` like

```json
{
  "builds": [
    {
      "src": "package.json",
      "use": "@now/static-build",
      "config": { "distDir": "www" }
    }
  ]
}
```

Closes #19