### PR TITLE
[now-node-server] Update `@now/node-bridge` to v1.0.0-canary.2

### DIFF
--- a/packages/now-node-server/launcher.js
+++ b/packages/now-node-server/launcher.js
@@ -4,22 +4,16 @@ const { Bridge } = require('./bridge.js');
 const bridge = new Bridge();
 
 const saveListen = Server.prototype.listen;
-Server.prototype.listen = function listen(...args) {
-  this.on('listening', function listening() {
-    bridge.port = this.address().port;
-  });
-  saveListen.apply(this, args);
+Server.prototype.listen = function listen() {
+  bridge.setServer(this);
+  Server.prototype.listen = saveListen;
+  return bridge.listen();
 };
 
-try {
-  if (!process.env.NODE_ENV) {
-    process.env.NODE_ENV = 'production';
-  }
-
-  // PLACEHOLDER
-} catch (error) {
-  console.error(error);
-  bridge.userError = error;
+if (!process.env.NODE_ENV) {
+  process.env.NODE_ENV = 'production';
 }
+
+// PLACEHOLDER
 
 exports.launcher = bridge.launcher;

--- a/packages/now-node-server/package.json
+++ b/packages/now-node-server/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/now-node-server"
   },
   "dependencies": {
-    "@now/node-bridge": "0.1.11-canary.0",
+    "@now/node-bridge": "1.0.0-canary.2",
     "fs-extra": "7.0.1"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -728,11 +728,6 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@now/node-bridge@0.1.11-canary.0":
-  version "0.1.11-canary.0"
-  resolved "https://registry.yarnpkg.com/@now/node-bridge/-/node-bridge-0.1.11-canary.0.tgz#2a4215f9b75cf59f416f86f1a8abf8ce5db7ab68"
-  integrity sha512-FCC4X9cr7WnMtavdhAQ6M+c1SEHUoNLVG27/g7PgJqOrEGFW0MIJIEfSOAeblcseQEW6fQfQjpSDd8Jbg+Vsiw==
-
 "@now/node-bridge@0.1.4":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@now/node-bridge/-/node-bridge-0.1.4.tgz#59a555e090f16f5e02d289bd1fd6c47f4274304b"


### PR DESCRIPTION
Update `@now/node-server` to use the latest `@now/node-bridge`, which removes the hard-coded port 3000 that was previously in-place, which was problematic for `now dev`. Now the `http.Server` instance listens on an ephemeral port which is detected by the Now node runtime.