### PR TITLE
[now-node] Add `config.includeFiles`

### DIFF
--- a/packages/now-bash/package.json
+++ b/packages/now-bash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@now/bash",
-  "version": "0.1.3-canary.0",
+  "version": "0.1.3",
   "description": "Now 2.0 builder for HTTP endpoints written in Bash",
   "main": "index.js",
   "author": "Nathan Rajlich <nate@zeit.co>",

--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -69,7 +69,7 @@ async function compile(workNccPath: string, downloadedFiles, entrypoint: string,
   const ncc = require(join(workNccPath, 'node_modules/@zeit/ncc'));
   const { code, assets } = await ncc(input);
 
-  if (config.includeFiles) {
+  if (config && config.includeFiles) {
     for (const pattern of config.includeFiles) {
       const files = await glob(pattern, inputDir);
 

--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -10,6 +10,10 @@ import {
   runPackageJsonScript
 } from '@now/build-utils/fs/run-user-scripts.js';
 
+interface CompilerConfig {
+  includeFiles?: string[]
+}
+
 /** @typedef { import('@now/build-utils/file-ref') } FileRef */
 /** @typedef {{[filePath: string]: FileRef}} Files */
 
@@ -59,14 +63,15 @@ async function downloadInstallAndBundle(
   return [downloadedFiles, nccPath, entrypointFsDirname];
 }
 
-async function compile(workNccPath: string, downloadedFiles, entrypoint: string, config) {
+async function compile(workNccPath: string, downloadedFiles, entrypoint: string, config: CompilerConfig) {
   const input = downloadedFiles[entrypoint].fsPath;
+  const inputDir = dirname(downloadedFiles[entrypoint].fsPath);
   const ncc = require(join(workNccPath, 'node_modules/@zeit/ncc'));
   const { code, assets } = await ncc(input);
 
-  if (config.bundle) {
-    for (const pattern of config.bundle) {
-      const files = await glob(pattern, dirname(downloadedFiles[entrypoint].fsPath));
+  if (config.includeFiles) {
+    for (const pattern of config.includeFiles) {
+      const files = await glob(pattern, inputDir);
 
       for (const assetName of Object.keys(files)) {
         const stream = files[assetName].toStream();

--- a/packages/now-node/test/fixtures/09-include-files/index.js
+++ b/packages/now-node/test/fixtures/09-include-files/index.js
@@ -1,0 +1,7 @@
+const edge = require('edge.js');
+
+module.exports = (req, resp) => {
+  edge.registerViews('templates');
+
+  resp.end(edge.render('index', { name: 'Now!' }));
+};

--- a/packages/now-node/test/fixtures/09-include-files/now.json
+++ b/packages/now-node/test/fixtures/09-include-files/now.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "index.js",
+      "use": "@now/node",
+      "config": {
+        "includeFiles": [
+          "templates/**"
+        ]
+      }
+    }
+  ],
+  "probes": [
+    {
+      "path": "/",
+      "mustContain": "hello Now!"
+    }
+  ]
+}

--- a/packages/now-node/test/fixtures/09-include-files/package.json
+++ b/packages/now-node/test/fixtures/09-include-files/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "edge.js": "^1.1.4"
+  }
+}

--- a/packages/now-node/test/fixtures/09-include-files/templates/index.edge
+++ b/packages/now-node/test/fixtures/09-include-files/templates/index.edge
@@ -1,0 +1,1 @@
+hello {{ name }}


### PR DESCRIPTION
if `bundle` provide in `config` object, then all of the files will be bundle with `handler`.

This fixes [this problem](https://spectrum.chat/zeit/now/reading-template-assets-on-file-system-using-now-node~56f167d9-7416-444f-a352-6738b341df48) when template files (assets) are not included in the output.