### PR TITLE
Can we update Go to 1.12?

### DIFF
--- a/packages/now-go/go-helpers.js
+++ b/packages/now-go/go-helpers.js
@@ -90,7 +90,7 @@ async function createGo(
 
 async function downloadGo(
   dir = GO_DIR,
-  version = '1.11.5',
+  version = '1.12',
   platform = process.platform,
   arch = process.arch,
 ) {


### PR DESCRIPTION
This might allow users to use `go.mod`, since on 1.12 they did the following:

> ... the go command now supports module-aware operations outside of a module directory, provided that those operations do not need to resolve import paths relative to the current directory or explicitly edit the go.mod file. ...

Perhaps after that, the users would be simply able to add this to their config files and make it work?

```
  "build": {    
    "env": {                                                              
      "GO111MODULE": "on"    
    }    
  },
```

It's just an idea! But we would totally appreciate the update to 1.12 wether my previous reasoning is valid or not.