### PR TITLE
[now-bash] Use `mktemp` dry run syntax that is compatible with BSD

### DIFF
--- a/packages/now-bash/runtime.sh
+++ b/packages/now-bash/runtime.sh
@@ -52,7 +52,7 @@ _lambda_runtime_next() {
 	# Need to use a fifo here instead of bash <() because Lambda
 	# errors with "/dev/fd/63 not found" for some reason :/
 	local stdin
-	stdin="$(mktemp --dry-run)"
+	stdin="$(mktemp -u)"
 	mkfifo "$stdin"
 	_lambda_runtime_body "$event" > "$stdin" &
 


### PR DESCRIPTION
For `now dev` running on a MacOS machine, some of our builders will need
to be adjusted to be "platform-aware".

In this case, `mktemp` is provided by BSD instead of GNU, which doesn't
support the long form `--dry-run` flag, however both support the `-u`
flag which does the same thing.