### PR TITLE
Add missing license to package.json

### DIFF
--- a/packages/now-build-utils/package.json
+++ b/packages/now-build-utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@now/build-utils",
   "version": "0.4.32-canary.3",
+  "license": "MIT",
   "dependencies": {
     "async-retry": "1.2.3",
     "async-sema": "2.1.4",

--- a/packages/now-cgi/package.json
+++ b/packages/now-cgi/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@now/cgi",
   "version": "0.0.14",
+  "license": "MIT",
   "scripts": {
     "test": "best -I test/*.js",
     "prepublish": "./build.sh"

--- a/packages/now-go/package.json
+++ b/packages/now-go/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@now/go",
   "version": "0.2.11",
+  "license": "MIT",
   "scripts": {
     "test": "best -I test/*.js",
     "prepublish": "./build.sh"

--- a/packages/now-html-minifier/package.json
+++ b/packages/now-html-minifier/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@now/html-minifier",
   "version": "1.0.6",
+  "license": "MIT",
   "dependencies": {
     "html-minifier": "3.5.21"
   },

--- a/packages/now-lambda/package.json
+++ b/packages/now-lambda/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@now/lambda",
   "version": "0.4.8",
+  "license": "MIT",
   "peerDependencies": {
     "@now/build-utils": ">=0.0.1"
   },

--- a/packages/now-md/package.json
+++ b/packages/now-md/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@now/md",
   "version": "0.4.8",
+  "license": "MIT",
   "dependencies": {
     "rehype-document": "^2.2.0",
     "rehype-format": "^2.3.0",

--- a/packages/now-mdx-deck/package.json
+++ b/packages/now-mdx-deck/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@now/mdx-deck",
   "version": "0.4.18-canary.0",
+  "license": "MIT",
   "peerDependencies": {
     "@now/build-utils": ">=0.0.1"
   },

--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@now/next",
   "version": "0.0.82-canary.1",
+  "license": "MIT",
   "dependencies": {
     "@now/node-bridge": "0.1.4",
     "execa": "^1.0.0",

--- a/packages/now-node-bridge/package.json
+++ b/packages/now-node-bridge/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@now/node-bridge",
   "version": "0.1.10-canary.0",
+  "license": "MIT",
   "peerDependencies": {
     "@now/build-utils": ">=0.0.1"
   }

--- a/packages/now-node-server/package.json
+++ b/packages/now-node-server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@now/node-server",
   "version": "0.4.26-canary.5",
+  "license": "MIT",
   "dependencies": {
     "@now/node-bridge": "^0.1.10-canary.0",
     "fs-extra": "7.0.1"

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@now/node",
   "version": "0.4.28-canary.4",
+  "license": "MIT",
   "dependencies": {
     "@now/node-bridge": "^0.1.10-canary.0",
     "fs-extra": "7.0.1"

--- a/packages/now-optipng/package.json
+++ b/packages/now-optipng/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@now/optipng",
   "version": "0.4.7",
+  "license": "MIT",
   "dependencies": {
     "multipipe": "2.0.3",
     "optipng": "1.1.0"

--- a/packages/now-php-bridge/package.json
+++ b/packages/now-php-bridge/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@now/php-bridge",
   "version": "0.4.13-canary.0",
+  "license": "MIT",
   "dependencies": {
     "fastcgi-client": "0.0.1"
   },

--- a/packages/now-php/package.json
+++ b/packages/now-php/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@now/php",
   "version": "0.4.13-canary.1",
+  "license": "MIT",
   "dependencies": {
     "@now/php-bridge": "^0.4.13-canary.0"
   },

--- a/packages/now-static-build/package.json
+++ b/packages/now-static-build/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@now/static-build",
   "version": "0.4.16",
+  "license": "MIT",
   "peerDependencies": {
     "@now/build-utils": ">=0.0.1"
   },

--- a/packages/now-wordpress/package.json
+++ b/packages/now-wordpress/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@now/wordpress",
   "version": "0.4.14-canary.0",
+  "license": "MIT",
   "dependencies": {
     "@now/php-bridge": "^0.4.13-canary.0",
     "node-fetch": "2.3.0",


### PR DESCRIPTION
I noticed that the v2 logs show warnings about missing license. At first I thought it was my own code but then I realized it was the builders.