### PR TITLE
Remove @now/build-utils peer dependency

### DIFF
--- a/packages/now-bash/index.js
+++ b/packages/now-bash/index.js
@@ -1,10 +1,10 @@
 const execa = require('execa');
 const { join } = require('path');
 const snakeCase = require('snake-case');
-const glob = require('@now/build-utils/fs/glob');
-const download = require('@now/build-utils/fs/download');
-const { createLambda } = require('@now/build-utils/lambda');
-const getWritableDirectory = require('@now/build-utils/fs/get-writable-directory');
+const glob = require('@now/build-utils/fs/glob'); // eslint-disable-line import/no-extraneous-dependencies
+const download = require('@now/build-utils/fs/download'); // eslint-disable-line import/no-extraneous-dependencies
+const { createLambda } = require('@now/build-utils/lambda'); // eslint-disable-line import/no-extraneous-dependencies
+const getWritableDirectory = require('@now/build-utils/fs/get-writable-directory'); // eslint-disable-line import/no-extraneous-dependencies
 
 exports.config = {
   maxLambdaSize: '10mb',

--- a/packages/now-bash/package.json
+++ b/packages/now-bash/package.json
@@ -20,8 +20,5 @@
   "dependencies": {
     "execa": "^1.0.0",
     "snake-case": "^2.1.0"
-  },
-  "peerDependencies": {
-    "@now/build-utils": ">=0.0.1"
   }
 }

--- a/packages/now-cgi/index.js
+++ b/packages/now-cgi/index.js
@@ -1,10 +1,10 @@
 const path = require('path');
 const { mkdirp, copyFile } = require('fs-extra');
 
-const glob = require('@now/build-utils/fs/glob');
-const download = require('@now/build-utils/fs/download');
-const { createLambda } = require('@now/build-utils/lambda');
-const getWritableDirectory = require('@now/build-utils/fs/get-writable-directory');
+const glob = require('@now/build-utils/fs/glob'); // eslint-disable-line import/no-extraneous-dependencies
+const download = require('@now/build-utils/fs/download'); // eslint-disable-line import/no-extraneous-dependencies
+const { createLambda } = require('@now/build-utils/lambda'); // eslint-disable-line import/no-extraneous-dependencies
+const getWritableDirectory = require('@now/build-utils/fs/get-writable-directory'); // eslint-disable-line import/no-extraneous-dependencies
 
 exports.analyze = ({ files, entrypoint }) => files[entrypoint].digest;
 

--- a/packages/now-cgi/package.json
+++ b/packages/now-cgi/package.json
@@ -21,8 +21,5 @@
   "devDependencies": {
     "@zeit/best": "0.4.3",
     "rmfr": "2.0.0"
-  },
-  "peerDependencies": {
-    "@now/build-utils": ">=0.0.1"
   }
 }

--- a/packages/now-go/download-go-bin.js
+++ b/packages/now-go/download-go-bin.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 const fetch = require('node-fetch');
 const tar = require('tar');
-const getWritableDirectory = require('@now/build-utils/fs/get-writable-directory.js');
+const getWritableDirectory = require('@now/build-utils/fs/get-writable-directory.js'); // eslint-disable-line import/no-extraneous-dependencies
 
 const url = 'https://dl.google.com/go/go1.11.1.linux-amd64.tar.gz';
 

--- a/packages/now-go/index.js
+++ b/packages/now-go/index.js
@@ -2,11 +2,11 @@ const path = require('path');
 const { mkdirp, readFile, writeFile } = require('fs-extra');
 
 const execa = require('execa');
-const { createLambda } = require('@now/build-utils/lambda.js');
-const getWritableDirectory = require('@now/build-utils/fs/get-writable-directory.js');
-const download = require('@now/build-utils/fs/download.js');
+const { createLambda } = require('@now/build-utils/lambda.js'); // eslint-disable-line import/no-extraneous-dependencies
+const getWritableDirectory = require('@now/build-utils/fs/get-writable-directory.js'); // eslint-disable-line import/no-extraneous-dependencies
+const download = require('@now/build-utils/fs/download.js'); // eslint-disable-line import/no-extraneous-dependencies
 const downloadGit = require('lambda-git');
