### PR TITLE
[now-next] Strip Carat from version

### DIFF
--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -2,6 +2,7 @@ const { createLambda } = require('@now/build-utils/lambda'); // eslint-disable-l
 const download = require('@now/build-utils/fs/download'); // eslint-disable-line import/no-extraneous-dependencies
 const FileFsRef = require('@now/build-utils/file-fs-ref'); // eslint-disable-line import/no-extraneous-dependencies
 const FileBlob = require('@now/build-utils/file-blob'); // eslint-disable-line import/no-extraneous-dependencies
+const resolveFrom = require('resolve-from');
 const path = require('path');
 const url = require('url');
 const {
@@ -86,7 +87,7 @@ async function writeNpmRc(workPath, token) {
 }
 
 function getNextVersion(userPath) {
-  const nextPackage = require(`${userPath}/node_modules/next/package.json`);
+  const nextPackage = resolveFrom(userPath, 'next/package.json');
 
   return nextPackage.version;
 }

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -85,14 +85,10 @@ async function writeNpmRc(workPath, token) {
   );
 }
 
-function getNextVersion(packageJson) {
-  let nextVersion;
-  if (packageJson.dependencies && packageJson.dependencies.next) {
-    nextVersion = packageJson.dependencies.next;
-  } else if (packageJson.devDependencies && packageJson.devDependencies.next) {
-    nextVersion = packageJson.devDependencies.next;
-  }
-  return nextVersion;
+function getNextVersion() {
+  const nextPackage = require('next/package.json');
+
+  return nextPackage.version;
 }
 
 function isLegacyNext(nextVersion) {
@@ -148,7 +144,7 @@ exports.build = async ({
 
   const pkg = await readPackageJson(entryPath);
 
-  const nextVersion = getNextVersion(pkg);
+  const nextVersion = getNextVersion();
   if (!nextVersion) {
     throw new Error(
       'No Next.js version could be detected in "package.json". Make sure `"next"` is installed in "dependencies" or "devDependencies"',
@@ -197,10 +193,8 @@ exports.build = async ({
     await writeNpmRc(entryPath, process.env.NPM_AUTH_TOKEN);
   }
 
-  const isUpdated = (version) => {
-    let v = version;
+  const isUpdated = (v) => {
     if (v === 'canary') return true;
-    if (v.charAt(0) === '^' || v.charAt(0) === '~') v = v.substr(1);
 
     try {
       return semver.satisfies(v, '>=8.0.5-canary.8', {

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -85,8 +85,8 @@ async function writeNpmRc(workPath, token) {
   );
 }
 
-function getNextVersion() {
-  const nextPackage = require('next/package.json');
+function getNextVersion(userPath) {
+  const nextPackage = require(`${userPath}/node_modules/next/package.json`);
 
   return nextPackage.version;
 }
@@ -144,7 +144,7 @@ exports.build = async ({
 
   const pkg = await readPackageJson(entryPath);
 
-  const nextVersion = getNextVersion();
+  const nextVersion = getNextVersion(entryPath);
   if (!nextVersion) {
     throw new Error(
       'No Next.js version could be detected in "package.json". Make sure `"next"` is installed in "dependencies" or "devDependencies"',

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -149,7 +149,7 @@ exports.build = async ({
 
   const pkg = await readPackageJson(entryPath);
 
-  let nextVersion = getNextVersion(entryPath);
+  let nextVersion = getNextVersion(pkg);
   if (!nextVersion) {
     throw new Error(
       'No Next.js version could be detected in "package.json". Make sure `"next"` is installed in "dependencies" or "devDependencies"',

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -197,8 +197,10 @@ exports.build = async ({
     await writeNpmRc(entryPath, process.env.NPM_AUTH_TOKEN);
   }
 
-  const isUpdated = (v) => {
+  const isUpdated = (version) => {
+    let v = version;
     if (v === 'canary') return true;
+    if (v.charAt(0) === '^' || v.charAt(0) === '~') v = v.substr(1);
 
     try {
       return semver.satisfies(v, '>=8.0.5-canary.8', {

--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -14,6 +14,7 @@
     "@now/node-bridge": "^1.0.0",
     "execa": "^1.0.0",
     "fs-extra": "^7.0.0",
+    "resolve-from": "^4.0.0",
     "semver": "^5.6.0"
   }
 }

--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@now/next",
-  "version": "0.1.3-canary.6",
+  "version": "0.1.3-canary.7",
   "license": "MIT",
   "scripts": {
     "build": "tsc"

--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@now/next",
-  "version": "0.1.3-canary.7",
+  "version": "0.1.3-canary.6",
   "license": "MIT",
   "scripts": {
     "build": "tsc"

--- a/yarn.lock
+++ b/yarn.lock
@@ -728,11 +728,6 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@now/node-bridge@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@now/node-bridge/-/node-bridge-1.0.0.tgz#3e7c1cd5760dc681febb4689201bbea6fdd35230"
-  integrity sha512-tHcr0GlgNlE8ucjuw4w7mseJ68R4VkxuHbFQpSUJ5cZqTJbKggtsdv9UL3u5uBJBXgqDmidlEepF3wOm7A99IQ==
-
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"


### PR DESCRIPTION
`^8.0.5-canary.8` didn't work while `8.0.5-canary.8` and `canary` did.