### PR TITLE
[now-built-utils] Use constants for the `type` field

### DIFF
--- a/packages/now-build-utils/src/file-blob.ts
+++ b/packages/now-build-utils/src/file-blob.ts
@@ -13,7 +13,7 @@ interface FromStreamOptions {
 }
 
 export default class FileBlob implements File {
-  public type: string;
+  public type: 'FileBlob';
   public mode: number;
   public data: string | Buffer;
 

--- a/packages/now-build-utils/src/file-fs-ref.ts
+++ b/packages/now-build-utils/src/file-fs-ref.ts
@@ -23,7 +23,7 @@ interface FromStreamOptions {
 }
 
 class FileFsRef implements File {
-  public type: string;
+  public type: 'FileFsRef';
   public mode: number;
   public fsPath: string;
 

--- a/packages/now-build-utils/src/file-ref.ts
+++ b/packages/now-build-utils/src/file-ref.ts
@@ -22,7 +22,7 @@ class BailableError extends Error {
 }
 
 export default class FileRef implements File {
-  public type: string;
+  public type: 'FileRef';
   public mode: number;
   public digest: string;
 

--- a/packages/now-build-utils/src/lambda.ts
+++ b/packages/now-build-utils/src/lambda.ts
@@ -23,7 +23,7 @@ interface CreateLambdaOptions {
 }
 
 export class Lambda {
-  public type: string;
+  public type: 'Lambda';
   public zipBuffer: Buffer;
   public handler: string;
   public runtime: string;


### PR DESCRIPTION
This is important for TypeScript usage with the combined `File` type
declaration. It helps the compiler understand the proper type in
consuming code via `if` checks to avoid casting.