### PR TITLE
@now/mdx-deck: Accept patch releases for mdx-deck 1.7.x

### DIFF
--- a/packages/now-mdx-deck/index.js
+++ b/packages/now-mdx-deck/index.js
@@ -14,7 +14,7 @@ exports.build = async ({ files, entrypoint, workPath }) => {
   console.log('downloading user files...');
   const downloadedFiles = await download(files, workPath);
   console.log('writing package.json...');
-  const packageJson = { dependencies: { 'mdx-deck': '1.7.7' } };
+  const packageJson = { dependencies: { 'mdx-deck': '^1.7.7' } };
   const packageJsonPath = path.join(workPath, 'package.json');
   await writeFile(packageJsonPath, JSON.stringify(packageJson));
   console.log('running npm install...');
@@ -47,7 +47,7 @@ exports.build = async ({ files, entrypoint, workPath }) => {
 
 exports.prepareCache = async ({ cachePath }) => {
   console.log('writing package.json...');
-  const packageJson = { dependencies: { 'mdx-deck': '1.7.7' } };
+  const packageJson = { dependencies: { 'mdx-deck': '^1.7.7' } };
   const packageJsonPath = path.join(cachePath, 'package.json');
   await writeFile(packageJsonPath, JSON.stringify(packageJson));
   console.log('running npm install...');


### PR DESCRIPTION
I'm getting an error in my [deployment](https://zeit.co/anmonteiro/reasonml-native-lisbon/vtm3pazjh) that has been fixed upstream by https://github.com/jxnblk/mdx-deck/pull/229.

My proposed fix is to allow yarn to install patch releases for the 1.7.x release line of mdx-deck.