### PR TITLE
Cache Next.js `node_modules` for faster rebuilds

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "pre-commit": "lint-staged",
   "lint-staged": {
     "*.js": [
-      "prettier --write --single-quote",
+      "prettier --write",
       "eslint --fix",
       "git add"
     ]

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -68,6 +68,36 @@ async function writeNpmRc(workPath, token) {
   );
 }
 
+function isLegacyNext(nextVersion) {
+  // If version is using the dist-tag instead of a version range
+  if (nextVersion === 'canary' || nextVersion === 'latest') {
+    return false;
+  }
+
+  // If the version is an exact match with the legacy versions
+  if (nextLegacyVersions.indexOf(nextVersion) !== -1) {
+    return true;
+  }
+
+  const maxSatisfying = semver.maxSatisfying(nextLegacyVersions, nextVersion);
+  // When the version can't be matched with legacy versions, so it must be a newer version
+  if (maxSatisfying === null) {
+    return false;
+  }
+
+  return true;
+}
+
+function getNextVersion(packageJson) {
+  let nextVersion;
+  if (packageJson.dependencies && packageJson.dependencies.next) {
+    nextVersion = packageJson.dependencies.next;
+  } else if (packageJson.devDependencies && packageJson.devDependencies.next) {
+    nextVersion = packageJson.devDependencies.next;
+  }
+  return nextVersion;
+}
+
 exports.config = {
   maxLambdaSize: '5mb',
 };
