### PR TITLE
Add note about @now/next not supporting distDir

### DIFF
--- a/errors/now-next-no-serverless-pages-built.md
+++ b/errors/now-next-no-serverless-pages-built.md
@@ -35,8 +35,7 @@ module.exports = {
 
 4. Remove `distDir` from `next.config.js` as `@now/next` can't parse this file and expects your build output at `/.next`
 
-
-4. Optionally make sure the `"src"` in `"builds"` points to your application `package.json`
+5. Optionally make sure the `"src"` in `"builds"` points to your application `package.json`
 
 ```js
 {

--- a/errors/now-next-no-serverless-pages-built.md
+++ b/errors/now-next-no-serverless-pages-built.md
@@ -29,9 +29,12 @@ npm install next --save
 ```js
 module.exports = {
   target: 'serverless'
-  // Other options are still valid
+  // Other options
 }
 ```
+
+4. Remove `distDir` from `next.config.js` as `@now/next` can't parse this file and expects your build output at `/.next`
+
 
 4. Optionally make sure the `"src"` in `"builds"` points to your application `package.json`
 


### PR DESCRIPTION
`now-builders` can't parse `next.config.js` because it can hold functions.

It expects `/.next` as the build output.

Closes: #288 