### PR TITLE
[now-go] fix subdirectory build fail for `@now/go`

### DIFF
--- a/packages/now-go/index.js
+++ b/packages/now-go/index.js
@@ -88,7 +88,7 @@ async function build({ files, entrypoint }) {
 
     if (isGoModExist) {
       const goModContents = await readFile(
-        `${entrypointDirname}${sep}go.mod`,
+        join(entrypointDirname, 'go.mod'),
         'utf8',
       );
       goPackageName = `${

--- a/packages/now-go/index.js
+++ b/packages/now-go/index.js
@@ -1,4 +1,4 @@
-const { join, dirname } = require('path');
+const { join, sep, dirname } = require('path');
 const {
   readFile, writeFile, pathExists, move,
 } = require('fs-extra');
@@ -55,7 +55,7 @@ async function build({ files, entrypoint }) {
 
   // check if package name other than main
   const packageName = parseFunctionName.split(',')[1];
-  const isGoModExist = await pathExists(`${entrypointDirname}/go.mod`);
+  const isGoModExist = await pathExists(`${entrypointDirname}${sep}go.mod`);
   if (packageName !== 'main') {
     const go = await createGo(
       goPath,
@@ -88,7 +88,7 @@ async function build({ files, entrypoint }) {
 
     if (isGoModExist) {
       const goModContents = await readFile(
-        `${entrypointDirname}/go.mod`,
+        `${entrypointDirname}${sep}go.mod`,
         'utf8',
       );
       goPackageName = `${
@@ -110,7 +110,7 @@ async function build({ files, entrypoint }) {
     try {
       // default path
       let finalDestination = join(entrypointDirname, packageName, entrypoint);
-      const entrypointArr = entrypoint.split('/');
+      const entrypointArr = entrypoint.split(sep);
 
       // if `entrypoint` include folder, only use filename
       if (entrypointArr.length > 1) {

--- a/packages/now-go/index.js
+++ b/packages/now-go/index.js
@@ -55,7 +55,7 @@ async function build({ files, entrypoint }) {
 
   // check if package name other than main
   const packageName = parseFunctionName.split(',')[1];
-  const isGoModExist = await pathExists(`${entrypointDirname}${sep}go.mod`);
+  const isGoModExist = await pathExists(join(entrypointDirname, 'go.mod'));
   if (packageName !== 'main') {
     const go = await createGo(
       goPath,

--- a/packages/now-go/index.js
+++ b/packages/now-go/index.js
@@ -108,10 +108,20 @@ async function build({ files, entrypoint }) {
 
     // move user go file to folder
     try {
-      await move(
-        downloadedFiles[entrypoint].fsPath,
-        `${join(entrypointDirname, packageName, entrypoint)}`,
-      );
+      // default path
+      let finalDestination = join(entrypointDirname, packageName, entrypoint);
+      const entrypointArr = entrypoint.split('/');
+
+      // if `entrypoint` include folder, only use filename
+      if (entrypointArr.length > 1) {
+        finalDestination = join(
+          entrypointDirname,
+          packageName,
+          entrypointArr.pop(),
+        );
+      }
+
+      await move(downloadedFiles[entrypoint].fsPath, finalDestination);
     } catch (err) {
       console.log('failed to move entry to package folder');
       throw err;

--- a/packages/now-go/test/fixtures/01-cowsay/index.go
+++ b/packages/now-go/test/fixtures/01-cowsay/index.go
@@ -1,0 +1,13 @@
+package cowsay
+
+import (
+	"fmt"
+	"net/http"
+
+	say "github.com/dhruvbird/go-cowsay"
+)
+
+// Handler function
+func Handler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, say.Format("cow:RANDOMNESS_PLACEHOLDER"))
+}

--- a/packages/now-go/test/fixtures/01-cowsay/now.json
+++ b/packages/now-go/test/fixtures/01-cowsay/now.json
@@ -1,0 +1,11 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "index.go", "use": "@now/go" },
+    { "src": "subdirectory/index.go", "use": "@now/go" }
+  ],
+  "probes": [
+    { "path": "/", "mustContain": "cow:RANDOMNESS_PLACEHOLDER" },
+    { "path": "/subdirectory", "mustContain": "subcow:RANDOMNESS_PLACEHOLDER" }
+  ]
+}

--- a/packages/now-go/test/fixtures/01-cowsay/subdirectory/index.go
+++ b/packages/now-go/test/fixtures/01-cowsay/subdirectory/index.go
@@ -1,0 +1,13 @@
+package subcow
+
+import (
+	"fmt"
+	"net/http"
+
+	say "github.com/dhruvbird/go-cowsay"
+)
+
+// Handler function
+func Handler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, say.Format("subcow:RANDOMNESS_PLACEHOLDER"))
+}

--- a/packages/now-go/test/test.js
+++ b/packages/now-go/test/test.js
@@ -1,0 +1,33 @@
+/* global beforeAll, expect, it, jest */
+const fs = require('fs');
+const path = require('path');
+
+const {
+  packAndDeploy,
+  testDeployment,
+} = require('../../../test/lib/deployment/test-deployment.js');
+
+jest.setTimeout(4 * 60 * 1000);
+const buildUtilsUrl = '@canary';
+let builderUrl;
+
+beforeAll(async () => {
+  const builderPath = path.resolve(__dirname, '..');
+  builderUrl = await packAndDeploy(builderPath);
+  console.log('builderUrl', builderUrl);
+});
+
+const fixturesPath = path.resolve(__dirname, 'fixtures');
+
+// eslint-disable-next-line no-restricted-syntax
+for (const fixture of fs.readdirSync(fixturesPath)) {
+  // eslint-disable-next-line no-loop-func
+  it(`should build ${fixture}`, async () => {
+    await expect(
+      testDeployment(
+        { builderUrl, buildUtilsUrl },
+        path.join(fixturesPath, fixture),
+      ),
+    ).resolves.toBeDefined();
+  });
+}


### PR DESCRIPTION
**Back story**
In the process of write test case for `@now/go`, I found this bug. It was introduce with `go.mod` release.

**How build work?**
Given `entrypoint` is `index.go`:
```go
package handler

import (
        "fmt"
        "net/http"
)

func Handler(w http.ResponseWriter, r *http.Request) {
        fmt.Fprintf(w, "<h1>Hello from Go on Now!</h1>")
}
```
Before we run command `go build`, we move `entrypoint` to folder (using package name as folder name). Then our main go file will look like this:
```go
package main

import (
	"net/http"
	"function/function"

	now "github.com/zeit/now-builders/utils/go/bridge"
)

func main() {
	now.Start(http.HandlerFunc(function.Handler))
}
```
**What went wrong?**
When we move `entrypoint` to folder, we had this as destination
```
join(entrypointDirname, packageName, entrypoint)
```
This will work fine with `entrypoint` without subdirectory. but if `entrypoint` inside subdirectory, it will duplicate.
```
/tmp/e961a48/src/lambda/api/function/api/index.go
vs
/tmp/e961a48/src/lambda/api/function/index.go
```

So, I just ensure, always use filename.
