### PR TITLE
[now-go] better way to init go.mod

### DIFF
--- a/packages/now-go/index.js
+++ b/packages/now-go/index.js
@@ -68,9 +68,11 @@ async function build({ files, entrypoint }) {
     );
     if (!isGoModExist) {
       try {
-        go('mod', 'init', packageName);
+        const defaultGoModContent = `module ${packageName}`;
+
+        await writeFile(join(entrypointDirname, 'go.mod'), defaultGoModContent);
       } catch (err) {
-        console.log(`failed to \`go mod init ${packageName}\``);
+        console.log(`failed to create default go.mod for ${packageName}`);
         throw err;
       }
     }


### PR DESCRIPTION
With our current example: https://zeit.co/docs/v2/deployments/official-builders/go-now-go/#how-to-use-it

`@now/go` build will fail if user don't provide `go.mod`. This happen because command `go mod init packageName` not working as intended.

Ultimately, we just want something like this in default `go.mod` file
```
module defaultName
```
So I use `writeFile()` function to create that file instead.