### PR TITLE
Allow simpler API for `@now/rust`

### DIFF
--- a/packages/now-rust/src/error.rs
+++ b/packages/now-rust/src/error.rs
@@ -1,3 +1,4 @@
+use http;
 use lambda_runtime::error::LambdaErrorExt;
 use std::{error::Error, fmt};
 
@@ -19,9 +20,17 @@ impl fmt::Display for NowError {
         write!(f, "{}", self.msg)
     }
 }
+
 impl Error for NowError {}
+
 impl From<std::num::ParseIntError> for NowError {
     fn from(i: std::num::ParseIntError) -> Self {
+        NowError::new(&format!("{}", i))
+    }
+}
+
+impl From<http::Error> for NowError {
+    fn from(i: http::Error) -> Self {
         NowError::new(&format!("{}", i))
     }
 }

--- a/packages/now-rust/src/request.rs
+++ b/packages/now-rust/src/request.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, fmt, mem};
 
 use http::{self, header::HeaderValue, HeaderMap, Method, Request as HttpRequest};
-use serde::de::{Deserialize, Deserializer, Error as DeError, MapAccess, Visitor};
+use serde::de::{Deserializer, Error as DeError, MapAccess, Visitor};
 use serde_derive::Deserialize;
 
 use crate::body::Body;

--- a/packages/now-rust/src/request.rs
+++ b/packages/now-rust/src/request.rs
@@ -3,8 +3,6 @@ use std::{borrow::Cow, fmt, mem};
 use http::{self, header::HeaderValue, HeaderMap, Method, Request as HttpRequest};
 use serde::de::{Deserialize, Deserializer, Error as DeError, MapAccess, Visitor};
 use serde_derive::Deserialize;
-#[allow(unused_imports)]
-use serde_json::Value;
 
 use crate::body::Body;
 
@@ -87,18 +85,6 @@ where
     }
 
     deserializer.deserialize_map(HeaderVisitor)
-}
-
-/// deserializes (json) null values to their default values
-// https://github.com/serde-rs/serde/issues/1098
-#[allow(dead_code)]
-fn nullable_default<'de, T, D>(deserializer: D) -> Result<T, D::Error>
-where
-    D: Deserializer<'de>,
-    T: Default + Deserialize<'de>,
-{
-    let opt = Option::deserialize(deserializer)?;
-    Ok(opt.unwrap_or_else(T::default))
 }
 
 impl<'a> From<NowRequest<'a>> for HttpRequest<Body> {


### PR DESCRIPTION
This changeset improves `@now/rust` to allow the for the following API:

```rust
pub fn handler(request: Request<()>) -> http::Result<Response<String>> {
    let uri = request.uri();
    let response = Response::builder()
        .status(StatusCode::OK)
        .body(format!(
            "You made a request to the '/foo' lambda. URL: {}",
            uri
        ))
        .expect("failed to render response");

    Ok(response)
}
```

This was originally suggested by @TooTallNate and @timothyis, and makes it so that the simplest API has no `Now_lambda` visible parts.