-const glob = require('@now/build-utils/fs/glob.js');
+const glob = require('@now/build-utils/fs/glob.js'); // eslint-disable-line import/no-extraneous-dependencies
 const downloadGoBin = require('./download-go-bin');
 
 // creates a `$GOPATH` directory tree, as per

--- a/packages/now-go/package.json
+++ b/packages/now-go/package.json
@@ -28,8 +28,5 @@
   "devDependencies": {
     "@zeit/best": "0.4.3",
     "rmfr": "2.0.0"
-  },
-  "peerDependencies": {
-    "@now/build-utils": ">=0.0.1"
   }
 }

--- a/packages/now-html-minifier/index.js
+++ b/packages/now-html-minifier/index.js
@@ -1,4 +1,4 @@
-const FileBlob = require('@now/build-utils/file-blob.js');
+const FileBlob = require('@now/build-utils/file-blob.js'); // eslint-disable-line import/no-extraneous-dependencies
 const { minify } = require('html-minifier');
 
 const defaultOptions = {

--- a/packages/now-html-minifier/package.json
+++ b/packages/now-html-minifier/package.json
@@ -9,8 +9,5 @@
   },
   "dependencies": {
     "html-minifier": "3.5.21"
-  },
-  "peerDependencies": {
-    "@now/build-utils": ">=0.0.1"
   }
 }

--- a/packages/now-lambda/index.js
+++ b/packages/now-lambda/index.js
@@ -1,5 +1,5 @@
-const { Lambda } = require('@now/build-utils/lambda.js');
-const streamToBuffer = require('@now/build-utils/fs/stream-to-buffer.js');
+const { Lambda } = require('@now/build-utils/lambda.js'); // eslint-disable-line import/no-extraneous-dependencies
+const streamToBuffer = require('@now/build-utils/fs/stream-to-buffer.js'); // eslint-disable-line import/no-extraneous-dependencies
 
 exports.build = async ({ files, entrypoint, config }) => {
   if (!files[entrypoint]) throw new Error('Entrypoint not found in files');

--- a/packages/now-lambda/package.json
+++ b/packages/now-lambda/package.json
@@ -7,9 +7,6 @@
     "url": "https://github.com/zeit/now-builders.git",
     "directory": "packages/now-lambda"
   },
-  "peerDependencies": {
-    "@now/build-utils": ">=0.0.1"
-  },
   "scripts": {
     "test": "jest"
   }

--- a/packages/now-md/index.js
+++ b/packages/now-md/index.js
@@ -1,4 +1,4 @@
-const FileBlob = require('@now/build-utils/file-blob.js');
+const FileBlob = require('@now/build-utils/file-blob.js'); // eslint-disable-line import/no-extraneous-dependencies
 const unified = require('unified');
 const unifiedStream = require('unified-stream');
 const markdown = require('remark-parse');

--- a/packages/now-md/package.json
+++ b/packages/now-md/package.json
@@ -16,9 +16,6 @@
     "unified": "^7.0.0",
     "unified-stream": "^1.0.2"
   },
-  "peerDependencies": {
-    "@now/build-utils": ">=0.0.1"
-  },
   "scripts": {
     "test": "jest"
   }

--- a/packages/now-mdx-deck/index.js
+++ b/packages/now-mdx-deck/index.js
@@ -1,10 +1,10 @@
-const download = require('@now/build-utils/fs/download.js');
+const download = require('@now/build-utils/fs/download.js'); // eslint-disable-line import/no-extraneous-dependencies
 const fs = require('fs');
 const { promisify } = require('util');
-const getWritableDirectory = require('@now/build-utils/fs/get-writable-directory.js');
-const glob = require('@now/build-utils/fs/glob.js');
+const getWritableDirectory = require('@now/build-utils/fs/get-writable-directory.js'); // eslint-disable-line import/no-extraneous-dependencies
+const glob = require('@now/build-utils/fs/glob.js'); // eslint-disable-line import/no-extraneous-dependencies
 const path = require('path');
-const { runNpmInstall } = require('@now/build-utils/fs/run-user-scripts.js');
+const { runNpmInstall } = require('@now/build-utils/fs/run-user-scripts.js'); // eslint-disable-line import/no-extraneous-dependencies
 
 const writeFile = promisify(fs.writeFile);
 

