### PR TITLE
[now-node] bump ncc to 0.15.1

### DIFF
--- a/packages/now-node-server/index.js
+++ b/packages/now-node-server/index.js
@@ -48,7 +48,7 @@ async function downloadInstallAndBundle(
         data: JSON.stringify({
           license: 'UNLICENSED',
           dependencies: {
-            '@zeit/ncc': '0.13.2',
+            '@zeit/ncc': '0.15.1',
           },
         }),
       }),

--- a/packages/now-node/index.js
+++ b/packages/now-node/index.js
@@ -46,7 +46,7 @@ async function downloadInstallAndBundle(
         data: JSON.stringify({
           license: 'UNLICENSED',
           dependencies: {
-            '@zeit/ncc': '0.13.2',
+            '@zeit/ncc': '0.15.1',
           },
         }),
       }),


### PR DESCRIPTION
This fixes a regression introduced in ncc@0.13.2 and also prints the version of ncc used at build time.

See [release notes](https://github.com/zeit/ncc/releases/tag/0.15.1) for more info.