### PR TITLE
[now-bash] add `stdio: inherit` to builder.sh script

### DIFF
--- a/packages/now-bash/index.js
+++ b/packages/now-bash/index.js
@@ -38,6 +38,7 @@ exports.build = async ({ files, entrypoint, config }) => {
   await execa(builderPath, [entrypoint], {
     env,
     cwd: workDir,
+    stdio: 'inherit',
   });
 
   const lambda = await createLambda({


### PR DESCRIPTION
So that the build logs of the bash script are sent to the deployment logs.