### PR TITLE
Allowing main functions through the Go builder

### DIFF
--- a/packages/now-go/go-helpers.js
+++ b/packages/now-go/go-helpers.js
@@ -131,7 +131,7 @@ async function cachedReadFile(filePath) {
   // TODO:
   // This sync call is still locking the thread,
   // should we promisify this and await it?
-  const data = fs.readFileSync(filePath);
+  const data = fs.readFileSync(join(__dirname, filePath));
   fileCache[filePath] = data;
   return data;
 }
@@ -165,7 +165,7 @@ async function replaceMain(filePath, newMain) {
   // TODO:
   // This sync call is still locking the thread,
   // should we promisify this and await it?
-  fs.writeFileSync(filePath, data);
+  fs.writeFileSync(join(__dirname, filePath), data);
 }
 
 module.exports = {

--- a/packages/now-go/go-helpers.js
+++ b/packages/now-go/go-helpers.js
@@ -159,10 +159,8 @@ async function getNewMain(filePath) {
 
 async function replaceMain(filePath, newMain) {
   debug('Replacing the main function in %o', filePath);
-  const data = await cachedReadFile(fileName);
-  data.replace();
-  let data = fs.readFileSync(filePath);
-  data = data.replace(mainDeclaration, `func ${newName} {`);
+  let data = await cachedReadFile(fileName);
+  data = data.replace(mainDeclaration, `func ${newMain} {`);
   // TODO:
   // This sync call is still locking the thread,
   // should we promisify this and await it?

--- a/packages/now-go/go-helpers.js
+++ b/packages/now-go/go-helpers.js
@@ -126,7 +126,7 @@ async function downloadGo(
 const mainDeclaration = 'func main() {'
 
 let fileCache = {}
-async cachedReadFile(filePath) {
+async function cachedReadFile(filePath) {
   if (fileCache[filePath]) return fileCache[filePath]
   // TODO:
   // This sync call is still locking the thread,
@@ -136,13 +136,13 @@ async cachedReadFile(filePath) {
   return data
 }
 
-async hasMainFunction(filePath) {
+async function hasMainFunction(filePath) {
   debug('Checking if there\'s a main function in %o', filePath);
   const data = await cachedReadFile(fileName)
   return data.indexOf(mainDeclaration) >= 0
 }
 
-async getNewMain(filePath) {
+async function getNewMain(filePath) {
   debug('Finding a function name that\'s not already in %o', filePath);
   const data = await cachedReadFile(fileName);
   let found = false;
@@ -157,7 +157,7 @@ async getNewMain(filePath) {
   }
 }
 
-async replaceMain(filePath, newMain) {
+async function replaceMain(filePath, newMain) {
   debug('Replacing the main function in %o', filePath);
   const data = await cachedReadFile(fileName);
   data.replace();

--- a/packages/now-go/index.js
+++ b/packages/now-go/index.js
@@ -7,7 +7,9 @@ const glob = require('@now/build-utils/fs/glob.js'); // eslint-disable-line impo
 const download = require('@now/build-utils/fs/download.js'); // eslint-disable-line import/no-extraneous-dependencies
 const { createLambda } = require('@now/build-utils/lambda.js'); // eslint-disable-line import/no-extraneous-dependencies
 const getWritableDirectory = require('@now/build-utils/fs/get-writable-directory.js'); // eslint-disable-line import/no-extraneous-dependencies
-const { createGo, getExportedFunctionName, hasMainFunction, getNewMain, replaceMain } = require('./go-helpers');
+const {
+  createGo, getExportedFunctionName, hasMainFunction, getNewMain, replaceMain,
+} = require('./go-helpers');
 
 const config = {
   maxLambdaSize: '10mb',
@@ -23,7 +25,7 @@ async function build({ files, entrypoint }) {
 
   const srcPath = join(goPath, 'src', 'lambda');
   const downloadedFiles = await download(files, srcPath);
-  const filePath = downloadedFiles[entrypoint].fsPath
+  const filePath = downloadedFiles[entrypoint].fsPath;
 
   console.log(`Parsing AST for "${entrypoint}"`);
   let parseFunctionName;
@@ -38,7 +40,7 @@ async function build({ files, entrypoint }) {
   let mainCall = '';
   // NOTE: This should be safe since getExportedFunctionName already checked if this file exists
   if (await hasMainFunction(filePath)) {
-    let customMain = await getNewMain(filePath);
+    const customMain = await getNewMain(filePath);
     await replaceMain(filePath, customMain);
     mainCall = `${customMain}()`;
   }

--- a/packages/now-go/main.go
+++ b/packages/now-go/main.go
@@ -6,5 +6,6 @@ import (
 )
 
 func main() {
+	__ORIGINAL_MAIN_CALL
 	now.Start(http.HandlerFunc(__NOW_HANDLER_FUNC_NAME))
 }


### PR DESCRIPTION
This is a concept idea that should fix #252

This PR will replace any existing `main` function with a function called
`Main` with an apendix to the name composed of random numbers, as in:
`Main3831`. This will be done only if the `src` file has a `main`
package.  After that, knowing that a main function was present, this PR
makes sure that this `Main` function gets called within the `main`
function we declare in the build, right before
`now.Start(http.HandlerFunc(__NOW_HANDLER_FUNC_NAME))`.

If this PR is not ok, feel free to close it! I hope it serves at least
as a form of documentation for any further fixes to #252

Best regards to the Zeit team,
Daniel.