### PR TITLE
Increase heap size for @now/next

### DIFF
--- a/packages/now-next/utils.js
+++ b/packages/now-next/utils.js
@@ -164,7 +164,7 @@ function normalizePackageJson(defaultPackageJson = {}) {
     },
     scripts: {
       ...defaultPackageJson.scripts,
-      'now-build': 'next build --lambdas',
+      'now-build': 'NODE_OPTIONS=--max_old_space_size=3000 next build --lambdas',
     },
   };
 }

--- a/test/unit/now-next/utils.test.js
+++ b/test/unit/now-next/utils.test.js
@@ -216,7 +216,8 @@ describe('normalizePackageJson', () => {
         next: 'canary',
       },
       scripts: {
-        'now-build': 'next build --lambdas',
+        'now-build':
+          'NODE_OPTIONS=--max_old_space_size=3000 next build --lambdas',
       },
     });
   });
@@ -246,7 +247,8 @@ describe('normalizePackageJson', () => {
         next: 'canary',
       },
       scripts: {
-        'now-build': 'next build --lambdas',
+        'now-build':
+          'NODE_OPTIONS=--max_old_space_size=3000 next build --lambdas',
       },
     });
   });
@@ -270,7 +272,8 @@ describe('normalizePackageJson', () => {
         next: 'canary',
       },
       scripts: {
-        'now-build': 'next build --lambdas',
+        'now-build':
+          'NODE_OPTIONS=--max_old_space_size=3000 next build --lambdas',
       },
     });
   });
@@ -294,7 +297,8 @@ describe('normalizePackageJson', () => {
         next: 'canary',
       },
       scripts: {
-        'now-build': 'next build --lambdas',
+        'now-build':
+          'NODE_OPTIONS=--max_old_space_size=3000 next build --lambdas',
       },
     });
   });
@@ -318,7 +322,8 @@ describe('normalizePackageJson', () => {
         next: 'canary',
       },
       scripts: {
-        'now-build': 'next build --lambdas',
+        'now-build':
+          'NODE_OPTIONS=--max_old_space_size=3000 next build --lambdas',
       },
     });
   });
@@ -380,7 +385,8 @@ describe('normalizePackageJson', () => {
       scripts: {
         dev: 'next',
         build: 'next build',
-        'now-build': 'next build --lambdas',
+        'now-build':
+          'NODE_OPTIONS=--max_old_space_size=3000 next build --lambdas',
         start: 'next start',
         test: "xo && stylelint './pages/**/*.js' && jest",
       },


### PR DESCRIPTION
This makes sure larger applications don't run out of memory when building.