### PR TITLE
[now-static-build] allow custom glob pattern on static deployments

### DIFF
--- a/packages/now-static-build/index.js
+++ b/packages/now-static-build/index.js
@@ -30,12 +30,13 @@ exports.build = async ({
     path.dirname(entrypoint),
     (config && config.distDir) || 'dist',
   );
+  const matching = (config && config.matching) || '**';
 
   if (path.basename(entrypoint) === 'package.json') {
     await runNpmInstall(entrypointFsDirname, ['--prefer-offline']);
     if (await runPackageJsonScript(entrypointFsDirname, 'now-build')) {
       validateDistDir(distPath);
-      return glob('**', distPath, mountpoint);
+      return glob(matching, distPath, mountpoint);
     }
     throw new Error(`An error running "now-build" script in "${entrypoint}"`);
   }
@@ -43,7 +44,7 @@ exports.build = async ({
   if (path.extname(entrypoint) === '.sh') {
     await runShellScript(path.join(workPath, entrypoint));
     validateDistDir(distPath);
-    return glob('**', distPath, mountpoint);
+    return glob(matching, distPath, mountpoint);
   }
 
   throw new Error('Proper build script must be specified as entrypoint');

--- a/packages/now-static-build/test/fixtures/05-matching/build.js
+++ b/packages/now-static-build/test/fixtures/05-matching/build.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const path = require('path');
+
+const cowsay = require('cowsay');
+
+for (let i = 1; i < 10; i += 1) {
+  const file = path.join(__dirname, `dist/${i}.html`);
+  fs.writeFileSync(file, `<h1>Number ${i}:RANDOMNESS_PLACEHOLDER</h1>`);
+}
+
+const file = path.join(__dirname, 'dist/cow.txt');
+fs.writeFileSync(file, cowsay.say({ text: 'cow:RANDOMNESS_PLACEHOLDER' }));

--- a/packages/now-static-build/test/fixtures/05-matching/now.json
+++ b/packages/now-static-build/test/fixtures/05-matching/now.json
@@ -1,0 +1,10 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "package.json", "use": "@now/static-build", "config": { "matching": "**.txt" } }
+  ],
+  "probes": [
+    { "path": "/cow.txt", "mustContain": "cow:RANDOMNESS_PLACEHOLDER" },
+    { "path": "/", "mustNotContain": "1.html" }
+  ]
+}

--- a/packages/now-static-build/test/fixtures/05-matching/package.json
+++ b/packages/now-static-build/test/fixtures/05-matching/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "cowsay": "^1.3.1"
+  },
+  "scripts": {
+    "now-build": "mkdir dist && node ./build"
+  }
+}

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -22,7 +22,11 @@ async function packAndDeploy (builderPath) {
 
 const RANDOMNESS_PLACEHOLDER_STRING = 'RANDOMNESS_PLACEHOLDER';
 
-async function testDeployment ({ builderUrl, buildUtilsUrl }, fixturePath, buildDelegate) {
+async function testDeployment (
+  { builderUrl, buildUtilsUrl },
+  fixturePath,
+  buildDelegate
+) {
   console.log('testDeployment', fixturePath);
   const globResult = await glob(`${fixturePath}/**`, { nodir: true });
   const bodies = globResult.reduce((b, f) => {
@@ -89,7 +93,14 @@ async function testDeployment ({ builderUrl, buildUtilsUrl }, fixturePath, build
         await fs.writeFile(path.join(__dirname, 'failed-page.txt'), text);
         throw new Error(
           `Fetched page ${probeUrl} does not contain ${probe.mustContain}.`
-          + ` Instead it contains ${text.slice(0, 60)}`
+            + ` Instead it contains ${text.slice(0, 60)}`
+        );
+      }
+    } else if (probe.mustNotContain) {
+      if (text.includes(probe.mustNotContain)) {
+        await fs.writeFile(path.join(__dirname, 'failed-page.txt'), text);
+        throw new Error(
+          `Fetched page ${probeUrl} contains ${probe.mustNotContain}.`
         );
       }
     } else {
@@ -118,8 +129,11 @@ async function fetchDeploymentUrl (url, opts) {
   for (let i = 0; i < 500; i += 1) {
     const resp = await fetch(url, opts);
     const text = await resp.text();
-    if (text && !text.includes('Join Free')
-        && !text.includes('The page could not be found')) {
+    if (
+      text
+      && !text.includes('Join Free')
+      && !text.includes('The page could not be found')
+    ) {
       return text;
     }
 


### PR DESCRIPTION
We are deploying a large monorepo managed with Lerna. Everything works, but there are a lot of files in our `dist` directory that are not necessary for the static builder to be uploading every single time. Rather than writing a custom script to prune these files each time before they are uploaded, this just adds an optional configuration to the builder to support passing a custom glob pattern.