### PR TITLE
@now/next: Support custom source folder

### DIFF
--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -27,6 +27,7 @@ const {
  * @property {Files} files - Files object
  * @property {string} entrypoint - Entrypoint specified for the builder
  * @property {string} workPath - Working directory for this build
+ * @property {Object} config - User-passed config from now.json
  */
 
 /**
@@ -74,7 +75,9 @@ exports.config = {
  * @param {BuildParamsType} buildParams
  * @returns {Promise<Files>}
  */
-exports.build = async ({ files, workPath, entrypoint }) => {
+exports.build = async ({
+  files, workPath, entrypoint, config,
+}) => {
   validateEntrypoint(entrypoint);
 
   console.log('downloading user files...');
@@ -96,6 +99,7 @@ exports.build = async ({ files, workPath, entrypoint }) => {
   console.log('normalizing package.json');
   const packageJson = normalizePackageJson(
     await readPackageJson(downloadedFiles),
+    config && config.srcDir,
   );
   console.log('normalized package.json result: ', packageJson);
   await writePackageJson(workPath, packageJson);

--- a/packages/now-next/utils.js
+++ b/packages/now-next/utils.js
@@ -114,8 +114,9 @@ function excludeStaticDirectory(files) {
 /**
  * Enforce specific package.json configuration for smallest possible lambda
  * @param {{dependencies?: any, devDependencies?: any, scripts?: any}} defaultPackageJson
+ * @param {string=} srcDir
  */
-function normalizePackageJson(defaultPackageJson = {}) {
+function normalizePackageJson(defaultPackageJson = {}, srcDir) {
   const dependencies = {};
   const devDependencies = {
     ...defaultPackageJson.dependencies,
@@ -151,7 +152,7 @@ function normalizePackageJson(defaultPackageJson = {}) {
     },
     scripts: {
       ...defaultPackageJson.scripts,
-      'now-build': 'next build --lambdas',
+      'now-build': `next build${srcDir ? ` ${srcDir}` : ''} --lambdas`,
     },
   };
 }

--- a/test/unit/now-next/utils.test.js
+++ b/test/unit/now-next/utils.test.js
@@ -290,6 +290,30 @@ describe('normalizePackageJson', () => {
     });
   });
 
+  it('should consider srcDir option in now-build script', () => {
+    const defaultPackage = {
+      dependencies: {
+        react: 'latest',
+        'react-dom': 'latest',
+        next: 'latest',
+      },
+    };
+    const result = normalizePackageJson(defaultPackage, 'src');
+    expect(result).toEqual({
+      dependencies: {
+        'next-server': 'canary',
+        react: 'latest',
+        'react-dom': 'latest',
+      },
+      devDependencies: {
+        next: 'canary',
+      },
+      scripts: {
+        'now-build': 'next build src --lambdas',
+      },
+    });
+  });
+
   // https://github.com/zeit/next.js/issues/5700
   it('should normalize user report zeit/next.js#5700 correctly', () => {
     const defaultPackage = {


### PR DESCRIPTION
Support a custom source folder with `srcDir` config. Example:

```bash
├── src
│   ├── components
│   ├── pages
│   └── next.config.js
└── package.json
```

```json
{
  "builds": [
    { "src": "src/next.config.js", "use": "@now/next", "config": { "srcDir": "src" } }
  ]
}
```

Fixes #48.