--- a/packages/now-mdx-deck/package.json
+++ b/packages/now-mdx-deck/package.json
@@ -7,9 +7,6 @@
     "url": "https://github.com/zeit/now-builders.git",
     "directory": "packages/now-mdx-deck"
   },
-  "peerDependencies": {
-    "@now/build-utils": ">=0.0.1"
-  },
   "scripts": {
     "test": "jest"
   }

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -1,14 +1,14 @@
-const { createLambda } = require('@now/build-utils/lambda.js');
-const download = require('@now/build-utils/fs/download.js');
-const FileFsRef = require('@now/build-utils/file-fs-ref.js');
-const FileBlob = require('@now/build-utils/file-blob');
+const { createLambda } = require('@now/build-utils/lambda.js'); // eslint-disable-line import/no-extraneous-dependencies
+const download = require('@now/build-utils/fs/download.js'); // eslint-disable-line import/no-extraneous-dependencies
+const FileFsRef = require('@now/build-utils/file-fs-ref.js'); // eslint-disable-line import/no-extraneous-dependencies
+const FileBlob = require('@now/build-utils/file-blob'); // eslint-disable-line import/no-extraneous-dependencies
 const path = require('path');
 const { readFile, writeFile, unlink } = require('fs.promised');
 const {
   runNpmInstall,
   runPackageJsonScript,
-} = require('@now/build-utils/fs/run-user-scripts.js');
-const glob = require('@now/build-utils/fs/glob.js');
+} = require('@now/build-utils/fs/run-user-scripts.js'); // eslint-disable-line import/no-extraneous-dependencies
+const glob = require('@now/build-utils/fs/glob.js'); // eslint-disable-line import/no-extraneous-dependencies
 const semver = require('semver');
 const nextLegacyVersions = require('./legacy-versions');
 const {

--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -12,8 +12,5 @@
     "execa": "^1.0.0",
     "fs.promised": "^3.0.0",
     "semver": "^5.6.0"
-  },
-  "peerDependencies": {
-    "@now/build-utils": ">=0.0.1"
   }
 }

--- a/packages/now-next/utils.js
+++ b/packages/now-next/utils.js
@@ -1,4 +1,4 @@
-const rename = require('@now/build-utils/fs/rename.js');
+const rename = require('@now/build-utils/fs/rename.js'); // eslint-disable-line import/no-extraneous-dependencies
 
 /** @typedef { import('@now/build-utils/file-ref') } FileRef */
 /** @typedef { import('@now/build-utils/file-fs-ref') } FileFsRef */

--- a/packages/now-node-bridge/package.json
+++ b/packages/now-node-bridge/package.json
@@ -6,8 +6,5 @@
     "type": "git",
     "url": "https://github.com/zeit/now-builders.git",
     "directory": "packages/now-node-bridge"
-  },
-  "peerDependencies": {
-    "@now/build-utils": ">=0.0.1"
   }
 }

--- a/packages/now-node-server/index.js
+++ b/packages/now-node-server/index.js
@@ -1,15 +1,15 @@
-const { createLambda } = require('@now/build-utils/lambda.js');
-const download = require('@now/build-utils/fs/download.js');
-const FileBlob = require('@now/build-utils/file-blob.js');
-const FileFsRef = require('@now/build-utils/file-fs-ref.js');
+const { createLambda } = require('@now/build-utils/lambda.js'); // eslint-disable-line import/no-extraneous-dependencies
+const download = require('@now/build-utils/fs/download.js'); // eslint-disable-line import/no-extraneous-dependencies
+const FileBlob = require('@now/build-utils/file-blob.js'); // eslint-disable-line import/no-extraneous-dependencies
+const FileFsRef = require('@now/build-utils/file-fs-ref.js'); // eslint-disable-line import/no-extraneous-dependencies
 const fs = require('fs-extra');
-const glob = require('@now/build-utils/fs/glob.js');
+const glob = require('@now/build-utils/fs/glob.js'); // eslint-disable-line import/no-extraneous-dependencies
 const path = require('path');
-const rename = require('@now/build-utils/fs/rename.js');
+const rename = require('@now/build-utils/fs/rename.js'); // eslint-disable-line import/no-extraneous-dependencies
 const {
   runNpmInstall,
   runPackageJsonScript,
-} = require('@now/build-utils/fs/run-user-scripts.js');
+} = require('@now/build-utils/fs/run-user-scripts.js'); // eslint-disable-line import/no-extraneous-dependencies
 
 /** @typedef { import('@now/build-utils/file-ref') } FileRef */
 /** @typedef {{[filePath: string]: FileRef}} Files */
