### PR TITLE
[now-md] Remove `console.log()` call of Markdown file result

### DIFF
--- a/packages/now-md/index.js
+++ b/packages/now-md/index.js
@@ -34,8 +34,6 @@ exports.build = async ({ files, entrypoint, config }) => {
     stream: stream.pipe(unifiedStream(processor)),
   });
 
-  console.log(result.data.toString());
-
   const replacedEntrypoint = entrypoint.replace(/\.[^.]+$/, '.html');
 
   return { [replacedEntrypoint]: result };


### PR DESCRIPTION
Not sure why this was here, but it's pretty noisey in the logs,
especially when executing this builder via `now dev`.