### PR TITLE
[now-go] Allow users to use a package name other than 'main'

### DIFF
--- a/packages/now-go/main.go
+++ b/packages/now-go/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	now "../../utils/go/bridge"
 	"net/http"
+	__NOW_HANDLER_PACKAGE_NAME
 )
 
 func main() {

--- a/packages/now-go/util/get-exported-function-name.go
+++ b/packages/now-go/util/get-exported-function-name.go
@@ -34,7 +34,7 @@ func main() {
 		if fn.Name.IsExported() == true {
 			// we found the first exported function
 			// we're done!
-			fmt.Print(fn.Name.Name)
+			fmt.Print(parsed.Name.Name + "." + fn.Name.Name)
 			os.Exit(0)
 		}
 	}


### PR DESCRIPTION
This feature allows users to use a different name for their handler package.

```golang
package main
// vs
package myhandler
```

I did this because go linting complains that the main `package` doesn't have a main `func`. If you use a different `package` name then go linter doesn't care. 