### PR TITLE
[now-node] Bump ncc to 0.17.0

### DIFF
--- a/packages/now-node-server/index.js
+++ b/packages/now-node-server/index.js
@@ -48,7 +48,7 @@ async function downloadInstallAndBundle(
         data: JSON.stringify({
           license: 'UNLICENSED',
           dependencies: {
-            '@zeit/ncc': '0.16.1',
+            '@zeit/ncc': '0.17.0',
           },
         }),
       }),

--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -47,7 +47,7 @@ async function downloadInstallAndBundle({
         data: JSON.stringify({
           license: 'UNLICENSED',
           dependencies: {
-            '@zeit/ncc': '0.16.1',
+            '@zeit/ncc': '0.17.0',
           }
         })
       })


### PR DESCRIPTION
This bumps ncc to `0.17.0` for node builders

See the release notes here: https://github.com/zeit/ncc/releases/tag/0.17.0