### PR TITLE
[now-bash] make the `curl` calls to AWS API silent

### DIFF
--- a/packages/now-bash/runtime.sh
+++ b/packages/now-bash/runtime.sh
@@ -69,11 +69,11 @@ _lambda_runtime_next() {
 			--arg body "$(base64 --wrap=0 < "$body")" \
 			'{statusCode:$statusCode|tonumber, headers:$headers, encoding:"base64", body:$body}')"
 		rm -f "$body" "$_HEADERS"
-		_lambda_runtime_api "invocation/$request_id/response" -X POST -d "$response"
+		_lambda_runtime_api "invocation/$request_id/response" -X POST -d "$response" > /dev/null
 	else
-		local error
-		error='{"exitCode":'"$exit_code"'}'
-		_lambda_runtime_api "invocation/$request_id/error" -X POST -d "$error"
+		echo "\`handler\` function return code: $exit_code"
+		local error='{"exitCode":'"$exit_code"'}'
+		_lambda_runtime_api "invocation/$request_id/error" -X POST -d "$error" > /dev/null
 	fi
 }
 

--- a/packages/now-bash/runtime.sh
+++ b/packages/now-bash/runtime.sh
@@ -39,7 +39,6 @@ _lambda_runtime_next() {
 
 	local request_id
 	request_id="$(grep -Fi Lambda-Runtime-Aws-Request-Id "$headers" | tr -d '[:space:]' | cut -d: -f2)"
-	echo "Request-Id: $request_id" >&2
 	rm -f "$headers"
 
 	# Execute the handler function from the script


### PR DESCRIPTION
Also log the exit status of the `handler` function.