### PR TITLE
Add repository key to package.json

### DIFF
--- a/packages/now-bash/package.json
+++ b/packages/now-bash/package.json
@@ -5,6 +5,11 @@
   "main": "index.js",
   "author": "Nathan Rajlich <nate@zeit.co>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zeit/now-builders.git",
+    "directory": "packages/now-bash"
+  },
   "files": [
     "builder.sh",
     "runtime.sh",

--- a/packages/now-build-utils/package.json
+++ b/packages/now-build-utils/package.json
@@ -2,6 +2,11 @@
   "name": "@now/build-utils",
   "version": "0.4.33-canary.1",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zeit/now-builders.git",
+    "directory": "packages/now-build-utils"
+  },
   "dependencies": {
     "async-retry": "1.2.3",
     "async-sema": "2.1.4",

--- a/packages/now-cgi/package.json
+++ b/packages/now-cgi/package.json
@@ -2,6 +2,11 @@
   "name": "@now/cgi",
   "version": "0.0.15",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zeit/now-builders.git",
+    "directory": "packages/now-cgi"
+  },
   "scripts": {
     "test": "best -I test/*.js",
     "prepublish": "./build.sh"

--- a/packages/now-go/package.json
+++ b/packages/now-go/package.json
@@ -2,6 +2,11 @@
   "name": "@now/go",
   "version": "0.2.12",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zeit/now-builders.git",
+    "directory": "packages/now-go"
+  },
   "scripts": {
     "test": "best -I test/*.js",
     "prepublish": "./build.sh"

--- a/packages/now-html-minifier/package.json
+++ b/packages/now-html-minifier/package.json
@@ -2,6 +2,11 @@
   "name": "@now/html-minifier",
   "version": "1.0.7",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zeit/now-builders.git",
+    "directory": "packages/now-html-minifier"
+  },
   "dependencies": {
     "html-minifier": "3.5.21"
   },

--- a/packages/now-lambda/package.json
+++ b/packages/now-lambda/package.json
@@ -2,6 +2,11 @@
   "name": "@now/lambda",
   "version": "0.4.9",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zeit/now-builders.git",
+    "directory": "packages/now-lambda"
+  },
   "peerDependencies": {
     "@now/build-utils": ">=0.0.1"
   },

--- a/packages/now-md/package.json
+++ b/packages/now-md/package.json
@@ -2,6 +2,11 @@
   "name": "@now/md",
   "version": "0.4.9",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zeit/now-builders.git",
+    "directory": "packages/now-md"
+  },
   "dependencies": {
     "rehype-document": "^2.2.0",
     "rehype-format": "^2.3.0",

--- a/packages/now-mdx-deck/package.json
+++ b/packages/now-mdx-deck/package.json
@@ -2,6 +2,11 @@
   "name": "@now/mdx-deck",
   "version": "0.4.18",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zeit/now-builders.git",
+    "directory": "packages/now-mdx-deck"
+  },
   "peerDependencies": {
     "@now/build-utils": ">=0.0.1"
   },

--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -2,6 +2,11 @@
   "name": "@now/next",
   "version": "0.0.84",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zeit/now-builders.git",
+    "directory": "packages/now-next"
+  },
   "dependencies": {
     "@now/node-bridge": "0.1.4",
     "execa": "^1.0.0",

--- a/packages/now-node-bridge/package.json
+++ b/packages/now-node-bridge/package.json
@@ -2,6 +2,11 @@
   "name": "@now/node-bridge",
   "version": "0.1.10",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zeit/now-builders.git",
+    "directory": "packages/now-node-bridge"
+  },
   "peerDependencies": {
     "@now/build-utils": ">=0.0.1"
   }

--- a/packages/now-node-server/package.json
+++ b/packages/now-node-server/package.json
@@ -2,6 +2,11 @@
   "name": "@now/node-server",
   "version": "0.4.27-canary.0",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zeit/now-builders.git",
+    "directory": "packages/now-node-server"
+  },
   "dependencies": {
     "@now/node-bridge": "^0.1.10",
     "fs-extra": "7.0.1"

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -2,6 +2,11 @@
   "name": "@now/node",
   "version": "0.4.29-canary.0",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zeit/now-builders.git",
+    "directory": "packages/now-node"
+  },
   "dependencies": {
     "@now/node-bridge": "^0.1.10",
     "fs-extra": "7.0.1"

--- a/packages/now-optipng/package.json
+++ b/packages/now-optipng/package.json
@@ -2,6 +2,11 @@
   "name": "@now/optipng",
   "version": "0.4.8",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zeit/now-builders.git",
+    "directory": "packages/now-optipng"
+  },
   "dependencies": {
     "multipipe": "2.0.3",
     "optipng": "1.1.0"

--- a/packages/now-php-bridge/package.json
+++ b/packages/now-php-bridge/package.json
@@ -2,6 +2,11 @@
   "name": "@now/php-bridge",
   "version": "0.4.13",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zeit/now-builders.git",
+    "directory": "packages/now-php-bridge"
+  },
   "dependencies": {
     "fastcgi-client": "0.0.1"
   },

--- a/packages/now-php/package.json
+++ b/packages/now-php/package.json
@@ -2,6 +2,11 @@
   "name": "@now/php",
   "version": "0.4.13",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zeit/now-builders.git",
+    "directory": "packages/now-php"
+  },
   "dependencies": {
     "@now/php-bridge": "^0.4.13"
   },

--- a/packages/now-python/package.json
+++ b/packages/now-python/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.40",
   "main": "index.js",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zeit/now-builders.git",
+    "directory": "packages/now-python"
+  },
   "dependencies": {
     "execa": "^1.0.0",
     "fs.promised": "^3.0.0",

--- a/packages/now-static-build/package.json
+++ b/packages/now-static-build/package.json
@@ -2,6 +2,11 @@
   "name": "@now/static-build",
   "version": "0.4.17",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zeit/now-builders.git",
+    "directory": "packages/now-static-build"
+  },
   "peerDependencies": {
     "@now/build-utils": ">=0.0.1"
   },

--- a/packages/now-wordpress/package.json
+++ b/packages/now-wordpress/package.json
@@ -2,6 +2,11 @@
   "name": "@now/wordpress",
   "version": "0.4.14",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zeit/now-builders.git",
+    "directory": "packages/now-wordpress"
+  },
   "dependencies": {
     "@now/php-bridge": "^0.4.13",
     "node-fetch": "2.3.0",


### PR DESCRIPTION
This will increase discoverability for users who see a builder, visit npmjs.com, and then want to know how to get to github to submit a PR.

The `repository` key will add a link to github from npm.

I also added the `directory` so the future npm will be able to link to the exact package in this monorepo. See [RFC 10](https://github.com/npm/rfcs/blob/latest/accepted/0010-monorepo-subdirectory-declaration.md) for more info.