### PR TITLE
Fix static files for latest now/next using target serverless

### DIFF
--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -355,15 +355,9 @@ exports.build = async ({ files, workPath, entrypoint }) => {
     {},
   );
 
-  const nextStaticDirectory = onlyStaticDirectory(
+  const staticDirectoryFiles = onlyStaticDirectory(
     includeOnlyEntryDirectory(files, entryDirectory),
-  );
-  const staticDirectoryFiles = Object.keys(nextStaticDirectory).reduce(
-    (mappedFiles, file) => ({
-      ...mappedFiles,
-      [path.join(entryDirectory, file)]: nextStaticDirectory[file],
-    }),
-    {},
+    entryDirectory,
   );
 
   return { ...lambdas, ...staticFiles, ...staticDirectoryFiles };

--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@now/next",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/now-next/utils.js
+++ b/packages/now-next/utils.js
@@ -82,13 +82,13 @@ function excludeLockFiles(files) {
 }
 
 /**
- * Exclude the static directory from files
+ * Include the static directory from files
  * @param {Files} files
  * @returns {Files}
  */
-function onlyStaticDirectory(files) {
+function onlyStaticDirectory(files, entryDir) {
   function matcher(filePath) {
-    return !filePath.startsWith('static');
+    return !filePath.startsWith(path.join(entryDir, 'static'));
   }
 
   return excludeFiles(files, matcher);

--- a/test/integration/now-next/index.test.js
+++ b/test/integration/now-next/index.test.js
@@ -75,10 +75,21 @@ it('Should throw when package.json or next.config.js is not the "src"', async ()
 });
 
 it(
-  'Should build the static-files test',
+  'Should build the static-files test on legacy',
   async () => {
     const { buildResult } = await runBuildLambda(
       path.join(__dirname, 'legacy-static-files'),
+    );
+    expect(buildResult['static/test.txt']).toBeDefined();
+  },
+  FOUR_MINUTES,
+);
+
+it(
+  'Should build the static-files test',
+  async () => {
+    const { buildResult } = await runBuildLambda(
+      path.join(__dirname, 'static-files'),
     );
     expect(buildResult['static/test.txt']).toBeDefined();
   },

--- a/test/integration/now-next/index.test.js
+++ b/test/integration/now-next/index.test.js
@@ -27,6 +27,7 @@ it(
       path.join(__dirname, 'monorepo'),
     );
     expect(buildResult['www/index']).toBeDefined();
+    expect(buildResult['www/static/test.txt']).toBeDefined();
     const filePaths = Object.keys(buildResult);
     const hasUnderScoreAppStaticFile = filePaths.some(filePath => filePath.match(/static.*\/pages\/_app\.js$/));
     const hasUnderScoreErrorStaticFile = filePaths.some(filePath => filePath.match(/static.*\/pages\/_error\.js$/));

--- a/test/integration/now-next/monorepo/www/static/test.txt
+++ b/test/integration/now-next/monorepo/www/static/test.txt
@@ -1,0 +1,1 @@
+hello world

--- a/test/integration/now-next/static-files/next.config.js
+++ b/test/integration/now-next/static-files/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  target: 'serverless',
+};

--- a/test/integration/now-next/static-files/now.json
+++ b/test/integration/now-next/static-files/now.json
@@ -1,0 +1,6 @@
+{
+  "version": 2,
+  "builds": [
+    {"src": "next.config.js", "use": "@now/next"}
+  ]
+}

--- a/test/integration/now-next/static-files/package.json
+++ b/test/integration/now-next/static-files/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "now-build": "next build"
+  },
+  "dependencies": {
+    "next": "8",
+    "react": "16",
+    "react-dom": "16"
+  }
+}

--- a/test/integration/now-next/static-files/pages/index.js
+++ b/test/integration/now-next/static-files/pages/index.js
@@ -1,0 +1,1 @@
+export default () => 'Index page';

--- a/test/integration/now-next/static-files/static/test.txt
+++ b/test/integration/now-next/static-files/static/test.txt
@@ -1,0 +1,1 @@
+hello world


### PR DESCRIPTION
This adds a test for uploading the static folder with `target: serverless` in a regular `@now/next` deploy and in a monorepo.
When being used in a monorepo there was a bug with outputting `static` files