### PR TITLE
Check for distDir existence inside `now-static-build`

### DIFF
--- a/packages/now-static-build/index.js
+++ b/packages/now-static-build/index.js
@@ -1,11 +1,21 @@
 const download = require('@now/build-utils/fs/download.js'); // eslint-disable-line import/no-extraneous-dependencies
 const glob = require('@now/build-utils/fs/glob.js'); // eslint-disable-line import/no-extraneous-dependencies
 const path = require('path');
+const { existsSync } = require('fs');
 const {
   runNpmInstall,
   runPackageJsonScript,
   runShellScript,
 } = require('@now/build-utils/fs/run-user-scripts.js'); // eslint-disable-line import/no-extraneous-dependencies
+
+function validateDistDir(distDir) {
+  const distDirName = path.basename(distDir);
+  if (!existsSync(distDir)) {
+    const message = `Build was unable to create the distDir: ${distDirName}.`
+      + 'Make sure you mentioned the correct dist directory: https://zeit.co/docs/v2/deployments/official-builders/static-build-now-static-build/#configuring-the-dist-directory';
+    throw new Error(message);
+  }
+}
 
 exports.build = async ({
   files, entrypoint, workPath, config,
@@ -24,6 +34,7 @@ exports.build = async ({
   if (path.basename(entrypoint) === 'package.json') {
     await runNpmInstall(entrypointFsDirname, ['--prefer-offline']);
     if (await runPackageJsonScript(entrypointFsDirname, 'now-build')) {
+      validateDistDir(distPath);
       return glob('**', distPath, mountpoint);
     }
     throw new Error(`An error running "now-build" script in "${entrypoint}"`);
@@ -31,6 +42,7 @@ exports.build = async ({
 
   if (path.extname(entrypoint) === '.sh') {
     await runShellScript(path.join(workPath, entrypoint));
+    validateDistDir(distPath);
     return glob('**', distPath, mountpoint);
   }
 

--- a/packages/now-static-build/test/fixtures/04-wrong-dist-dir/now.json
+++ b/packages/now-static-build/test/fixtures/04-wrong-dist-dir/now.json
@@ -1,0 +1,6 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "package.json", "use": "@now/static-build", "config": {"distDir": "out"} }
+  ]
+}

--- a/packages/now-static-build/test/fixtures/04-wrong-dist-dir/package.json
+++ b/packages/now-static-build/test/fixtures/04-wrong-dist-dir/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "cowsay": "^1.3.1"
+  },
+  "scripts": {
+    "now-build": "mkdir dist && cowsay cow:RANDOMNESS_PLACEHOLDER > dist/index.txt"
+  }
+}

--- a/packages/now-static-build/test/fixtures/04-wrong-dist-dir/subdirectory/package.json
+++ b/packages/now-static-build/test/fixtures/04-wrong-dist-dir/subdirectory/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "yodasay": "^1.1.6"
+  },
+  "scripts": {
+    "now-build": "mkdir dist && yodasay yoda:RANDOMNESS_PLACEHOLDER > dist/index.txt"
+  }
+}

--- a/packages/now-static-build/test/test.js
+++ b/packages/now-static-build/test/test.js
@@ -21,6 +21,21 @@ const fixturesPath = path.resolve(__dirname, 'fixtures');
 
 // eslint-disable-next-line no-restricted-syntax
 for (const fixture of fs.readdirSync(fixturesPath)) {
+  if (fixture === '04-wrong-dist-dir') {
+    // eslint-disable-next-line no-loop-func
+    it(`should not build ${fixture}`, async () => {
+      try {
+        await testDeployment(
+          { builderUrl, buildUtilsUrl },
+          path.join(fixturesPath, fixture),
+        );
+      } catch (err) {
+        expect(err.message).toMatch(/is ERROR/);
+      }
+    });
+    continue; //eslint-disable-line
+  }
+
   // eslint-disable-next-line no-loop-func
   it(`should build ${fixture}`, async () => {
     await expect(


### PR DESCRIPTION
When building an app with `now-static-build`, we check the existence of the distDir.
If there's no check like this, we are going to deploy a 404 page.

It's a user-error, but we need to mention it to the user.