### PR TITLE
Add license to satisify warning

### DIFF
--- a/packages/now-node-server/index.js
+++ b/packages/now-node-server/index.js
@@ -46,7 +46,7 @@ async function downloadInstallAndBundle(
     {
       'package.json': new FileBlob({
         data: JSON.stringify({
-          license: 'MIT',
+          license: 'UNLICENSED',
           dependencies: {
             '@zeit/ncc': '0.13.0',
           },

--- a/packages/now-node-server/index.js
+++ b/packages/now-node-server/index.js
@@ -46,6 +46,7 @@ async function downloadInstallAndBundle(
     {
       'package.json': new FileBlob({
         data: JSON.stringify({
+          license: 'MIT',
           dependencies: {
             '@zeit/ncc': '0.13.0',
           },

--- a/packages/now-node/index.js
+++ b/packages/now-node/index.js
@@ -44,6 +44,7 @@ async function downloadInstallAndBundle(
     {
       'package.json': new FileBlob({
         data: JSON.stringify({
+          license: 'MIT',
           dependencies: {
             '@zeit/ncc': '0.13.0',
           },

--- a/packages/now-node/index.js
+++ b/packages/now-node/index.js
@@ -44,7 +44,7 @@ async function downloadInstallAndBundle(
     {
       'package.json': new FileBlob({
         data: JSON.stringify({
-          license: 'MIT',
+          license: 'UNLICENSED',
           dependencies: {
             '@zeit/ncc': '0.13.0',
           },


### PR DESCRIPTION
This solves the warning seen in `/_logs` all the time:

```
warning package.json: No license field
```