### PR TITLE
Update mdx-deck dependancy

### DIFF
--- a/packages/now-mdx-deck/index.js
+++ b/packages/now-mdx-deck/index.js
@@ -14,7 +14,7 @@ exports.build = async ({ files, entrypoint, workPath }) => {
   console.log('downloading user files...');
   const downloadedFiles = await download(files, workPath);
   console.log('writing package.json...');
-  const packageJson = { dependencies: { 'mdx-deck': '1.7.7' } };
+  const packageJson = { dependencies: { 'mdx-deck': '1.7.15' } };
   const packageJsonPath = path.join(workPath, 'package.json');
   await writeFile(packageJsonPath, JSON.stringify(packageJson));
   console.log('running npm install...');

--- a/packages/now-mdx-deck/index.js
+++ b/packages/now-mdx-deck/index.js
@@ -47,7 +47,7 @@ exports.build = async ({ files, entrypoint, workPath }) => {
 
 exports.prepareCache = async ({ cachePath }) => {
   console.log('writing package.json...');
-  const packageJson = { dependencies: { 'mdx-deck': '1.7.7' } };
+  const packageJson = { dependencies: { 'mdx-deck': '1.7.15' } };
   const packageJsonPath = path.join(cachePath, 'package.json');
   await writeFile(packageJsonPath, JSON.stringify(packageJson));
   console.log('running npm install...');


### PR DESCRIPTION
Builds failing due to a breaking change in babel-plugin-styled-components 1.9.0. Updates mdx-deck to a version with babel-plugin-styled-components pinned to 1.8.0.

https://github.com/jxnblk/mdx-deck/issues/228

Related: https://github.com/styled-components/babel-plugin-styled-components/issues/182