### PR TITLE
[now-node] Bump ncc to 0.16.0

### DIFF
--- a/packages/now-node-server/index.js
+++ b/packages/now-node-server/index.js
@@ -48,7 +48,7 @@ async function downloadInstallAndBundle(
         data: JSON.stringify({
           license: 'UNLICENSED',
           dependencies: {
-            '@zeit/ncc': '0.15.2',
+            '@zeit/ncc': '0.16.0',
           },
         }),
       }),

--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -46,7 +46,7 @@ async function downloadInstallAndBundle(
         data: JSON.stringify({
           license: 'UNLICENSED',
           dependencies: {
-            '@zeit/ncc': '0.15.2',
+            '@zeit/ncc': '0.16.0',
           }
         })
       })


### PR DESCRIPTION
This bumps `ncc` to version 0.16.0