### PR TITLE
[now-build-utils] Fix shim for lambda export

### DIFF
--- a/packages/now-build-utils/lambda.js
+++ b/packages/now-build-utils/lambda.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/index');
+module.exports = require('./dist/index').Lambda;


### PR DESCRIPTION
This was missed when shimming the build-utils