### PR TITLE
[now-go] Add missing await to `getExportedFunctionName()`

### DIFF
--- a/packages/now-go/go-helpers.js
+++ b/packages/now-go/go-helpers.js
@@ -21,12 +21,12 @@ const getGoUrl = (version, platform, arch) => {
   return `https://dl.google.com/go/go${version}.${goPlatform}-${goArch}.${ext}`;
 };
 
-function getExportedFunctionName(filePath) {
+async function getExportedFunctionName(filePath) {
   debug('Detecting handler name for %o', filePath);
   const bin = join(__dirname, 'get-exported-function-name');
   const args = [filePath];
-  const name = execa.stdout(bin, args);
-  debug('Detected exported name %o', filePath);
+  const name = await execa.stdout(bin, args);
+  debug('Detected exported name %o', name);
   return name;
 }
 


### PR DESCRIPTION
This fixes a subtle bug in the `getExportedFunctionName()` helper function.

It wasn't actually causing any issues in production, since the `index.js` file also does `await` on the return value of this function so it was still resolving the promise properly, but this is more correct and fixes the associated `debug()` call.