@@ -37,7 +37,7 @@ async function downloadInstallAndBundle(
   console.log('downloading user files...');
   const downloadedFiles = await download(files, userPath);
 
-  console.log('installing dependencies for user\'s code...');
+  console.log("installing dependencies for user's code...");
   const entrypointFsDirname = path.join(userPath, path.dirname(entrypoint));
   await runNpmInstall(entrypointFsDirname, npmArguments);
 

--- a/packages/now-node-server/package.json
+++ b/packages/now-node-server/package.json
@@ -11,9 +11,6 @@
     "@now/node-bridge": "^0.1.10",
     "fs-extra": "7.0.1"
   },
-  "peerDependencies": {
-    "@now/build-utils": ">=0.0.1"
-  },
   "scripts": {
     "test": "jest"
   }

--- a/packages/now-node/index.js
+++ b/packages/now-node/index.js
@@ -1,14 +1,14 @@
-const { createLambda } = require('@now/build-utils/lambda.js');
-const download = require('@now/build-utils/fs/download.js');
-const FileBlob = require('@now/build-utils/file-blob.js');
-const FileFsRef = require('@now/build-utils/file-fs-ref.js');
+const { createLambda } = require('@now/build-utils/lambda.js'); // eslint-disable-line import/no-extraneous-dependencies
+const download = require('@now/build-utils/fs/download.js'); // eslint-disable-line import/no-extraneous-dependencies
+const FileBlob = require('@now/build-utils/file-blob.js'); // eslint-disable-line import/no-extraneous-dependencies
+const FileFsRef = require('@now/build-utils/file-fs-ref.js'); // eslint-disable-line import/no-extraneous-dependencies
 const fs = require('fs-extra');
-const glob = require('@now/build-utils/fs/glob.js');
+const glob = require('@now/build-utils/fs/glob.js'); // eslint-disable-line import/no-extraneous-dependencies
 const path = require('path');
 const {
   runNpmInstall,
   runPackageJsonScript,
-} = require('@now/build-utils/fs/run-user-scripts.js');
+} = require('@now/build-utils/fs/run-user-scripts.js'); // eslint-disable-line import/no-extraneous-dependencies
 
 /** @typedef { import('@now/build-utils/file-ref') } FileRef */
 /** @typedef {{[filePath: string]: FileRef}} Files */
@@ -35,7 +35,7 @@ async function downloadInstallAndBundle(
   console.log('downloading user files...');
   const downloadedFiles = await download(files, userPath);
 
-  console.log('installing dependencies for user\'s code...');
+  console.log("installing dependencies for user's code...");
   const entrypointFsDirname = path.join(userPath, path.dirname(entrypoint));
   await runNpmInstall(entrypointFsDirname, npmArguments);
 

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -11,9 +11,6 @@
     "@now/node-bridge": "^0.1.10",
     "fs-extra": "7.0.1"
   },
-  "peerDependencies": {
-    "@now/build-utils": ">=0.0.1"
-  },
   "scripts": {
     "test": "jest"
   }

--- a/packages/now-optipng/index.js
+++ b/packages/now-optipng/index.js
@@ -1,4 +1,4 @@
-const FileBlob = require('@now/build-utils/file-blob.js');
+const FileBlob = require('@now/build-utils/file-blob.js'); // eslint-disable-line import/no-extraneous-dependencies
 const OptiPng = require('optipng');
 const pipe = require('multipipe');
 

--- a/packages/now-optipng/package.json
+++ b/packages/now-optipng/package.json
@@ -10,8 +10,5 @@
   "dependencies": {
     "multipipe": "2.0.3",
     "optipng": "1.1.0"
-  },
-  "peerDependencies": {
-    "@now/build-utils": ">=0.0.1"
   }
 }

