### PR TITLE
[now-html-minifier] Remove collapseInlineTagWhitespace option

### DIFF
--- a/packages/now-html-minifier/index.js
+++ b/packages/now-html-minifier/index.js
@@ -11,7 +11,6 @@ const defaultOptions = {
   removeRedundantAttributes: true,
   useShortDoctype: true,
   collapseWhitespace: true,
-  collapseInlineTagWhitespace: true,
   collapseBooleanAttributes: true,
   caseSensitive: true,
 };


### PR DESCRIPTION
`collapseInlineTagWhitespace` removes white space between inline elements so `<p>Text with <a href="https://zeit.co/now">a link</a> is hard to read.</p>` renders as `Text witha linkis hard to read.`

See example at https://runkit.com/5c8a1c7a0f950f0012252fbb/5c8a1c7a0f950f0012252fbc

It's probably safe to keep the `collapseWhitespace` option for now but [it can also affect document rendering](http://perfectionkills.com/experimenting-with-html-minifier/#collapse_whitespace).