### PR TITLE
Enhance TS declarations

### DIFF
--- a/packages/now-build-utils/src/download.ts
+++ b/packages/now-build-utils/src/download.ts
@@ -1,0 +1,27 @@
+import path from 'path';
+import FileFsRef from './file-fs-ref';
+import { File, Files } from './types';
+
+export interface DownloadedFiles {
+  [filePath: string]: FileFsRef
+}
+
+async function downloadFile(file: File, fsPath: string): Promise<FileFsRef> {
+  const { mode } = file;
+  const stream = file.toStream();
+  return FileFsRef.fromStream({ mode, stream, fsPath });
+}
+
+export default async function download(files: Files, basePath: string): Promise<DownloadedFiles> {
+  const files2: DownloadedFiles = {};
+
+  await Promise.all(
+    Object.keys(files).map(async (name) => {
+      const file = files[name];
+      const fsPath = path.join(basePath, name);
+      files2[name] = await downloadFile(file, fsPath);
+    }),
+  );
+
+  return files2;
+};

--- a/packages/now-build-utils/src/file-blob.ts
+++ b/packages/now-build-utils/src/file-blob.ts
@@ -9,7 +9,7 @@ interface FileBlobOptions {
 
 interface FromStreamOptions {
   mode?: number;
-  stream: NodeJS.ReadStream;
+  stream: NodeJS.ReadableStream;
 }
 
 export default class FileBlob implements File {

--- a/packages/now-build-utils/src/fs/glob.ts
+++ b/packages/now-build-utils/src/fs/glob.ts
@@ -9,7 +9,7 @@ interface FsFiles {
   [filePath: string]: FileFsRef
 }
 
-export default function glob(pattern: string, opts: GlobOptions | string, mountpoint: string): Promise<FsFiles> {
+export default function glob(pattern: string, opts: GlobOptions | string, mountpoint?: string): Promise<FsFiles> {
   return new Promise<FsFiles>((resolve, reject) => {
     let options: GlobOptions;
     if (typeof opts === 'string') {

--- a/packages/now-build-utils/src/index.ts
+++ b/packages/now-build-utils/src/index.ts
@@ -1,7 +1,7 @@
 import FileBlob from './file-blob';
 import FileFsRef from './file-fs-ref';
 import FileRef from './file-ref';
-import { File, Files } from './types';
+import { File, Files, AnalyzeOptions, BuildOptions, PrepareCacheOptions } from './types';
 import { Lambda, createLambda } from './lambda';
 import download from './fs/download';
 import getWriteableDirectory from './fs/get-writable-directory'
@@ -23,6 +23,9 @@ export {
     glob,
     rename,
     installDependencies, runPackageJsonScript, runNpmInstall, runShellScript,
-    streamToBuffer
+    streamToBuffer,
+    AnalyzeOptions,
+    BuildOptions,
+    PrepareCacheOptions,
 };
 

--- a/packages/now-build-utils/src/types.ts
+++ b/packages/now-build-utils/src/types.ts
@@ -7,3 +7,95 @@ export interface File {
 export interface Files {
   [filePath: string]: File
 }
+
+export interface Config {
+  [key: string]: string
+}
+
+export interface AnalyzeOptions {
+  /**
+   * All source files of the project
+   */
+  files: Files;
+
+  /**
+   * Name of entrypoint file for this particular build job. Value
+   * `files[entrypoint]` is guaranteed to exist and be a valid File reference.
+   * `entrypoint` is always a discrete file and never a glob, since globs are
+   * expanded into separate builds at deployment time.
+   */
+  entrypoint: string;
+
+  /**
+   * A writable temporary directory where you are encouraged to perform your
+   * build process. This directory will be populated with the restored cache.
+   */
+  workPath: string;
+
+  /**
+   * An arbitrary object passed by the user in the build definition defined
+   * in `now.json`.
+   */
+  config: Config;
+}
+
+
+export interface BuildOptions {
+  /**
+   * All source files of the project
+   */
+  files: Files;
+
+  /**
+   * Name of entrypoint file for this particular build job. Value
+   * `files[entrypoint]` is guaranteed to exist and be a valid File reference.
+   * `entrypoint` is always a discrete file and never a glob, since globs are
+   * expanded into separate builds at deployment time.
+   */
+  entrypoint: string;
+
+  /**
+   * A writable temporary directory where you are encouraged to perform your
+   * build process. This directory will be populated with the restored cache.
+   */
+  workPath: string;
+
+  /**
+   * An arbitrary object passed by the user in the build definition defined
+   * in `now.json`.
+   */
+  config: Config;
+}
+
+export interface PrepareCacheOptions {
+  /**
+   * All source files of the project
+   */
+  files: Files;
+
+  /**
+   * Name of entrypoint file for this particular build job. Value
+   * `files[entrypoint]` is guaranteed to exist and be a valid File reference.
+   * `entrypoint` is always a discrete file and never a glob, since globs are
+   * expanded into separate builds at deployment time.
+   */
+  entrypoint: string;
+
+  /**
+   * A writable temporary directory where you are encouraged to perform your
+   * build process.
+   */
+  workPath: string;
+
+  /**
+   * A writable temporary directory where you can build a cache to use for
+   * the next run.
+   */
+  cachePath: string;
+
+  /**
+   * An arbitrary object passed by the user in the build definition defined
+   * in `now.json`.
+   */
+  config: Config;
+}

--- a/packages/now-node-bridge/tsconfig.json
+++ b/packages/now-node-bridge/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "esModuleInterop": true,
+    "lib": ["esnext"],
+    "target": "esnext",
     "module": "commonjs",
     "outDir": ".",
     "strict": true,

--- a/packages/now-node/tsconfig.json
+++ b/packages/now-node/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "esModuleInterop": true,
+    "lib": ["esnext"],
+    "target": "esnext",
     "module": "commonjs",
     "outDir": "dist",
     "sourceMap": false,


### PR DESCRIPTION
This adds a few new exports to `@now/build-utils` with proper documentation 😄 

- AnalyzeOptions
- BuildOptions
- PrepareCacheOptions

I also updated TS is `now-node` and `now-node-bridge`.

### Screenshot

Here's an example of what the docs look like with TS Intellisense 📖 

![image](https://user-images.githubusercontent.com/229881/54851181-80825380-4cbf-11e9-9703-2ca75e8cdf47.png)
