### PR TITLE
Make @now/next compatible with `now dev`

### DIFF
--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -124,7 +124,7 @@ exports.config = {
  * @returns {Promise<Files>}
  */
 exports.build = async ({
-  files, workPath, entrypoint, meta,
+  files, workPath, entrypoint, meta = {},
 }) => {
   validateEntrypoint(entrypoint);
 
@@ -190,11 +190,11 @@ exports.build = async ({
     await writeNpmRc(entryPath, process.env.NPM_AUTH_TOKEN);
   }
 
-  if (meta && meta.isDev) {
+  if (meta.isDev) {
     // eslint-disable-next-line no-underscore-dangle
     process.env.__NEXT_BUILDER_EXPERIMENTAL_DEBUG = 'true';
   }
-  if (meta && meta.requestPath) {
+  if (meta.requestPath) {
     const { pathname } = url.parse(meta.requestPath);
     // eslint-disable-next-line no-underscore-dangle
     process.env.__NEXT_BUILDER_EXPERIMENTAL_PAGE = pathname;

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -9,7 +9,6 @@ const {
   runPackageJsonScript,
 } = require('@now/build-utils/fs/run-user-scripts'); // eslint-disable-line import/no-extraneous-dependencies
 const glob = require('@now/build-utils/fs/glob'); // eslint-disable-line import/no-extraneous-dependencies
-const getWritableDirectory = require('@now/build-utils/fs/get-writable-directory'); // eslint-disable-line import/no-extraneous-dependencies
 const {
   readFile,
   writeFile,
@@ -424,22 +423,18 @@ exports.prepareCache = async ({ cachePath, workPath, entrypoint }) => {
 };
 
 exports.subscribe = async ({ entrypoint, files }) => {
-  const srcDir = await getWritableDirectory();
-  await download(files, srcDir);
-
   const entryDirectory = path.dirname(entrypoint);
-  const pagesPath = path.join(srcDir, entryDirectory, 'pages');
-
-  const pages = await glob('**', pagesPath);
-
-  await removePath(srcDir);
+  const pageFiles = includeOnlyEntryDirectory(
+    files,
+    entryDirectory === '.' ? 'pages' : path.join(entryDirectory, 'pages'),
+  );
 
   return [
-    '_next/**',
+    entryDirectory === '.' ? '_next/**' : path.join(entryDirectory, '_next/**'),
     // List all pages without their extensions
-    ...Object.keys(pages).map(page => page
+    ...Object.keys(pageFiles).map(page => page
       .split('.')
       .slice(0, -1)
       .join('.')),
-  ].map(v => path.join(entryDirectory, v));
+  ];
 };

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -431,6 +431,9 @@ exports.subscribe = async ({ entrypoint, files }) => {
   const pagesPath = path.join(srcDir, entryDirectory, 'pages');
 
   const pages = await glob('**', pagesPath);
+
+  await removePath(srcDir);
+
   return [
     '_next/**',
     // List all pages without their extensions

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -208,8 +208,11 @@ exports.build = async ({
   }
   if (meta.requestPath) {
     const { pathname } = url.parse(meta.requestPath);
+    const assetPath = pathname.match(/_next\/static\/[^/]+\/pages(\/.+)$/);
     // eslint-disable-next-line no-underscore-dangle
-    process.env.__NEXT_BUILDER_EXPERIMENTAL_PAGE = pathname;
+    process.env.__NEXT_BUILDER_EXPERIMENTAL_PAGE = assetPath
+      ? assetPath[1]
+      : pathname;
   }
 
   console.log('installing dependencies...');

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -9,6 +9,7 @@ const {
   runPackageJsonScript,
 } = require('@now/build-utils/fs/run-user-scripts'); // eslint-disable-line import/no-extraneous-dependencies
 const glob = require('@now/build-utils/fs/glob'); // eslint-disable-line import/no-extraneous-dependencies
+const getWritableDirectory = require('@now/build-utils/fs/get-writable-directory'); // eslint-disable-line import/no-extraneous-dependencies
 const {
   readFile,
   writeFile,
@@ -420,4 +421,22 @@ exports.prepareCache = async ({ cachePath, workPath, entrypoint }) => {
     ...(await glob(path.join(cacheEntrypoint, 'package-lock.json'), cachePath)),
     ...(await glob(path.join(cacheEntrypoint, 'yarn.lock'), cachePath)),
   };
+};
+
+exports.subscribe = async ({ entrypoint, files }) => {
+  const srcDir = await getWritableDirectory();
+  await download(files, srcDir);
+
+  const entryDirectory = path.dirname(entrypoint);
+  const pagesPath = path.join(srcDir, entryDirectory, 'pages');
+
+  const pages = await glob('**', pagesPath);
+  return [
+    '_next/**',
+    // List all pages without their extensions
+    ...Object.keys(pages).map(page => page
+      .split('.')
+      .slice(0, -1)
+      .join('.')),
+  ];
 };

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -32,10 +32,17 @@ const {
 /** @typedef { import('@now/build-utils/fs/download').DownloadedFiles } DownloadedFiles */
 
 /**
+ * @typedef {Object} BuildParamsMeta
+ * @property {boolean} [isDev] - Files object
+ * @property {?string} [requestPath] - Entrypoint specified for the builder
+ */
+
+/**
  * @typedef {Object} BuildParamsType
  * @property {Files} files - Files object
  * @property {string} entrypoint - Entrypoint specified for the builder
  * @property {string} workPath - Working directory for this build
+ * @property {BuildParamsMeta} [meta] - Various meta settings
  */
 
 /**
@@ -115,7 +122,9 @@ exports.config = {
  * @param {BuildParamsType} buildParams
  * @returns {Promise<Files>}
  */
-exports.build = async ({ files, workPath, entrypoint }) => {
+exports.build = async ({
+  files, workPath, entrypoint, meta,
+}) => {
   validateEntrypoint(entrypoint);
 
   console.log('downloading user files...');
@@ -179,6 +188,13 @@ exports.build = async ({ files, workPath, entrypoint }) => {
     console.log('found NPM_AUTH_TOKEN in environment, creating .npmrc');
     await writeNpmRc(entryPath, process.env.NPM_AUTH_TOKEN);
   }
+
+  if (meta && meta.isDev) {
+    // eslint-disable-next-line no-underscore-dangle
+    process.env.__NEXT_BUILDER_EXPERIMENTAL_DEBUG = 'true';
+  }
+
+  // TODO: set __NEXT_BUILDER_EXPERIMENTAL_PAGE
 
   console.log('installing dependencies...');
   await runNpmInstall(entryPath, ['--prefer-offline']);

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -441,5 +441,5 @@ exports.subscribe = async ({ entrypoint, files }) => {
       .split('.')
       .slice(0, -1)
       .join('.')),
-  ];
+  ].map(v => path.join(entryDirectory, v));
 };

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -190,6 +190,18 @@ exports.build = async ({
     await writeNpmRc(entryPath, process.env.NPM_AUTH_TOKEN);
   }
 
+  if (
+    (meta.isDev || meta.requestPath)
+    && !(
+      semver.satisfies(nextVersion, '>=8.0.5-canary.2')
+      || nextVersion === 'canary'
+    )
+  ) {
+    throw new Error(
+      '`now dev` can only be used with Next.js >=8.0.5-canary.2!',
+    );
+  }
+
   if (meta.isDev) {
     // eslint-disable-next-line no-underscore-dangle
     process.env.__NEXT_BUILDER_EXPERIMENTAL_DEBUG = 'true';

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -208,7 +208,9 @@ exports.build = async ({
   }
   if (meta.requestPath) {
     const { pathname } = url.parse(meta.requestPath);
-    const assetPath = pathname.match(/_next\/static\/[^/]+\/pages(\/.+)$/);
+    const assetPath = pathname.match(
+      /^\/_next\/static\/[^/]+\/pages\/(.+)\.js$$/,
+    );
     // eslint-disable-next-line no-underscore-dangle
     process.env.__NEXT_BUILDER_EXPERIMENTAL_PAGE = assetPath
       ? assetPath[1]

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -3,6 +3,7 @@ const download = require('@now/build-utils/fs/download'); // eslint-disable-line
 const FileFsRef = require('@now/build-utils/file-fs-ref'); // eslint-disable-line import/no-extraneous-dependencies
 const FileBlob = require('@now/build-utils/file-blob'); // eslint-disable-line import/no-extraneous-dependencies
 const path = require('path');
+const url = require('url');
 const {
   runNpmInstall,
   runPackageJsonScript,
@@ -193,8 +194,11 @@ exports.build = async ({
     // eslint-disable-next-line no-underscore-dangle
     process.env.__NEXT_BUILDER_EXPERIMENTAL_DEBUG = 'true';
   }
-
-  // TODO: set __NEXT_BUILDER_EXPERIMENTAL_PAGE
+  if (meta && meta.requestPath) {
+    const { pathname } = url.parse(meta.requestPath);
+    // eslint-disable-next-line no-underscore-dangle
+    process.env.__NEXT_BUILDER_EXPERIMENTAL_PAGE = pathname;
+  }
 
   console.log('installing dependencies...');
   await runNpmInstall(entryPath, ['--prefer-offline']);

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -443,7 +443,7 @@ exports.subscribe = async ({ entrypoint, files }) => {
   const entryDirectory = path.dirname(entrypoint);
   const pageFiles = includeOnlyEntryDirectory(
     files,
-    entryDirectory === '.' ? 'pages' : path.join(entryDirectory, 'pages'),
+    path.join(entryDirectory, 'pages'),
   );
 
   return [

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -209,7 +209,7 @@ exports.build = async ({
   if (meta.requestPath) {
     const { pathname } = url.parse(meta.requestPath);
     const assetPath = pathname.match(
-      /^\/_next\/static\/[^/]+\/pages\/(.+)\.js$$/,
+      /^\/_next\/static\/[^/]+\/pages\/(.+)\.js$/,
     );
     // eslint-disable-next-line no-underscore-dangle
     process.env.__NEXT_BUILDER_EXPERIMENTAL_PAGE = assetPath

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -447,7 +447,7 @@ exports.subscribe = async ({ entrypoint, files }) => {
   );
 
   return [
-    entryDirectory === '.' ? '_next/**' : path.join(entryDirectory, '_next/**'),
+    path.join(entryDirectory, '_next/**'),
     // List all pages without their extensions
     ...Object.keys(pageFiles).map(page => page
       .split('.')


### PR DESCRIPTION
This pull request makes `@now/next` compatible with `now dev` (emitting debug production builds and building individual pages).

~We should finish implementing `subscription()` before merging this. Also, these changes require Next.js `>=8.0.5-canary.2` so we should probably handle that.~

---

~We still need to get rid of build ID for this to work correctly. We'll require a newer Next.js canary for this.~