### PR TITLE
Place generated `@now/rust` lambdas in the location that matches thei…

### DIFF
--- a/packages/now-rust/index.js
+++ b/packages/now-rust/index.js
@@ -60,6 +60,7 @@ exports.build = async ({ files, entrypoint, workPath }) => {
   );
 
   const lambdas = {};
+  const lambdaPath = path.dirname(entrypoint);
   await Promise.all(
     binaries.map(async (binary) => {
       const fsPath = path.join(targetPath, binary);
@@ -71,7 +72,7 @@ exports.build = async ({ files, entrypoint, workPath }) => {
         runtime: 'provided',
       });
 
-      lambdas[binary] = lambda;
+      lambdas[path.join(lambdaPath, binary)] = lambda;
     }),
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7065,13 +7065,6 @@ rimraf@2, rimraf@^2.2.6, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.
   dependencies:
     glob "^7.0.5"
 
-rimraf@^2.6.3:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
-  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  dependencies:
-    glob "^7.1.3"
-
 rmfr@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/rmfr/-/rmfr-2.0.0.tgz#8a42e81332550b3f0019b8fb8ab245bea81b6d1c"


### PR DESCRIPTION
…r entrypoint