### PR TITLE
[now-node] add sourceMap flag to ncc

### DIFF
--- a/packages/now-node-server/index.js
+++ b/packages/now-node-server/index.js
@@ -64,7 +64,7 @@ async function downloadInstallAndBundle(
 async function compile(workNccPath, downloadedFiles, entrypoint) {
   const input = downloadedFiles[entrypoint].fsPath;
   const ncc = require(path.join(workNccPath, 'node_modules/@zeit/ncc'));
-  const { code, assets } = await ncc(input);
+  const { code, assets } = await ncc(input, { sourceMap: true });
 
   const preparedFiles = {};
   const blob = new FileBlob({ data: code });

--- a/packages/now-node/index.js
+++ b/packages/now-node/index.js
@@ -62,7 +62,7 @@ async function downloadInstallAndBundle(
 async function compile(workNccPath, downloadedFiles, entrypoint) {
   const input = downloadedFiles[entrypoint].fsPath;
   const ncc = require(path.join(workNccPath, 'node_modules/@zeit/ncc'));
-  const { code, assets } = await ncc(input);
+  const { code, assets } = await ncc(input, { sourceMap: true });
 
   const preparedFiles = {};
   const blob = new FileBlob({ data: code });


### PR DESCRIPTION
This adds a {sourceMap:true} flag to ncc builds