--- a/packages/now-php-bridge/index.js
+++ b/packages/now-php-bridge/index.js
@@ -1,23 +1,38 @@
-const FileBlob = require('@now/build-utils/file-blob.js');
-const FileFsRef = require('@now/build-utils/file-fs-ref.js');
-const glob = require('@now/build-utils/fs/glob.js');
+const FileBlob = require('@now/build-utils/file-blob.js'); // eslint-disable-line import/no-extraneous-dependencies
+const FileFsRef = require('@now/build-utils/file-fs-ref.js'); // eslint-disable-line import/no-extraneous-dependencies
+const glob = require('@now/build-utils/fs/glob.js'); // eslint-disable-line import/no-extraneous-dependencies
 const path = require('path');
 
 async function getFiles() {
   const files = await glob('native/**', __dirname);
 
-  const phpConfig = await FileBlob.fromStream({ stream: files['native/php.ini'].toStream() });
-  phpConfig.data = phpConfig.data.toString()
+  const phpConfig = await FileBlob.fromStream({
+    stream: files['native/php.ini'].toStream(),
+  });
+  phpConfig.data = phpConfig.data
+    .toString()
     .replace(/\/root\/app\/modules/g, '/var/task/native/modules');
   files['native/php.ini'] = phpConfig;
 
   Object.assign(files, {
-    'fastcgi/connection.js': new FileFsRef({ fsPath: require.resolve('fastcgi-client/lib/connection.js') }),
-    'fastcgi/consts.js': new FileFsRef({ fsPath: require.resolve('fastcgi-client/lib/consts.js') }),
-    'fastcgi/stringifykv.js': new FileFsRef({ fsPath: require.resolve('fastcgi-client/lib/stringifykv.js') }),
-    'fastcgi/index.js': new FileFsRef({ fsPath: path.join(__dirname, 'fastcgi/index.js') }),
-    'fastcgi/port.js': new FileFsRef({ fsPath: path.join(__dirname, 'fastcgi/port.js') }),
-    'launcher.js': new FileFsRef({ fsPath: path.join(__dirname, 'launcher.js') }),
+    'fastcgi/connection.js': new FileFsRef({
+      fsPath: require.resolve('fastcgi-client/lib/connection.js'),
+    }),
+    'fastcgi/consts.js': new FileFsRef({
+      fsPath: require.resolve('fastcgi-client/lib/consts.js'),
+    }),
+    'fastcgi/stringifykv.js': new FileFsRef({
+      fsPath: require.resolve('fastcgi-client/lib/stringifykv.js'),
+    }),
+    'fastcgi/index.js': new FileFsRef({
+      fsPath: path.join(__dirname, 'fastcgi/index.js'),
+    }),
+    'fastcgi/port.js': new FileFsRef({
+      fsPath: path.join(__dirname, 'fastcgi/port.js'),
+    }),
+    'launcher.js': new FileFsRef({
+      fsPath: path.join(__dirname, 'launcher.js'),
+    }),
   });
 
   return files;

--- a/packages/now-php-bridge/package.json
+++ b/packages/now-php-bridge/package.json
@@ -9,8 +9,5 @@
   },
   "dependencies": {
     "fastcgi-client": "0.0.1"
-  },
-  "peerDependencies": {
-    "@now/build-utils": ">=0.0.1"
   }
 }

--- a/packages/now-php/index.js
+++ b/packages/now-php/index.js
@@ -1,6 +1,6 @@
-const { createLambda } = require('@now/build-utils/lambda.js');
+const { createLambda } = require('@now/build-utils/lambda.js'); // eslint-disable-line import/no-extraneous-dependencies
 const path = require('path');
