### PR TITLE
[now-node-server] Print a more helpful message when a module is missing

### DIFF
--- a/packages/now-node-server/launcher.js
+++ b/packages/now-node-server/launcher.js
@@ -14,6 +14,18 @@ if (!process.env.NODE_ENV) {
   process.env.NODE_ENV = 'production';
 }
 
-// PLACEHOLDER
+try {
+  // PLACEHOLDER
+} catch (err) {
+  if (err.code === 'MODULE_NOT_FOUND') {
+    console.error(err.message);
+    console.error(
+      'Did you forget to add it to "dependencies" in `package.json`?',
+    );
+    process.exit(1);
+  } else {
+    throw err;
+  }
+}
 
 exports.launcher = bridge.launcher;


### PR DESCRIPTION
Similar to #312, but for `@now/node-server`.