### PR TITLE
add support go.mod for @now/go

### DIFF
--- a/packages/now-go/go-helpers.js
+++ b/packages/now-go/go-helpers.js
@@ -68,6 +68,7 @@ async function createGo(
   platform = process.platform,
   arch = process.arch,
   opts = {},
+  goMod = false
 ) {
   const env = {
     ...process.env,
@@ -75,6 +76,20 @@ async function createGo(
     GOPATH: goPath,
     ...opts.env,
   };
+
+  if (goMod) {
+    const { PATH: gccPath,
+      LD_LIBRARY_PATH,
+      CPATH,
+      LIBRARY_PATH
+    } = await downloadGCC();
+
+    env.GO111MODULE = 'on';
+    env.PATH = `${env.PATH}:${gccPath}`;
+    env.LD_LIBRARY_PATH = LD_LIBRARY_PATH;
+    env.CPATH = CPATH;
+    env.LIBRARY_PATH = LIBRARY_PATH;
+  }
 
   function go(...args) {
     debug('Exec %o', `go ${args.join(' ')}`);
@@ -115,6 +130,39 @@ async function downloadGo(
   });
 
   return createGo(dir, platform, arch);
+}
+
+async function downloadGCC() {
+  const ccUrl = 'https://dmmcy0pwk6bqi.cloudfront.net/gcc-4.8.5.tgz';
+  console.log('downloading GCC');
+  const res = await fetch(ccUrl);
+
+  if (!res.ok) {
+    throw new Error(`Failed to download: ${ccUrl} `);
+  }
+
+  return new Promise((resolve, reject) => {
+    res.body
+      .on('error', reject)
+      // NOTE(anmonteiro): We pipe GCC into `/ tmp` instead of getting a writable
+      // directory from `@now/build-utils` because the GCC distribution that we
+      // use is specifically packaged for AWS Lambda (where `/tmp` is writable)
+      // and contains several hardcoded symlinks to paths in `/tmp`.
+      .pipe(tar.extract({ gzip: true, cwd: '/tmp' }))
+      .on('finish', async () => {
+        const { LD_LIBRARY_PATH } = process.env;
+        // Set the environment variables as per
+        // https://github.com/lambci/lambci/blob/e6c9c7/home/init/gcc#L14-L17
+        const newEnv = {
+          PATH: '/tmp/bin:/tmp/sbin',
+          LD_LIBRARY_PATH: `/tmp/lib:/tmp/lib64:${LD_LIBRARY_PATH}`,
+          CPATH: '/tmp/include',
+          LIBRARY_PATH: '/tmp/lib',
+        };
+
+        return resolve(newEnv);
+      });
+  });
 }
 
 module.exports = {

--- a/packages/now-go/go-helpers.js
+++ b/packages/now-go/go-helpers.js
@@ -21,6 +21,39 @@ const getGoUrl = (version, platform, arch) => {
   return `https://dl.google.com/go/go${version}.${goPlatform}-${goArch}.${ext}`;
 };
 
+async function downloadGCC() {
+  const ccUrl = 'https://dmmcy0pwk6bqi.cloudfront.net/gcc-4.8.5.tgz';
+  console.log('downloading GCC');
+  const res = await fetch(ccUrl);
+
+  if (!res.ok) {
+    throw new Error(`Failed to download: ${ccUrl} `);
+  }
+
+  return new Promise((resolve, reject) => {
+    res.body
+      .on('error', reject)
+      // NOTE(anmonteiro): We pipe GCC into `/ tmp` instead of getting a writable
+      // directory from `@now/build-utils` because the GCC distribution that we
+      // use is specifically packaged for AWS Lambda (where `/tmp` is writable)
+      // and contains several hardcoded symlinks to paths in `/tmp`.
+      .pipe(tar.extract({ gzip: true, cwd: '/tmp' }))
+      .on('finish', async () => {
+        const { LD_LIBRARY_PATH } = process.env;
+        // Set the environment variables as per
+        // https://github.com/lambci/lambci/blob/e6c9c7/home/init/gcc#L14-L17
+        const newEnv = {
+          PATH: '/tmp/bin:/tmp/sbin',
+          LD_LIBRARY_PATH: `/tmp/lib:/tmp/lib64:${LD_LIBRARY_PATH}`,
+          CPATH: '/tmp/include',
+          LIBRARY_PATH: '/tmp/lib',
+        };
+
+        return resolve(newEnv);
+      });
+  });
+}
+
 function getExportedFunctionName(filePath) {
   debug('Detecting handler name for %o', filePath);
   const bin = join(__dirname, 'get-exported-function-name');
@@ -68,7 +101,7 @@ async function createGo(
   platform = process.platform,
   arch = process.arch,
   opts = {},
-  goMod = false
+  goMod = false,
 ) {
   const env = {
     ...process.env,
@@ -78,10 +111,11 @@ async function createGo(
   };
 
   if (goMod) {
-    const { PATH: gccPath,
+    const {
+      PATH: gccPath,
       LD_LIBRARY_PATH,
       CPATH,
-      LIBRARY_PATH
+      LIBRARY_PATH,
     } = await downloadGCC();
 
     env.GO111MODULE = 'on';
@@ -130,39 +164,6 @@ async function downloadGo(
   });
 
   return createGo(dir, platform, arch);
-}
-
-async function downloadGCC() {
-  const ccUrl = 'https://dmmcy0pwk6bqi.cloudfront.net/gcc-4.8.5.tgz';
-  console.log('downloading GCC');
-  const res = await fetch(ccUrl);
-
-  if (!res.ok) {
-    throw new Error(`Failed to download: ${ccUrl} `);
-  }
-
-  return new Promise((resolve, reject) => {
-    res.body
-      .on('error', reject)
-      // NOTE(anmonteiro): We pipe GCC into `/ tmp` instead of getting a writable
-      // directory from `@now/build-utils` because the GCC distribution that we
-      // use is specifically packaged for AWS Lambda (where `/tmp` is writable)
-      // and contains several hardcoded symlinks to paths in `/tmp`.
-      .pipe(tar.extract({ gzip: true, cwd: '/tmp' }))
-      .on('finish', async () => {
-        const { LD_LIBRARY_PATH } = process.env;
-        // Set the environment variables as per
-        // https://github.com/lambci/lambci/blob/e6c9c7/home/init/gcc#L14-L17
-        const newEnv = {
-          PATH: '/tmp/bin:/tmp/sbin',
-          LD_LIBRARY_PATH: `/tmp/lib:/tmp/lib64:${LD_LIBRARY_PATH}`,
-          CPATH: '/tmp/include',
-          LIBRARY_PATH: '/tmp/lib',
-        };
-
-        return resolve(newEnv);
-      });
-  });
 }
 
 module.exports = {

--- a/packages/now-go/index.js
+++ b/packages/now-go/index.js
@@ -1,5 +1,5 @@
 const { join, dirname } = require('path');
-const { readFile, writeFile } = require('fs-extra');
+const { readFile, writeFile, pathExists, move } = require('fs-extra');
 
 const glob = require('@now/build-utils/fs/glob.js'); // eslint-disable-line import/no-extraneous-dependencies
 const download = require('@now/build-utils/fs/download.js'); // eslint-disable-line import/no-extraneous-dependencies
@@ -23,9 +23,9 @@ async function build({ files, entrypoint }) {
   const downloadedFiles = await download(files, srcPath);
 
   console.log(`Parsing AST for "${entrypoint}"`);
-  let handlerFunctionName;
+  let parseFunctionName;
   try {
-    handlerFunctionName = await getExportedFunctionName(
+    parseFunctionName = await getExportedFunctionName(
       downloadedFiles[entrypoint].fsPath,
     );
   } catch (err) {
@@ -33,7 +33,7 @@ async function build({ files, entrypoint }) {
     throw err;
   }
 
-  if (!handlerFunctionName) {
+  if (!parseFunctionName) {
     const err = new Error(
       `Could not find an exported function in "${entrypoint}"`,
     );
@@ -41,53 +41,125 @@ async function build({ files, entrypoint }) {
     throw err;
   }
 
+  let handlerFunctionName = parseFunctionName.split(',')[0];
+
   console.log(
     `Found exported function "${handlerFunctionName}" in "${entrypoint}"`,
   );
-
-  const origianlMainGoContents = await readFile(
-    join(__dirname, 'main.go'),
-    'utf8',
-  );
-  const mainGoContents = origianlMainGoContents.replace(
-    '__NOW_HANDLER_FUNC_NAME',
-    handlerFunctionName,
-  );
-  // in order to allow the user to have `main.go`, we need our `main.go` to be called something else
-  const mainGoFileName = 'main__now__go__.go';
 
   // we need `main.go` in the same dir as the entrypoint,
   // otherwise `go build` will refuse to build
   const entrypointDirname = dirname(downloadedFiles[entrypoint].fsPath);
 
-  // Go doesn't like to build files in different directories,
-  // so now we place `main.go` together with the user code
-  await writeFile(join(entrypointDirname, mainGoFileName), mainGoContents);
+  // check if package name other than main
+  const packageName = parseFunctionName.split(',')[1];
+  const isGoModExist = await pathExists(`${entrypointDirname}/go.mod`);
+  if (packageName !== 'main') {
+    const go = await createGo(goPath, process.platform, process.arch, {
+      cwd: entrypointDirname
+    }, true);
+    if (!isGoModExist) {
+      try {
+        go('mod', 'init', packageName);
+      } catch (err) {
+        console.log(`failed to \`go mod init ${packageName}\``);
+        throw err;
+      }
+    }
 
-  const go = await createGo(goPath, process.platform, process.arch, {
-    cwd: entrypointDirname,
-  });
+    const modMainGoContents = await readFile(
+      path.join(__dirname, 'main__mod__.go'),
+      'utf8',
+    );
 
-  // `go get` will look at `*.go` (note we set `cwd`), parse the `import`s
-  // and download any packages that aren't part of the stdlib
-  try {
-    await go.get();
-  } catch (err) {
-    console.log('failed to `go get`');
-    throw err;
-  }
+    let goPackageName = `${packageName}/${packageName}`;
+    let goFuncName = `${packageName}.${handlerFunctionName}`;
 
-  console.log('Running `go build`...');
-  const destPath = join(outDir, 'handler');
-  try {
-    const src = [
-      join(entrypointDirname, mainGoFileName),
-      downloadedFiles[entrypoint].fsPath,
-    ];
-    await go.build({ src, dest: destPath });
-  } catch (err) {
-    console.log('failed to `go build`');
-    throw err;
+    if (isGoModExist) {
+      let goModContents = await readFile(
+        `${entrypointDirname}/go.mod`,
+        'utf8',
+      );
+      goPackageName = `${goModContents.split('\n')[0].split(' ')[1]}/${packageName}`
+    }
+
+    const mainModGoContents = modMainGoContents
+      .replace('__NOW_HANDLER_PACKAGE_NAME', goPackageName)
+      .replace('__NOW_HANDLER_FUNC_NAME', goFuncName);
+
+    // write main__mod__.go
+    await writeFile(path.join(entrypointDirname, mainModGoFileName), mainModGoContents);
+
+    // move user go file to folder
+    try {
+      await move(
+        downloadedFiles[entrypoint].fsPath,
+        `${path.join(entrypointDirname, packageName, entrypoint)}`
+      );
+    } catch (err) {
+      console.log('failed to move entry to package folder');
+      throw err;
+    }
+
+    console.log('installing dependencies');
+    try {
+      go.get();
+    } catch (err) {
+      console.log('failed to `go get`');
+      throw err;
+    }
+
+    console.log('Running `go build`...');
+    const destPath = join(outDir, 'handler');
+    try {
+      const src = [
+        path.join(entrypointDirname, mainModGoFileName)
+      ];
+      await go.build({ src, dest: destPath });
+    } catch (err) {
+      console.log('failed to `go build`');
+      throw err;
+    }
+  } else {
+    const go = await createGo(goPath, process.platform, process.arch, {
+      cwd: entrypointDirname
+    }, false);
+    const origianlMainGoContents = await readFile(
+      join(__dirname, 'main.go'),
+      'utf8',
+    );
+    const mainGoContents = origianlMainGoContents.replace(
+      '__NOW_HANDLER_FUNC_NAME',
+      handlerFunctionName,
+    );
+    // in order to allow the user to have `main.go`, we need our `main.go` to be called something else
+    const mainGoFileName = 'main__now__go__.go';
+
+    // Go doesn't like to build files in different directories,
+    // so now we place `main.go` together with the user code
+    await writeFile(join(entrypointDirname, mainGoFileName), mainGoContents);
+
+    // `go get` will look at `*.go` (note we set `cwd`), parse the `import`s
+    // and download any packages that aren't part of the stdlib
+    try {
+      await go.get();
+    } catch (err) {
+      console.log('failed to `go get`');
+      throw err;
+    }
+
+    console.log('Running `go build`...');
+    const destPath = join(outDir, 'handler');
+    try {
+      const src = [
+        join(entrypointDirname, mainGoFileName),
+        downloadedFiles[entrypoint].fsPath,
+      ];
+      await go.build({ src, dest: destPath });
+    } catch (err) {
+      console.log('failed to `go build`');
+      throw err;
+    }
   }
 
   const lambda = await createLambda({

--- a/packages/now-go/index.js
+++ b/packages/now-go/index.js
@@ -67,8 +67,9 @@ async function build({ files, entrypoint }) {
       }
     }
 
+    const mainModGoFileName = 'main__mod__.go';
     const modMainGoContents = await readFile(
-      path.join(__dirname, 'main__mod__.go'),
+      join(__dirname, mainModGoFileName),
       'utf8',
     );
 
@@ -88,13 +89,13 @@ async function build({ files, entrypoint }) {
       .replace('__NOW_HANDLER_FUNC_NAME', goFuncName);
 
     // write main__mod__.go
-    await writeFile(path.join(entrypointDirname, mainModGoFileName), mainModGoContents);
+    await writeFile(join(entrypointDirname, mainModGoFileName), mainModGoContents);
 
     // move user go file to folder
     try {
       await move(
         downloadedFiles[entrypoint].fsPath,
-        `${path.join(entrypointDirname, packageName, entrypoint)}`
+        `${join(entrypointDirname, packageName, entrypoint)}`
       );
     } catch (err) {
       console.log('failed to move entry to package folder');
@@ -113,7 +114,7 @@ async function build({ files, entrypoint }) {
     const destPath = join(outDir, 'handler');
     try {
       const src = [
-        path.join(entrypointDirname, mainModGoFileName)
+        join(entrypointDirname, mainModGoFileName)
       ];
       await go.build({ src, dest: destPath });
     } catch (err) {

--- a/packages/now-go/index.js
+++ b/packages/now-go/index.js
@@ -117,6 +117,9 @@ async function build({ files, entrypoint }) {
 
     console.log('installing dependencies');
     try {
+      // ensure go.mod up-to-date
+      await go('mod', 'tidy');
+
       go.get();
     } catch (err) {
       console.log('failed to `go get`');

--- a/packages/now-go/main__mod__.go
+++ b/packages/now-go/main__mod__.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+  "net/http"
+  "__NOW_HANDLER_PACKAGE_NAME"
+
+  now "github.com/zeit/now-builders/utils/go/bridge"
+)
+
+func main() {
+  now.Start(http.HandlerFunc(__NOW_HANDLER_FUNC_NAME))
+}

--- a/packages/now-go/package.json
+++ b/packages/now-go/package.json
@@ -13,6 +13,7 @@
   "files": [
     "*.js",
     "main.go",
+    "main__mod__.go",
     "util"
   ],
   "dependencies": {

--- a/packages/now-go/util/get-exported-function-name.go
+++ b/packages/now-go/util/get-exported-function-name.go
@@ -34,7 +34,7 @@ func main() {
 		if fn.Name.IsExported() == true {
 			// we found the first exported function
 			// we're done!
-			fmt.Print(fn.Name.Name)
+			fmt.Print(fn.Name.Name, ",", parsed.Name.Name)
 			os.Exit(0)
 		}
 	}


### PR DESCRIPTION
This PR add support `go.mod` for `@now/go`. With this, it allow us to have package name other than `main`.

There are should be no breaking change.
both
```golang
package main

import (
        "fmt"
        "net/http"
)

func Handler(w http.ResponseWriter, r *http.Request) {
        fmt.Fprintf(w, "<h1>Hello from Go on Now!</h1>")
}
```
and
```golang
package myhandler

import (
        "fmt"
        "net/http"
)

func Handler(w http.ResponseWriter, r *http.Request) {
        fmt.Fprintf(w, "<h1>Hello from Go on Now!</h1>")
}
```
are working.

PS: ~~I also add `gcc` to satisfy go.mod.~~