### PR TITLE
[now-go and now-cgi] Don't follow redirects

### DIFF
--- a/packages/now-cgi/main.go
+++ b/packages/now-cgi/main.go
@@ -1,18 +1,18 @@
 package main
 
 import (
-	"os"
-	"fmt"
-	"net"
-	"strings"
-	"io/ioutil"
-	"net/http"
-	"net/http/cgi"
-	"path/filepath"
-	"encoding/json"
 	b64 "encoding/base64"
+	"encoding/json"
+	"fmt"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/cgi"
+	"os"
+	"path/filepath"
+	"strings"
 )
 
 type Request struct {
@@ -69,8 +69,8 @@ func (h *CgiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cgih := cgi.Handler{
 		Path: h.Script,
 		Root: "/" + h.Script,
-		Dir: h.Dir,
-		Env: []string{"SERVER_PORT=443", "HTTPS=on", "SERVER_SOFTWARE=@now/cgi"},
+		Dir:  h.Dir,
+		Env:  []string{"SERVER_PORT=443", "HTTPS=on", "SERVER_SOFTWARE=@now/cgi"},
 	}
 	cgih.ServeHTTP(w, r)
 }

--- a/packages/now-cgi/main.go
+++ b/packages/now-cgi/main.go
@@ -108,6 +108,11 @@ func main() {
 		internalReq, err := http.NewRequest(req.Method, url, strings.NewReader(req.Body))
 		if err != nil {
 			fmt.Println(err)
+			return createErrorResponse("Bad gateway", "bad_gateway", 502)
+		}
+
+		if err != nil {
+			fmt.Println(err)
 			return createErrorResponse("Bad gateway internal req failed", "bad_gateway", 502)
 		}
 

--- a/packages/now-go/main.go
+++ b/packages/now-go/main.go
@@ -95,7 +95,14 @@ func main() {
 			}
 		}
 
-		client := &http.Client{}
+		client := &http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				// we don't want to follow any redirects. that's something the actual client
+				// (i.e., the end user) should do. this internal request is just an implementation detail
+				// that acts like a proxy, so it shouldn't do things that are supposed to be done by the client
+				return http.ErrUseLastResponse
+			},
+		}
 		internalRes, err := client.Do(internalReq)
 		if err != nil {
 			fmt.Println(err)


### PR DESCRIPTION
`now-go` and `now-cgi` are nothing but a proxy. They shouldn't perform tasks that are supposed to be performed by the end-user.

This also prettifies `now-cgi`'s `main.go` via `gofmt`