-const rename = require('@now/build-utils/fs/rename.js');
+const rename = require('@now/build-utils/fs/rename.js'); // eslint-disable-line import/no-extraneous-dependencies
 const { getFiles } = require('@now/php-bridge');
 
 exports.config = {

--- a/packages/now-php/package.json
+++ b/packages/now-php/package.json
@@ -10,9 +10,6 @@
   "dependencies": {
     "@now/php-bridge": "^0.4.13"
   },
-  "peerDependencies": {
-    "@now/build-utils": ">=0.0.1"
-  },
   "scripts": {
     "test": "jest"
   }

--- a/packages/now-python/download-and-install-pip.js
+++ b/packages/now-python/download-and-install-pip.js
@@ -3,7 +3,7 @@ const fetch = require('node-fetch');
 const execa = require('execa');
 const { createWriteStream } = require('fs');
 
-const getWritableDirectory = require('@now/build-utils/fs/get-writable-directory.js');
+const getWritableDirectory = require('@now/build-utils/fs/get-writable-directory.js'); // eslint-disable-line import/no-extraneous-dependencies
 
 const url = 'https://bootstrap.pypa.io/get-pip.py';
 

--- a/packages/now-python/index.js
+++ b/packages/now-python/index.js
@@ -1,10 +1,10 @@
 const path = require('path');
 const execa = require('execa');
 const { readFile, writeFile } = require('fs.promised');
-const getWritableDirectory = require('@now/build-utils/fs/get-writable-directory.js');
-const download = require('@now/build-utils/fs/download.js');
-const glob = require('@now/build-utils/fs/glob.js');
-const { createLambda } = require('@now/build-utils/lambda.js');
+const getWritableDirectory = require('@now/build-utils/fs/get-writable-directory.js'); // eslint-disable-line import/no-extraneous-dependencies
+const download = require('@now/build-utils/fs/download.js'); // eslint-disable-line import/no-extraneous-dependencies
+const glob = require('@now/build-utils/fs/glob.js'); // eslint-disable-line import/no-extraneous-dependencies
+const { createLambda } = require('@now/build-utils/lambda.js'); // eslint-disable-line import/no-extraneous-dependencies
 const downloadAndInstallPip = require('./download-and-install-pip');
 
 async function pipInstall(pipPath, srcDir, ...args) {

--- a/packages/now-python/package.json
+++ b/packages/now-python/package.json
@@ -12,8 +12,5 @@
     "execa": "^1.0.0",
     "fs.promised": "^3.0.0",
     "node-fetch": "^2.2.0"
-  },
-  "peerDependencies": {
-    "@now/build-utils": ">=0.0.1"
   }
 }

--- a/packages/now-static-build/index.js
+++ b/packages/now-static-build/index.js
@@ -1,11 +1,11 @@
-const download = require('@now/build-utils/fs/download.js');
-const glob = require('@now/build-utils/fs/glob.js');
+const download = require('@now/build-utils/fs/download.js'); // eslint-disable-line import/no-extraneous-dependencies
+const glob = require('@now/build-utils/fs/glob.js'); // eslint-disable-line import/no-extraneous-dependencies
 const path = require('path');
 const {
   runNpmInstall,
   runPackageJsonScript,
   runShellScript,
-} = require('@now/build-utils/fs/run-user-scripts.js');
+} = require('@now/build-utils/fs/run-user-scripts.js'); // eslint-disable-line import/no-extraneous-dependencies
 
 exports.build = async ({
   files, entrypoint, workPath, config,

--- a/packages/now-static-build/package.json
+++ b/packages/now-static-build/package.json
@@ -7,9 +7,6 @@
     "url": "https://github.com/zeit/now-builders.git",
     "directory": "packages/now-static-build"
   },
-  "peerDependencies": {
-    "@now/build-utils": ">=0.0.1"
-  },
   "scripts": {
     "test": "jest"
   }

--- a/packages/now-wordpress/index.js
+++ b/packages/now-wordpress/index.js
@@ -1,11 +1,11 @@
 const assert = require('assert');
-const { createLambda } = require('@now/build-utils/lambda.js');
+const { createLambda } = require('@now/build-utils/lambda.js'); // eslint-disable-line import/no-extraneous-dependencies
 const fetch = require('node-fetch');
-const FileBlob = require('@now/build-utils/file-blob.js');
+const FileBlob = require('@now/build-utils/file-blob.js'); // eslint-disable-line import/no-extraneous-dependencies
 const { getFiles } = require('@now/php-bridge');
 const path = require('path');
-const rename = require('@now/build-utils/fs/rename.js');
-const streamToBuffer = require('@now/build-utils/fs/stream-to-buffer.js');
+const rename = require('@now/build-utils/fs/rename.js'); // eslint-disable-line import/no-extraneous-dependencies
+const streamToBuffer = require('@now/build-utils/fs/stream-to-buffer.js'); // eslint-disable-line import/no-extraneous-dependencies
 const yauzl = require('yauzl');
 
 exports.config = {
@@ -16,7 +16,9 @@ async function readReleaseUrl(releaseUrl) {
   const resp = await fetch(releaseUrl);
 
   if (!resp.ok) {
-    throw new Error(`Failed to download ${releaseUrl}. Status code is ${resp.status}`);
+    throw new Error(
+      `Failed to download ${releaseUrl}. Status code is ${resp.status}`,
+    );
   }
 
   return resp.buffer();
@@ -49,13 +51,15 @@ function decompressBuffer(buffer, mountpoint) {
             return;
           }
 
-          streamToBuffer(readStream).then((data) => {
-            assert(prefixRegexp.test(fileName), fileName);
-            const fileName2 = fileName.replace(prefixRegexp, '');
-            const fileName3 = path.join(mountpoint, fileName2);
-            files[fileName3] = new FileBlob({ data });
-            zipfile.readEntry();
-          }).catch(reject);
+          streamToBuffer(readStream)
+            .then((data) => {
+              assert(prefixRegexp.test(fileName), fileName);
+              const fileName2 = fileName.replace(prefixRegexp, '');
+              const fileName3 = path.join(mountpoint, fileName2);
+              files[fileName3] = new FileBlob({ data });
+              zipfile.readEntry();
+            })
+            .catch(reject);
         });
       });
 
