### PR TITLE
[now-build-utils] Add `FsFileRef.fromFile()` helper function

### DIFF
--- a/packages/now-build-utils/file-fs-ref.js
+++ b/packages/now-build-utils/file-fs-ref.js
@@ -27,6 +27,18 @@ class FileFsRef {
   }
 
   /**
+   * Creates a `FileFsRef` with the correct `mode` from the file system.
+   *
+   * @argument {Object} options
+   * @argument {string} options.fsPath
+   * @returns {Promise<FileFsRef>}
+   */
+  static async fromFile({ fsPath }) {
+    const { mode } = await fs.lstat(fsPath);
+    return new FileFsRef({ mode, fsPath });
+  }
+
+  /**
    * @argument {Object} options
    * @argument {number} [options.mode=0o100644]
    * @argument {NodeJS.ReadableStream} options.stream

--- a/packages/now-build-utils/file-fs-ref.js
+++ b/packages/now-build-utils/file-fs-ref.js
@@ -33,7 +33,7 @@ class FileFsRef {
    * @argument {string} options.fsPath
    * @returns {Promise<FileFsRef>}
    */
-  static async fromFile({ fsPath }) {
+  static async fromFsPath({ fsPath }) {
     const { mode } = await fs.lstat(fsPath);
     return new FileFsRef({ mode, fsPath });
   }


### PR DESCRIPTION
This helper function is very similar to the raw `FsFileRef` constructor, however it stats the file to retrieve the proper `mode`, so that settings like executable bits are not lost.