### PR TITLE
[now-node-server] Add `config.includeFiles`

### DIFF
--- a/packages/now-node-server/test/fixtures/11-include-files/index.js
+++ b/packages/now-node-server/test/fixtures/11-include-files/index.js
@@ -1,0 +1,6 @@
+const express = require('express');
+
+const app = express();
+app.use(express.static('templates'));
+
+app.listen();

--- a/packages/now-node-server/test/fixtures/11-include-files/now.json
+++ b/packages/now-node-server/test/fixtures/11-include-files/now.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "index.js",
+      "use": "@now/node-server",
+      "config": {
+        "includeFiles": [
+          "templates/**"
+        ]
+      }
+    }
+  ],
+  "probes": [
+    {
+      "path": "/",
+      "mustContain": "Hello Now!"
+    }
+  ]
+}

--- a/packages/now-node-server/test/fixtures/11-include-files/package.json
+++ b/packages/now-node-server/test/fixtures/11-include-files/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "express": "^4.16.4"
+  }
+}

--- a/packages/now-node-server/test/fixtures/11-include-files/templates/index.html
+++ b/packages/now-node-server/test/fixtures/11-include-files/templates/index.html
@@ -1,0 +1,1 @@
+Hello Now!


### PR DESCRIPTION
The main idea behind this is we want user be able to specific files in that should be include in the `handler` which later can be use in runtime.

For the most case, `ncc` be able to detect relevant files included in the `handler`. But the case that `ncc` not able to resolve, this option come in handy.

PR #277 does the same thing, but for `@now/node`.