### PR TITLE
[now-build-utils] Pin "end-of-stream" dependency to v1.4.1

### DIFF
--- a/packages/now-build-utils/package.json
+++ b/packages/now-build-utils/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "async-retry": "1.2.3",
     "async-sema": "2.1.4",
-    "end-of-stream": "^1.4.1",
+    "end-of-stream": "1.4.1",
     "fs-extra": "7.0.0",
     "glob": "7.1.3",
     "into-stream": "5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2653,7 +2653,7 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
-end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
+end-of-stream@1.4.1, end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
   integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==


### PR DESCRIPTION
All of the other deps are pinned versions, so this is for consistency.