### PR TITLE
Add `publish.sh` script for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,11 +30,8 @@ jobs:
           name: Potentially save npm token
           command: "([[ ! -z $NPM_TOKEN ]] && echo \"//registry.npmjs.org/:_authToken=$NPM_TOKEN\" >> ~/.npmrc) || echo \"Did not write npm token\""
       - run:
-          name: Potentially publish canary release
-          command: "if ls ~/.npmrc >/dev/null 2>&1 && [[ $(git describe --exact-match 2> /dev/null || :) =~ -canary ]]; then yarn run lerna publish from-git --npm-tag canary --yes; else  echo \"Did not publish\"; fi"
-      - run:
-          name: Potentially publish stable release
-          command: "if ls ~/.npmrc >/dev/null 2>&1 && [[ ! $(git describe --exact-match 2> /dev/null || :) =~ -canary ]]; then yarn run lerna publish from-git --yes; else  echo \"Did not publish\"; fi"
+          name: Potentially publish releases to npm
+          command: ./.circleci/publish.sh
 workflows:
   version: 2
   build-and-deploy:

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -21,4 +21,4 @@ else
   echo "Publishing stable release"
 fi
 
-echo yarn run lerna publish from-git $npm_tag --yes
+yarn run lerna publish from-git $npm_tag --yes

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ ! -e ~/.npmrc ]; then
+  echo "~/.npmrc file does not exist, skipping publish"
+  exit 0
+fi
+
+npm_tag=""
+tag="$(git describe --exact-match 2> /dev/null || :)"
+
+if [ -z "$tag" ]; then
+  echo "Not a tagged commit, skipping publish"
+  exit 0
+fi
+
+if [[ "$tag" =~ -canary ]]; then
+  echo "Publishing canary release"
+  npm_tag="--npm-tag canary"
+else
+  echo "Publishing stable release"
+fi
+
+echo yarn run lerna publish from-git $npm_tag --yes


### PR DESCRIPTION
Centralize the publishing logic for CircleCI to use.

There was a bug in the previous "Potentially publish stable release"
branch, such that it would be executed for non-tagged commits. The new
publish script checks if there are indeed any tags for the commit, and
bails if there are none.

As an additional bonus, there's now only one publish step in the CircleCI
config, because the publish script determines stable vs. canary based on
the tag name.