### PR TITLE
Fix `packAndDeploy()` for usage with `@now/node`

### DIFF
--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -9,7 +9,7 @@ const { nowDeploy } = require('./now-deploy.js');
 
 async function packAndDeploy (builderPath) {
   await spawnAsync('npm', [ '--loglevel', 'warn', 'pack' ], {
-    stdio: 'ignore',
+    stdio: 'inherit',
     cwd: builderPath
   });
   const tarballs = await glob('*.tgz', { cwd: builderPath });

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -8,11 +8,12 @@ const fetch = require('./fetch-retry.js');
 const { nowDeploy } = require('./now-deploy.js');
 
 async function packAndDeploy (builderPath) {
-  const tgzName = (await spawnAsync('npm', [ '--loglevel', 'warn', 'pack' ], {
-    stdio: [ 'ignore', 'pipe', 'inherit' ],
+  await spawnAsync('npm', [ '--loglevel', 'warn', 'pack' ], {
+    stdio: 'ignore',
     cwd: builderPath
-  })).trim();
-  const tgzPath = path.join(builderPath, tgzName);
+  });
+  const tarballs = await glob('*.tgz', { cwd: builderPath });
+  const tgzPath = tarballs[0];
   console.log('tgzPath', tgzPath);
   const url = await nowDeployIndexTgz(tgzPath);
   await fetchTgzUrl(`https://${url}`);

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -13,7 +13,7 @@ async function packAndDeploy (builderPath) {
     cwd: builderPath
   });
   const tarballs = await glob('*.tgz', { cwd: builderPath });
-  const tgzPath = tarballs[0];
+  const tgzPath = path.join(builderPath, tarballs[0]);
   console.log('tgzPath', tgzPath);
   const url = await nowDeployIndexTgz(tgzPath);
   await fetchTgzUrl(`https://${url}`);


### PR DESCRIPTION
Since the prepublish script for `@now/node` writes other stuff to stdout, so relying on `npm pack` outputting the tarball name is not reliable.

Instead, just `glob()` for a `*.tgz` file and expect that to be the output package tarball.

Fixes error:

```
Error: ENOENT: no such file or directory, open '/home/circleci/repo/packages/now-node/> @now/node@0.5.2-canary.2 prepublish /home/circleci/repo/packages/now-node
> npm run build
> @now/node@0.5.2-canary.2 build /home/circleci/repo/packages/now-node
> ./build.sh
'/home/circleci/repo/packages/now-node-bridge/bridge.d.ts' -> 'src/bridge.d.ts'
now-node-0.5.2-canary.2.tgz'
```