### PR TITLE
[now-next] Update `@now/node-bridge` to v1.0.0-canary.2

### DIFF
--- a/packages/now-next/launcher.js
+++ b/packages/now-next/launcher.js
@@ -4,10 +4,8 @@ const { Server } = require('http');
 const { Bridge } = require('./now__bridge.js');
 const page = require('./page.js');
 
-const bridge = new Bridge();
-bridge.port = 3000;
-
 const server = new Server(page.render);
-server.listen(bridge.port);
+const bridge = new Bridge(server);
+bridge.listen();
 
 exports.launcher = bridge.launcher;

--- a/packages/now-next/legacy-launcher.js
+++ b/packages/now-next/legacy-launcher.js
@@ -3,9 +3,6 @@ const next = require('next-server');
 const url = require('url');
 const { Bridge } = require('./now__bridge.js');
 
-const bridge = new Bridge();
-bridge.port = 3000;
-
 process.env.NODE_ENV = 'production';
 
 const app = next({});
@@ -14,6 +11,8 @@ const server = new Server((req, res) => {
   const parsedUrl = url.parse(req.url, true);
   app.render(req, res, 'PATHNAME_PLACEHOLDER', parsedUrl.query, parsedUrl);
 });
-server.listen(bridge.port);
+
+const bridge = new Bridge(server);
+bridge.listen();
 
 exports.launcher = bridge.launcher;

--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/now-next"
   },
   "dependencies": {
-    "@now/node-bridge": "0.1.4",
+    "@now/node-bridge": "1.0.0-canary.2",
     "execa": "^1.0.0",
     "fs.promised": "^3.0.0",
     "semver": "^5.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -728,11 +728,6 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@now/node-bridge@0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@now/node-bridge/-/node-bridge-0.1.4.tgz#59a555e090f16f5e02d289bd1fd6c47f4274304b"
-  integrity sha512-UXlDWyrPU1bB9nsh11MGfGo81GfLij1X4Dew+9fplThRzEGbrTey8aDTjNvmsTV+jxnyktLYzet2uaI9yXXiEw==
-
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"


### PR DESCRIPTION
Update `@now/next` to use the latest `@now/node-bridge`, which removes the hard-coded port 3000 that was previously in-place, which was problematic for `now dev`. Now the `http.Server` instance listens on an ephemeral port which is detected by the Now node runtime.

(Similar to 6101ba9d9505b0dacd6af49c1ee1e804313f9d17 and 8dc0c92c586d7d55e720d96359b8e2741845bb0f)