### PR TITLE
Add concurrent page building support to `@now/next`

### DIFF
--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -240,11 +240,13 @@ exports.build = async ({ files, workPath, entrypoint }) => {
     }
 
     pkg.scripts = {
+      ...(pkg.scripts || {}),
       'now-build': 'next build '.concat(
         experimentalPages.map(page => `--experimental-page=${page}`).join(' '),
       ),
-      ...(pkg.scripts || {}),
     };
+
+    console.log('pages build package.json result: ', pkg);
     await writePackageJson(entryPath, pkg);
   }
 

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -158,6 +158,9 @@ async function extrapolateEntrypoint(workPath, entrypoint) {
  * @returns {Promise<Files>}
  */
 exports.build = async ({ files, workPath, entrypoint }) => {
+  console.log('downloading user files...');
+  await download(files, workPath);
+
   let experimentalPages = [];
 
   try {
@@ -175,9 +178,7 @@ exports.build = async ({ files, workPath, entrypoint }) => {
 
   validateEntrypoint(entrypoint);
 
-  console.log('downloading user files...');
   const entryDirectory = path.dirname(entrypoint);
-  await download(files, workPath);
   const entryPath = path.join(workPath, entryDirectory);
 
   if (await pathExists(path.join(entryPath, '.next'))) {

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -148,7 +148,7 @@ async function extrapolateEntrypoint(workPath, entrypoint) {
   }
 
   return {
-    entry: rootPackageFile,
+    entry: path.relative(workPath, rootPackageFile),
     pages: [path.relative(rootPackagePages, workEntrypoint)],
   };
 }

--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@now/node-bridge": "^1.0.0",
     "execa": "^1.0.0",
+    "find-up": "^3.0.0",
     "fs-extra": "^7.0.0",
     "semver": "^5.6.0"
   }


### PR DESCRIPTION
This allows the user to build their app like so:
```json
{
  "version": 2,
  "name": "separate-bundles-test",
  "builds": [
    { "src": "pages/**/*.js", "use": "timer-now-next@0.1.3-canary.5" }
  ],
  "public": true
}
```

This pull request is _experimental_ and should not be merged until the Next.js side of things are declared **stable**.

---

Example application: https://separate-bundles-test-jpbw3xfyz.now.sh/nav