### PR TITLE
Lock Next.js Version

### DIFF
--- a/packages/now-next/utils.js
+++ b/packages/now-next/utils.js
@@ -179,4 +179,3 @@ module.exports = {
   excludeStaticDirectory,
   onlyStaticDirectory,
 };
-

--- a/packages/now-next/utils.js
+++ b/packages/now-next/utils.js
@@ -179,3 +179,4 @@ module.exports = {
   excludeStaticDirectory,
   onlyStaticDirectory,
 };
+

--- a/packages/now-next/utils.js
+++ b/packages/now-next/utils.js
@@ -153,12 +153,12 @@ function normalizePackageJson(defaultPackageJson = {}) {
       'react-dom': 'latest',
       ...dependencies, // override react if user provided it
       // next-server is forced to canary
-      'next-server': 'canary',
+      'next-server': 'v7.0.2-canary.49',
     },
     devDependencies: {
       ...devDependencies,
       // next is forced to canary
-      next: 'canary',
+      next: 'v7.0.2-canary.49',
       // next-server is a dependency here
       'next-server': undefined,
     },

--- a/test/unit/now-next/utils.test.js
+++ b/test/unit/now-next/utils.test.js
@@ -258,7 +258,7 @@ describe('normalizePackageJson', () => {
       dependencies: {
         react: 'latest',
         'react-dom': 'latest',
-        next: 'v7.0.2-canary.49',
+        next: 'latest',
       },
     };
     const result = normalizePackageJson(defaultPackage);
@@ -283,7 +283,7 @@ describe('normalizePackageJson', () => {
       dependencies: {
         react: 'latest',
         'react-dom': 'latest',
-        next: 'v7.0.2-canary.49',
+        next: 'latest',
       },
     };
     const result = normalizePackageJson(defaultPackage);

--- a/test/unit/now-next/utils.test.js
+++ b/test/unit/now-next/utils.test.js
@@ -208,12 +208,12 @@ describe('normalizePackageJson', () => {
     const result = normalizePackageJson();
     expect(result).toEqual({
       dependencies: {
-        'next-server': 'canary',
+        'next-server': 'v7.0.2-canary.49',
         react: 'latest',
         'react-dom': 'latest',
       },
       devDependencies: {
-        next: 'canary',
+        next: 'v7.0.2-canary.49',
       },
       scripts: {
         'now-build':
@@ -225,12 +225,12 @@ describe('normalizePackageJson', () => {
   it('should work with a package.json being supplied', () => {
     const defaultPackage = {
       dependencies: {
-        'next-server': 'canary',
+        'next-server': 'v7.0.2-canary.49',
         react: 'latest',
         'react-dom': 'latest',
       },
       devDependencies: {
-        next: 'canary',
+        next: 'v7.0.2-canary.49',
       },
       scripts: {
         'now-build': 'next build',
@@ -239,12 +239,12 @@ describe('normalizePackageJson', () => {
     const result = normalizePackageJson(defaultPackage);
     expect(result).toEqual({
       dependencies: {
-        'next-server': 'canary',
+        'next-server': 'v7.0.2-canary.49',
         react: 'latest',
         'react-dom': 'latest',
       },
       devDependencies: {
-        next: 'canary',
+        next: 'v7.0.2-canary.49',
       },
       scripts: {
         'now-build':
@@ -258,18 +258,18 @@ describe('normalizePackageJson', () => {
       dependencies: {
         react: 'latest',
         'react-dom': 'latest',
-        next: 'latest',
+        next: 'v7.0.2-canary.49',
       },
     };
     const result = normalizePackageJson(defaultPackage);
     expect(result).toEqual({
       dependencies: {
-        'next-server': 'canary',
+        'next-server': 'v7.0.2-canary.49',
         react: 'latest',
         'react-dom': 'latest',
       },
       devDependencies: {
-        next: 'canary',
+        next: 'v7.0.2-canary.49',
       },
       scripts: {
         'now-build':
@@ -283,18 +283,18 @@ describe('normalizePackageJson', () => {
       dependencies: {
         react: 'latest',
         'react-dom': 'latest',
-        next: 'latest',
+        next: 'v7.0.2-canary.49',
       },
     };
     const result = normalizePackageJson(defaultPackage);
     expect(result).toEqual({
       dependencies: {
-        'next-server': 'canary',
+        'next-server': 'v7.0.2-canary.49',
         react: 'latest',
         'react-dom': 'latest',
       },
       devDependencies: {
-        next: 'canary',
+        next: 'v7.0.2-canary.49',
       },
       scripts: {
         'now-build':
@@ -314,12 +314,12 @@ describe('normalizePackageJson', () => {
     const result = normalizePackageJson(defaultPackage);
     expect(result).toEqual({
       dependencies: {
-        'next-server': 'canary',
+        'next-server': 'v7.0.2-canary.49',
         react: 'latest',
         'react-dom': 'latest',
       },
       devDependencies: {
-        next: 'canary',
+        next: 'v7.0.2-canary.49',
       },
       scripts: {
         'now-build':
@@ -403,7 +403,7 @@ describe('normalizePackageJson', () => {
         'stylelint-config-recommended': '^2.1.0',
         'stylelint-config-styled-components': '^0.1.1',
         'stylelint-processor-styled-components': '^1.5.1',
-        next: 'canary',
+        next: 'v7.0.2-canary.49',
         'next-server': undefined,
         xo: '^0.23.0',
         consola: '^2.2.6',
@@ -411,7 +411,7 @@ describe('normalizePackageJson', () => {
         'styled-components': '^4.1.1',
       },
       dependencies: {
-        'next-server': 'canary',
+        'next-server': 'v7.0.2-canary.49',
         react: '^16.6.3',
         'react-dom': '^16.6.3',
       },


### PR DESCRIPTION
In preparation with a breaking change in the way Next.js builds, we need to lock the version used. (https://github.com/zeit/next.js/pull/5927)