### PR TITLE
[now-node] bump ncc to 0.15.2

### DIFF
--- a/packages/now-node-server/index.js
+++ b/packages/now-node-server/index.js
@@ -48,7 +48,7 @@ async function downloadInstallAndBundle(
         data: JSON.stringify({
           license: 'UNLICENSED',
           dependencies: {
-            '@zeit/ncc': '0.15.1',
+            '@zeit/ncc': '0.15.2',
           },
         }),
       }),

--- a/packages/now-node/index.js
+++ b/packages/now-node/index.js
@@ -46,7 +46,7 @@ async function downloadInstallAndBundle(
         data: JSON.stringify({
           license: 'UNLICENSED',
           dependencies: {
-            '@zeit/ncc': '0.15.1',
+            '@zeit/ncc': '0.15.2',
           },
         }),
       }),


### PR DESCRIPTION
This has a couple fixes.

See release notes here https://github.com/zeit/ncc/releases/tag/0.15.2