@@ -86,38 +116,14 @@ exports.build = async ({ files, workPath, entrypoint }) => {
 
   const pkg = await readPackageJson(entryPath);
 
-  let nextVersion;
-  if (pkg.dependencies && pkg.dependencies.next) {
-    nextVersion = pkg.dependencies.next;
-  } else if (pkg.devDependencies && pkg.devDependencies.next) {
-    nextVersion = pkg.devDependencies.next;
-  }
-
+  const nextVersion = getNextVersion(pkg);
   if (!nextVersion) {
     throw new Error(
       'No Next.js version could be detected in "package.json". Make sure `"next"` is installed in "dependencies" or "devDependencies"',
     );
   }
 
-  const isLegacy = (() => {
-    // If version is using the dist-tag instead of a version range
-    if (nextVersion === 'canary' || nextVersion === 'latest') {
-      return false;
-    }
-
-    // If the version is an exact match with the legacy versions
-    if (nextLegacyVersions.indexOf(nextVersion) !== -1) {
-      return true;
-    }
-
-    const maxSatisfying = semver.maxSatisfying(nextLegacyVersions, nextVersion);
-    // When the version can't be matched with legacy versions, so it must be a newer version
-    if (maxSatisfying === null) {
-      return false;
-    }
-
-    return true;
-  })();
+  const isLegacy = isLegacyNext(nextVersion);
 
   console.log(`MODE: ${isLegacy ? 'legacy' : 'serverless'}`);
 
@@ -329,12 +335,18 @@ exports.build = async ({ files, workPath, entrypoint }) => {
   return { ...lambdas, ...staticFiles, ...staticDirectoryFiles };
 };
 
-exports.prepareCache = async ({ files, cachePath }) => {
-  console.log('fetching files ...');
-  await download(files, cachePath);
+exports.prepareCache = async ({ workPath, entrypoint }) => {
+  const entryDirectory = path.dirname(entrypoint);
+  const entryPath = path.join(workPath, entryDirectory);
 
-  console.log('running npm install...');
-  await runNpmInstall(cachePath, ['--prefer-offline']);
+  const pkg = await readPackageJson(entryPath);
+  const nextVersion = getNextVersion(pkg);
+  const isLegacy = isLegacyNext(nextVersion);
 
-  return glob('node_modules/{**,!.*}', cachePath);
+  if (isLegacy) {
+    // skip caching legacy mode (swapping deps between all and production can get bug-prone)
+    return {};
+  }
+
+  return glob('node_modules/{**,!.*}', entryPath);
 };

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -361,7 +361,7 @@ exports.prepareCache = async ({ cachePath, workPath, entrypoint }) => {
   return glob(
     path.join(
       path.relative(cachePath, cacheEntryPath),
-      'node_modules/{**,!.*}',
+      'node_modules/{**,!.*,.yarn*}',
     ),
     cachePath,
   );

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -358,5 +358,11 @@ exports.prepareCache = async ({ cachePath, workPath, entrypoint }) => {
   fs.renameSync(entryPath, cacheEntryPath);
 
   console.log('producing cache file manifest ...');
-  return glob('node_modules/{**,!.*}', cacheEntryPath);
+  return glob(
+    path.join(
+      path.relative(cachePath, cacheEntryPath),
+      'node_modules/{**,!.*}',
+    ),
+    cachePath,
+  );
 };

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -308,7 +308,9 @@ exports.build = async ({ files, workPath, entrypoint }) => {
   const staticFiles = Object.keys(nextStaticFiles).reduce(
     (mappedFiles, file) => ({
       ...mappedFiles,
-      [path.join(entryDirectory, `_next/static/${file}`)]: nextStaticFiles[file],
+      [path.join(entryDirectory, `_next/static/${file}`)]: nextStaticFiles[
+        file
+      ],
     }),
     {},
   );
@@ -325,4 +327,14 @@ exports.build = async ({ files, workPath, entrypoint }) => {
   );
 
   return { ...lambdas, ...staticFiles, ...staticDirectoryFiles };
+};
+
+exports.prepareCache = async ({ files, cachePath }) => {
+  console.log('fetching files ...');
+  await download(files, cachePath);
+
+  console.log('running npm install...');
+  await runNpmInstall(cachePath, ['--prefer-offline']);
+
+  return glob('node_modules/{**,!.*}', cachePath);
 };

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -68,6 +68,16 @@ async function writeNpmRc(workPath, token) {
   );
 }
 
+function getNextVersion(packageJson) {
+  let nextVersion;
+  if (packageJson.dependencies && packageJson.dependencies.next) {
+    nextVersion = packageJson.dependencies.next;
+  } else if (packageJson.devDependencies && packageJson.devDependencies.next) {
+    nextVersion = packageJson.devDependencies.next;
+  }
+  return nextVersion;
+}
+
 function isLegacyNext(nextVersion) {
   // If version is using the dist-tag instead of a version range
   if (nextVersion === 'canary' || nextVersion === 'latest') {
@@ -86,16 +96,6 @@ function isLegacyNext(nextVersion) {
   }
 
   return true;
-}
-
-function getNextVersion(packageJson) {
-  let nextVersion;
-  if (packageJson.dependencies && packageJson.dependencies.next) {
-    nextVersion = packageJson.dependencies.next;
-  } else if (packageJson.devDependencies && packageJson.devDependencies.next) {
-    nextVersion = packageJson.devDependencies.next;
-  }
-  return nextVersion;
 }
 
 exports.config = {

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -358,11 +358,14 @@ exports.prepareCache = async ({ cachePath, workPath, entrypoint }) => {
   fs.renameSync(entryPath, cacheEntryPath);
 
   console.log('producing cache file manifest ...');
-  return glob(
-    path.join(
-      path.relative(cachePath, cacheEntryPath),
-      'node_modules/{**,!.*,.yarn*}',
-    ),
-    cachePath,
-  );
+
+  const cacheEntrypoint = path.relative(cachePath, cacheEntryPath);
+  return {
+    ...(await glob(
+      path.join(cacheEntrypoint, 'node_modules/{**,!.*,.yarn*}'),
+      cachePath,
+    )),
+    ...(await glob(path.join(cacheEntrypoint, 'package-lock.json'), cachePath)),
+    ...(await glob(path.join(cacheEntrypoint, 'yarn.lock'), cachePath)),
+  };
 };

--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@now/node-bridge": "1.0.0-canary.2",
     "execa": "^1.0.0",
+    "fs-extra": "^7.0.1",
     "fs.promised": "^3.0.0",
     "semver": "^5.6.0"
   }

--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@now/node-bridge": "1.0.0-canary.2",
     "execa": "^1.0.0",
-    "fs-extra": "^7.0.1",
+    "fs-extra": "^7.0.0",
     "fs.promised": "^3.0.0",
     "semver": "^5.6.0"
   }


### PR DESCRIPTION
This refactors two functions (extract method) and introduces a `prepareCache` export that saves the `node_modules/` directory (minus `.cache` & friends).