### PR TITLE
Switch bridge.go response headers to map of slices

### DIFF
--- a/packages/now-php/test/fixtures/12-setcookie/probe.js
+++ b/packages/now-php/test/fixtures/12-setcookie/probe.js
@@ -4,6 +4,6 @@ module.exports = async ({ deploymentUrl, fetch }) => {
   const resp = await fetch(`https://${deploymentUrl}/index.php`);
   assert(resp.status === 200);
   assert.equal(resp.headers.get('content-type'), 'text/plain; charset=UTF-16');
-  // assert(resp.headers.get('set-cookie').includes('cookie1=cookie1value')); // TODO
+  assert(resp.headers.get('set-cookie').includes('cookie1=cookie1value'));
   assert(resp.headers.get('set-cookie').includes('cookie2=cookie2value'));
 };

--- a/utils/go/bridge/bridge.go
+++ b/utils/go/bridge/bridge.go
@@ -21,10 +21,10 @@ type Request struct {
 }
 
 type Response struct {
-	StatusCode int               `json:"statusCode"`
-	Headers    map[string]string `json:"headers"`
-	Encoding   string            `json:"encoding,omitemtpy"`
-	Body       string            `json:"body"`
+	StatusCode int                 `json:"statusCode"`
+	Headers    map[string][]string `json:"headers"`
+	Encoding   string              `json:"encoding,omitemtpy"`
+	Body       string              `json:"body"`
 }
 
 type ResponseWriter struct {
@@ -93,10 +93,10 @@ func Serve(handler http.Handler, req *Request) (res Response, err error) {
 	handler.ServeHTTP(w, r)
 	defer r.Body.Close()
 
-	headers := make(map[string]string)
+	headers := make(map[string][]string)
 	for k, v := range w.headers {
 		for _, s := range v {
-			headers[k] = s
+			headers[k] = append(headers[k], s)
 		}
 	}
 


### PR DESCRIPTION
this fixes several-values-per-header-name issue + test