### PR TITLE
Bump `ncc` to v0.5.3

### DIFF
--- a/packages/now-node-server/index.js
+++ b/packages/now-node-server/index.js
@@ -47,7 +47,7 @@ async function downloadInstallAndBundle(
       'package.json': new FileBlob({
         data: JSON.stringify({
           dependencies: {
-            '@zeit/ncc': '0.4.1',
+            '@zeit/ncc': '0.5.3',
           },
         }),
       }),

--- a/packages/now-node/index.js
+++ b/packages/now-node/index.js
@@ -45,7 +45,7 @@ async function downloadInstallAndBundle(
       'package.json': new FileBlob({
         data: JSON.stringify({
           dependencies: {
-            '@zeit/ncc': '0.4.1',
+            '@zeit/ncc': '0.5.3',
           },
         }),
       }),


### PR DESCRIPTION
A more recent version of ncc is giving us better typescript support.

