### PR TITLE
Use `glob-gitignore` instead of vanilla `glob`

### DIFF
--- a/packages/now-build-utils/fs/glob.js
+++ b/packages/now-build-utils/fs/glob.js
@@ -1,6 +1,6 @@
-const assert = require('assert');
 const path = require('path');
-const vanillaGlob = require('glob');
+const assert = require('assert');
+const { glob: vanillaGlob } = require('glob-gitignore');
 const FileFsRef = require('../file-fs-ref.js');
 
 /** @typedef {import('fs').Stats} Stats */
@@ -13,55 +13,49 @@ const FileFsRef = require('../file-fs-ref.js');
  * @argument {string} [mountpoint]
  * @returns {Promise<GlobFiles>}
  */
-module.exports = function glob(pattern, opts = {}, mountpoint) {
-  return new Promise((resolve, reject) => {
-    /** @type {GlobOptions} */
-    let options;
-    if (typeof opts === 'string') {
-      options = { cwd: opts };
-    } else {
-      options = opts;
+module.exports = async function glob(pattern, opts = {}, mountpoint) {
+  /** @type {GlobOptions} */
+  let options;
+  if (typeof opts === 'string') {
+    options = { cwd: opts };
+  } else {
+    options = opts;
+  }
+
+  if (!options.cwd) {
+    throw new Error(
+      'Second argument (basePath) must be specified for names of resulting files',
+    );
+  }
+
+  if (!path.isAbsolute(options.cwd)) {
+    throw new Error(`basePath/cwd must be an absolute path (${options.cwd})`);
+  }
+
+  options.statCache = {};
+  options.stat = true;
+  options.dot = true;
+
+  // eslint-disable-next-line consistent-return
+  const files = await vanillaGlob(pattern, options);
+
+  return files.reduce((files2, relativePath) => {
+    const fsPath = path.join(options.cwd, relativePath);
+    /** @type {Stats|any} */
+    const stat = options.statCache[fsPath];
+    assert(
+      stat,
+      `statCache does not contain value for ${relativePath} (resolved to ${fsPath})`,
+    );
+    if (stat && stat.isFile()) {
+      let finalPath = relativePath;
+      if (mountpoint) finalPath = path.join(mountpoint, finalPath);
+      return {
+        ...files2,
+        [finalPath]: new FileFsRef({ mode: stat.mode, fsPath }),
+      };
     }
 
-    if (!options.cwd) {
-      throw new Error(
-        'Second argument (basePath) must be specified for names of resulting files',
-      );
-    }
-
-    if (!path.isAbsolute(options.cwd)) {
-      throw new Error(`basePath/cwd must be an absolute path (${options.cwd})`);
-    }
-
-    options.statCache = {};
-    options.stat = true;
-    options.dot = true;
-
-    // eslint-disable-next-line consistent-return
-    vanillaGlob(pattern, options, (error, files) => {
-      if (error) return reject(error);
-
-      resolve(
-        files.reduce((files2, relativePath) => {
-          const fsPath = path.join(options.cwd, relativePath);
-          /** @type {Stats|any} */
-          const stat = options.statCache[fsPath];
-          assert(
-            stat,
-            `statCache does not contain value for ${relativePath} (resolved to ${fsPath})`,
-          );
-          if (stat && stat.isFile()) {
-            let finalPath = relativePath;
-            if (mountpoint) finalPath = path.join(mountpoint, finalPath);
-            return {
-              ...files2,
-              [finalPath]: new FileFsRef({ mode: stat.mode, fsPath }),
-            };
-          }
-
-          return files2;
-        }, {}),
-      );
-    });
-  });
+    return files2;
+  }, {});
 };

--- a/packages/now-build-utils/package.json
+++ b/packages/now-build-utils/package.json
@@ -12,7 +12,7 @@
     "async-sema": "2.1.4",
     "fast-stream-to-buffer": "1.0.0",
     "fs-extra": "7.0.0",
-    "glob": "7.1.3",
+    "glob-gitignore": "1.0.14",
     "into-stream": "4.0.0",
     "memory-fs": "0.4.1",
     "multistream": "2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3488,6 +3488,18 @@ glob-base@^0.3.0:
     glob-parent "^2.0.0"
     is-glob "^2.0.0"
 
+glob-gitignore@1.0.14:
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/glob-gitignore/-/glob-gitignore-1.0.14.tgz#8b708cb029e73bd388d22f7f935213aa93a1e7c2"
+  integrity sha512-YuAEPqL58bOQDqDF2kMv009rIjSAtPs+WPzyGbwRWK+wD0UWQVRoP34Pz6yJ6ivco65C9tZnaIt0I3JCuQ8NZQ==
+  dependencies:
+    glob "^7.1.3"
+    ignore "^5.0.5"
+    lodash.difference "^4.5.0"
+    lodash.union "^4.6.0"
+    make-array "^1.0.5"
+    util.inherits "^1.0.3"
+
 glob-option-error@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/glob-option-error/-/glob-option-error-1.0.0.tgz#57cc65def9c7d5c1461baf13129bb5403cff6176"
@@ -3993,6 +4005,11 @@ ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.0.5.tgz#c663c548d6ce186fb33616a8ccb5d46e56bdbbf9"
+  integrity sha512-kOC8IUb8HSDMVcYrDVezCxpJkzSQWTAzf3olpKM6o9rM5zpojx23O0Fl8Wr4+qJ6ZbPEHqf1fdwev/DS7v7pmA==
 
 import-fresh@^2.0.0:
   version "2.0.0"
@@ -5772,6 +5789,11 @@ lodash._root@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz#fba1c4524c19ee9a5f8136b4609f017cf4ded692"
   integrity sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=
 
+lodash.difference@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
+  integrity sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=
+
 lodash.escape@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-3.2.0.tgz#995ee0dc18c1b48cc92effae71a10aab5b487698"
@@ -5850,6 +5872,11 @@ lodash.templatesettings@^4.0.0:
   integrity sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=
   dependencies:
     lodash._reinterpolate "~3.0.0"
+
+lodash.union@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
+  integrity sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=
 
 lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1:
   version "4.17.11"
@@ -5939,6 +5966,11 @@ lru-cache@^4.0.1, lru-cache@^4.1.2, lru-cache@^4.1.3:
   dependencies:
     pseudomap "^1.0.2"
     yallist "^3.0.2"
+
+make-array@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/make-array/-/make-array-1.0.5.tgz#326a7635c756a9f61ce0b2a6fdd5cc3460419bcb"
+  integrity sha512-sgK2SAzxT19rWU+qxKUcn6PAh/swiIiz2F8C2cZjLc1z4iwYIfdoihqFIDQ8BDzAGtWPYJ6Sr13K1j/DXynDLA==
 
 make-dir@^1.0.0, make-dir@^1.3.0:
   version "1.3.0"
@@ -8983,6 +9015,11 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
+util.inherits@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/util.inherits/-/util.inherits-1.0.3.tgz#a9c626a0d06d34829d47ba56cab1278d745f9ce6"
+  integrity sha1-qcYmoNBtNIKdR7pWyrEnjXRfnOY=
 
 util.promisify@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
See: https://www.npmjs.com/package/glob-gitignore

This module merges `glob` and the `ignore` packages for performance purposes. This is mainly for `now dev` (see zeit/now-cli#1899), so that we can easily pass the `Ignore` instance to the glob function to avoid unnecessary directory traversals.