@@ -65,12 +69,22 @@ function decompressBuffer(buffer, mountpoint) {
 }
 
 const staticRegexps = [
-  /\.css$/, /\.gif$/, /\.ico$/, /\.js$/, /\.jpg$/, /\.png$/, /\.svg$/, /\.woff$/, /\.woff2$/,
+  /\.css$/,
+  /\.gif$/,
+  /\.ico$/,
+  /\.js$/,
+  /\.jpg$/,
+  /\.png$/,
+  /\.svg$/,
+  /\.woff$/,
+  /\.woff2$/,
 ];
 
 exports.build = async ({ files, entrypoint, config }) => {
   if (path.basename(entrypoint) !== 'wp-config.php') {
-    throw new Error(`Entrypoint file name must be "wp-config.php". Currently it is ${entrypoint}`);
+    throw new Error(
+      `Entrypoint file name must be "wp-config.php". Currently it is ${entrypoint}`,
+    );
   }
 
   const { releaseUrl = 'https://wordpress.org/latest.zip' } = config;
@@ -84,9 +98,12 @@ exports.build = async ({ files, entrypoint, config }) => {
   if (config.patchForPersistentConnections) {
     const wpDbPhp = path.join(mountpoint, 'wp-includes/wp-db.php');
     const wpDbPhpBlob = mergedFiles[wpDbPhp];
-    wpDbPhpBlob.data = wpDbPhpBlob.data.toString()
-      .replace(/mysqli_real_connect\( \$this->dbh, \$host,/g,
-        'mysqli_real_connect( $this->dbh, \'p:\' . $host,');
+    wpDbPhpBlob.data = wpDbPhpBlob.data
+      .toString()
+      .replace(
+        /mysqli_real_connect\( \$this->dbh, \$host,/g,
+        "mysqli_real_connect( $this->dbh, 'p:' . $host,",
+      );
   }
 
   const staticFiles = {};

--- a/packages/now-wordpress/package.json
+++ b/packages/now-wordpress/package.json
@@ -12,9 +12,6 @@
     "node-fetch": "2.3.0",
     "yauzl": "2.10.0"
   },
-  "peerDependencies": {
-    "@now/build-utils": ">=0.0.1"
-  },
   "scripts": {
     "test": "jest"
   }

--- a/test/unit/now-next/utils.test.js
+++ b/test/unit/now-next/utils.test.js
@@ -8,7 +8,7 @@ const {
   excludeStaticDirectory,
   onlyStaticDirectory,
 } = require('@now/next/utils');
-const FileRef = require('@now/build-utils/file-ref');
+const FileRef = require('@now/build-utils/file-ref'); // eslint-disable-line import/no-extraneous-dependencies
 
 describe('excludeFiles', () => {
   it('should exclude files', () => {


### PR DESCRIPTION
This removes `@now/build-utils` as a peer dependency in order to suppress warnings in the build logs.

> warning "@now/node > @now/node-bridge@0.1.10" has unmet peer dependency "@now/build-utils@>=0.0.1".

An eslint rule was also added to suppress warnings about the missing dependency (ironically).