### PR TITLE
[circle-ci] set `GOPATH` to ~/go

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@ jobs:
     docker:
       - image: circleci/node:10
     working_directory: ~/repo
+    environment:
+      GOPATH: $HOME/go
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Attempting to fix this error:

```
> @now/cgi@0.0.13-canary.3 prepublish /home/circleci/repo/packages/now-cgi
> ./build.sh

main.go:14:2: cannot find package "github.com/aws/aws-lambda-go/events" in any of:
	/usr/lib/go/src/pkg/github.com/aws/aws-lambda-go/events (from $GOROOT)
	($GOPATH not set)
main.go:15:2: cannot find package "github.com/aws/aws-lambda-go/lambda" in any of:
	/usr/lib/go/src/pkg/github.com/aws/aws-lambda-go/lambda (from $GOROOT)
	($GOPATH not set)
```