### PR TITLE
[now-build-utils] Use `os.tmpdir()` for `getWritableDirectory()`

### DIFF
--- a/packages/now-build-utils/fs/get-writable-directory.js
+++ b/packages/now-build-utils/fs/get-writable-directory.js
@@ -1,12 +1,10 @@
-const path = require('path');
-const fs = require('fs-extra');
-
-const prod = process.env.AWS_EXECUTION_ENV || process.env.X_GOOGLE_CODE_LOCATION;
-const TMP_PATH = prod ? '/tmp' : path.join(__dirname, 'tmp');
+const { join } = require('path');
+const { tmpdir } = require('os');
+const { mkdirp } = require('fs-extra');
 
 module.exports = async function getWritableDirectory() {
   const name = Math.floor(Math.random() * 0x7fffffff).toString(16);
-  const directory = path.join(TMP_PATH, name);
-  await fs.mkdirp(directory);
+  const directory = join(tmpdir(), name);
+  await mkdirp(directory);
   return directory;
 };


### PR DESCRIPTION
`os.tmpdir()` abstracts away platform differences related to retrieving the writable temp directory, for example MacOS returns a user-specific temp directory instead of `/tmp`.

On AWS Lambda, [it returns `/tmp`](https://nexec-v2.n8.io/api/node?arg=-p&arg=require(%27os%27).tmpdir()).

More importantly, it removes the `__dirname/tmp` special-case when not running in prod. This was problematic for `now dev` because the module directory is not always writable (i.e. for a `pkg` binary).