### PR TITLE
[now-python] Use `workDir` provided by builder

### DIFF
--- a/packages/now-python/index.js
+++ b/packages/now-python/index.js
@@ -10,7 +10,7 @@ const downloadAndInstallPip = require('./download-and-install-pip');
 async function pipInstall(pipPath, workDir, ...args) {
   console.log(`running "pip install --target ${workDir} ${args.join(' ')}"...`);
   try {
-    await execa(pipPath, ['install', '--target', '.', ...args], {
+    await execa(pipPath, ['install', '--target', '--upgrade', '.', ...args], {
       stdio: 'inherit',
     });
   } catch (err) {

--- a/packages/now-python/index.js
+++ b/packages/now-python/index.js
@@ -7,15 +7,14 @@ const glob = require('@now/build-utils/fs/glob.js'); // eslint-disable-line impo
 const { createLambda } = require('@now/build-utils/lambda.js'); // eslint-disable-line import/no-extraneous-dependencies
 const downloadAndInstallPip = require('./download-and-install-pip');
 
-async function pipInstall(pipPath, srcDir, ...args) {
-  console.log(`running "pip install --target ${srcDir} ${args.join(' ')}"...`);
+async function pipInstall(pipPath, workDir, ...args) {
+  console.log(`running "pip install --target ${workDir} ${args.join(' ')}"...`);
   try {
     await execa(pipPath, ['install', '--target', '.', ...args], {
-      cwd: srcDir,
       stdio: 'inherit',
     });
   } catch (err) {
-    console.log(`failed to run "pip install -t ${srcDir} ${args.join(' ')}"`);
+    console.log(`failed to run "pip install -t ${workDir} ${args.join(' ')}"`);
     throw err;
   }
 }
@@ -24,13 +23,11 @@ exports.config = {
   maxLambdaSize: '5mb',
 };
 
-exports.build = async ({ files, entrypoint }) => {
+exports.build = async ({ workDir, files, entrypoint }) => {
   console.log('downloading files...');
 
-  const srcDir = await getWritableDirectory();
-
   // eslint-disable-next-line no-param-reassign
-  files = await download(files, srcDir);
+  files = await download(files, workDir);
 
   // this is where `pip` will be installed to
   // we need it to be under `/tmp`
@@ -47,14 +44,14 @@ exports.build = async ({ files, entrypoint }) => {
     //
     // distutils.errors.DistutilsOptionError: must supply either home
     // or prefix/exec-prefix -- not both
-    const setupCfg = path.join(srcDir, 'setup.cfg');
+    const setupCfg = path.join(workDir, 'setup.cfg');
     await writeFile(setupCfg, '[install]\nprefix=\n');
   } catch (err) {
     console.log('failed to create "setup.cfg" file');
     throw err;
   }
 
-  await pipInstall(pipPath, srcDir, 'requests');
+  await pipInstall(pipPath, workDir, 'requests');
 
   const entryDirectory = path.dirname(entrypoint);
   const requirementsTxt = path.join(entryDirectory, 'requirements.txt');
@@ -63,12 +60,12 @@ exports.build = async ({ files, entrypoint }) => {
     console.log('found local "requirements.txt"');
 
     const requirementsTxtPath = files[requirementsTxt].fsPath;
-    await pipInstall(pipPath, srcDir, '-r', requirementsTxtPath);
+    await pipInstall(pipPath, workDir, '-r', requirementsTxtPath);
   } else if (files['requirements.txt']) {
     console.log('found global "requirements.txt"');
 
     const requirementsTxtPath = files['requirements.txt'].fsPath;
-    await pipInstall(pipPath, srcDir, '-r', requirementsTxtPath);
+    await pipInstall(pipPath, workDir, '-r', requirementsTxtPath);
   }
 
   const originalNowHandlerPyContents = await readFile(
@@ -91,12 +88,12 @@ exports.build = async ({ files, entrypoint }) => {
   const nowHandlerPyFilename = 'now__handler__python';
 
   await writeFile(
-    path.join(srcDir, `${nowHandlerPyFilename}.py`),
+    path.join(workDir, `${nowHandlerPyFilename}.py`),
     nowHandlerPyContents,
   );
 
   const lambda = await createLambda({
-    files: await glob('**', srcDir),
+    files: await glob('**', workDir),
     handler: `${nowHandlerPyFilename}.now_handler`,
     runtime: 'python3.6',
     environment: {},


### PR DESCRIPTION
Instead of generating another temp directory.