### PR TITLE
Publish now_lambda 0.1.3

### DIFF
--- a/packages/now-rust/Cargo.lock
+++ b/packages/now-rust/Cargo.lock
@@ -448,7 +448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "now_lambda"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/packages/now-rust/Cargo.toml
+++ b/packages/now-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "now_lambda"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
 edition = "2018"
 description = "Rust bindings for Now.sh Lambdas"


### PR DESCRIPTION
Already published at https://crates.io/crates/now_lambda/0.1.3

