### PR TITLE
@now/rust: Import Deserialize traits behind `de` and `ser` namespaces

### DIFF
--- a/packages/now-rust/src/request.rs
+++ b/packages/now-rust/src/request.rs
@@ -1,10 +1,7 @@
 use std::{borrow::Cow, fmt, mem};
 
 use http::{self, header::HeaderValue, HeaderMap, Method, Request as HttpRequest};
-use serde::{
-    de::{Error as DeError, MapAccess, Visitor},
-    Deserialize, Deserializer,
-};
+use serde::de::{Deserialize, Deserializer, Error as DeError, MapAccess, Visitor};
 use serde_derive::Deserialize;
 #[allow(unused_imports)]
 use serde_json::Value;

--- a/packages/now-rust/src/response.rs
+++ b/packages/now-rust/src/response.rs
@@ -4,10 +4,7 @@ use http::{
     header::{HeaderMap, HeaderValue},
     Response,
 };
-use serde::{
-    ser::{Error as SerError, SerializeMap},
-    Serializer,
-};
+use serde::ser::{Error as SerError, SerializeMap, Serializer};
 use serde_derive::Serialize;
 
 use crate::body::Body;

--- a/packages/now-rust/src/strmap.rs
+++ b/packages/now-rust/src/strmap.rs
@@ -4,10 +4,7 @@ use std::{
     sync::Arc,
 };
 
-use serde::{
-    de::{MapAccess, Visitor},
-    Deserialize, Deserializer,
-};
+use serde::de::{Deserialize, Deserializer, MapAccess, Visitor};
 
 /// A read-only view into a map of string data
 #[derive(Default, Debug, PartialEq)]


### PR DESCRIPTION
I was working on transitioning a now v1 docker rust project to now v2 and ran into a compilation error where Deserialize was included twice but considered ambiguous. This seems to be tied to using serde's `derive` feature over `serde_derive`, but AWS Lambda took the same approach.

Here's the project I eventually got deployed with my patch: [locale](https://github.com/mike-engel/locale) and the URL to view it: [locale.now.sh](https://locale.now.sh).

For more discussion: https://github.com/serde-rs/serde/issues/1441