### PR TITLE
[now-bash] Improvements for error handling

### DIFF
--- a/packages/now-bash/bootstrap
+++ b/packages/now-bash/bootstrap
@@ -7,7 +7,9 @@ export IMPORT_CACHE="$LAMBDA_TASK_ROOT/.import-cache"
 export PATH="$IMPORT_CACHE/bin:$PATH"
 
 # Load `import` and runtime
+# shellcheck disable=SC1090
 . "$(which import)"
+# shellcheck disable=SC1090
 . "$IMPORT_CACHE/runtime.sh"
 
 # Load user code and process events in a loop forever

--- a/packages/now-bash/runtime.sh
+++ b/packages/now-bash/runtime.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 import "static-binaries@1.0.0"
 static_binaries jq
 

--- a/packages/now-bash/runtime.sh
+++ b/packages/now-bash/runtime.sh
@@ -17,10 +17,11 @@ _lambda_runtime_init() {
 	# shellcheck disable=SC1090
 	. "$SCRIPT_FILENAME" || {
 		local exit_code="$?"
-		local error
-		error='{"exitCode":'"$exit_code"'}'
+		local error_message="Initialization failed for '$SCRIPT_FILENAME' (exit code $exit_code)"
+		echo "$error_message" >&2
+		local error='{"errorMessage":"'"$error_message"'"}'
 		_lambda_runtime_api "init/error" -X POST -d "$error"
-		exit "$EXIT_CODE"
+		exit "$exit_code"
 	}
 
 	# Process events
@@ -47,9 +48,6 @@ _lambda_runtime_next() {
 	local body
 	body="$(mktemp)"
 
-	local exit_code=0
-	REQUEST="$event"
-
 	# Stdin of the `handler` function is the HTTP request body.
 	# Need to use a fifo here instead of bash <() because Lambda
 	# errors with "/dev/fd/63 not found" for some reason :/
@@ -58,6 +56,7 @@ _lambda_runtime_next() {
 	mkfifo "$stdin"
 	_lambda_runtime_body < "$event" > "$stdin" &
 
+	local exit_code=0
 	handler "$event" < "$stdin" > "$body" || exit_code="$?"
 
 	rm -f "$event" "$stdin"
@@ -71,8 +70,9 @@ _lambda_runtime_next() {
 			| _lambda_runtime_api "invocation/$request_id/response" -X POST -d @- > /dev/null
 		rm -f "$body" "$_HEADERS"
 	else
-		echo "\`handler\` function return code: $exit_code"
-		_lambda_runtime_api "invocation/$request_id/error" -X POST -d @- > /dev/null <<< '{"exitCode":'"$exit_code"'}'
+		local error_message="Invocation failed for 'handler' function in '$SCRIPT_FILENAME' (exit code $exit_code)"
+		echo "$error_message" >&2
+		_lambda_runtime_api "invocation/$request_id/error" -X POST -d '{"errorMessage":"'"$error_message"'"}' > /dev/null
 	fi
 }
 
@@ -102,7 +102,10 @@ http_response_header() {
 	local value="$2"
 	local tmp
 	tmp="$(mktemp)"
-	jq --arg name "$name" --arg value "$value" '.[$name] = $value' < "$_HEADERS" > "$tmp"
+	jq \
+		--arg name "$name" \
+		--arg value "$value" \
+		'.[$name] = $value' < "$_HEADERS" > "$tmp"
 	mv -f "$tmp" "$_HEADERS"
 }
 

--- a/packages/now-bash/runtime.sh
+++ b/packages/now-bash/runtime.sh
@@ -13,6 +13,7 @@ _lambda_runtime_api() {
 
 _lambda_runtime_init() {
 	# Initialize user code
+	# shellcheck disable=SC1090
 	. "$SCRIPT_FILENAME" || {
 		local exit_code="$?"
 		local error


### PR DESCRIPTION
* Send error responses with `errorMessage` property, so that `now dev` can display the error message properly.
 * Add shebang to `runtime.sh`, so that vim applies proper syntax highlighting when bash-specific features like `<<<` are used.
 * Add shellcheck ignore comments to dynamic imports (shellcheck is now passing).