### PR TITLE
[now-rust]: Allow a build.sh to be run prior to compile

### DIFF
--- a/packages/now-rust/src/request.rs
+++ b/packages/now-rust/src/request.rs
@@ -109,7 +109,7 @@ impl<'a> From<NowRequest<'a>> for HttpRequest<Body> {
                     // todo: document failure behavior
                     Body::from(::base64::decode(b.as_ref()).unwrap_or_default())
                 }
-                (Some(b), Some(_)) => Body::from(b.into_owned()),
+                (Some(b), _) => Body::from(b.into_owned()),
                 _ => Body::from(()),
             })
             .expect("failed to build request");


### PR DESCRIPTION
This supports a use case I have, where I need to have a couple extra things installed on the VM before the lambda is created (`wget`, `now`). This follows the same pattern that `@now/static-build` has.

For it to work, a `build.sh` file must be in the same directory as the entrypoint, which may be naïve, but I think works for most cases.

This also includes a fix for POST body parsing. For some reason, the way the Now event handles `encoding` is different than AWS Lambda's method, so it's usually `None` unless it's `base64` encoded. I don't think this should have any ill effects, but we'll have to wait for more users to use this ¯\\_(ツ)_/¯ 

Combined those two items into a single PR. If y'all want it split out into two, I'm happy to do that. Thanks!