### PR TITLE
[now-bash] Rename `serve` function to `handler`

### DIFF
--- a/packages/now-bash/builder.sh
+++ b/packages/now-bash/builder.sh
@@ -33,9 +33,9 @@ if declare -f build > /dev/null; then
 	build "$@"
 fi
 
-# Ensure the entrypoint defined a `serve` function
-if ! declare -f serve > /dev/null; then
-	echo "ERROR: A \`serve\` function must be defined in \"$ENTRYPOINT\"!" >&2
+# Ensure the entrypoint defined a `handler` function
+if ! declare -f handler > /dev/null; then
+	echo "ERROR: A \`handler\` function must be defined in \"$ENTRYPOINT\"!" >&2
 	exit 1
 fi
 

--- a/packages/now-bash/runtime.sh
+++ b/packages/now-bash/runtime.sh
@@ -49,7 +49,7 @@ _lambda_runtime_next() {
 	local exit_code=0
 	REQUEST="$event"
 
-	# Stdin of the `serve` function is the HTTP request body.
+	# Stdin of the `handler` function is the HTTP request body.
 	# Need to use a fifo here instead of bash <() because Lambda
 	# errors with "/dev/fd/63 not found" for some reason :/
 	local stdin
@@ -57,7 +57,7 @@ _lambda_runtime_next() {
 	mkfifo "$stdin"
 	_lambda_runtime_body "$event" > "$stdin" &
 
-	serve "$event" < "$stdin" > "$body" || exit_code="$?"
+	handler "$event" < "$stdin" > "$body" || exit_code="$?"
 	rm -f "$event" "$stdin"
 
 	if [ "$exit_code" -eq 0 ]; then


### PR DESCRIPTION
This is more consistent with what you would expect for a lambda function, and we should maintain that convention.

For example: https://github.com/gkrizek/bash-lambda-layer