### PR TITLE
[now-node] Print a more helpful message when a module is missing

### DIFF
--- a/packages/now-node/src/launcher.ts
+++ b/packages/now-node/src/launcher.ts
@@ -7,7 +7,17 @@ if (!process.env.NODE_ENV) {
   process.env.NODE_ENV = 'production';
 }
 
+try {
 // PLACEHOLDER
+} catch (err) {
+  if (err.code === 'MODULE_NOT_FOUND') {
+    console.error(err.message);
+    console.error('Did you forget to add it to "dependencies" in `package.json`?');
+    process.exit(1);
+  } else {
+    throw err;
+  }
+}
 
 const server = new Server(listener);
 const bridge = new Bridge(server);


### PR DESCRIPTION
This fixes the dreaded `Unable to import module 'launcher'` error message. If this looks good then we can add it to `@now/node-server` as well.

**Before:**

<img width="646" alt="Screen Shot 2019-03-22 at 1 59 03 PM" src="https://user-images.githubusercontent.com/71256/54852753-06e06a80-4cab-11e9-94bd-19eeed17b7ba.png">

**After:**

<img width="667" alt="Screen Shot 2019-03-22 at 1 57 39 PM" src="https://user-images.githubusercontent.com/71256/54852776-152e8680-4cab-11e9-8969-34ea4379c620.png">
