### PR TITLE
Update `prepareCache()` functions to use existing `workPath`

### DIFF
--- a/packages/now-mdx-deck/index.js
+++ b/packages/now-mdx-deck/index.js
@@ -43,17 +43,8 @@ exports.build = async ({ files, entrypoint, workPath }) => {
   return glob('**', outDir, mountpoint);
 };
 
-exports.prepareCache = async ({ cachePath }) => {
-  console.log('writing package.json...');
-  const packageJson = { dependencies: { 'mdx-deck': '1.7.15' } };
-  const packageJsonPath = path.join(cachePath, 'package.json');
-  await writeFile(packageJsonPath, JSON.stringify(packageJson));
-  console.log('running npm install...');
-  await runNpmInstall(path.dirname(packageJsonPath), ['--prod']);
-
-  return {
-    ...(await glob('node_modules/**', cachePath)),
-    ...(await glob('package-lock.json', cachePath)),
-    ...(await glob('yarn.lock', cachePath)),
-  };
-};
+exports.prepareCache = async ({ workPath }) => ({
+  ...(await glob('node_modules/**', workPath)),
+  ...(await glob('package-lock.json', workPath)),
+  ...(await glob('yarn.lock', workPath)),
+});

--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -15,8 +15,6 @@ const {
   writeFile,
   unlink: unlinkFile,
   remove: removePath,
-  mkdirp,
-  rename: renamePath,
   pathExists,
 } = require('fs-extra');
 const semver = require('semver');
@@ -415,12 +413,10 @@ exports.build = async ({
   return { ...lambdas, ...staticFiles, ...staticDirectoryFiles };
 };
 
-exports.prepareCache = async ({ cachePath, workPath, entrypoint }) => {
+exports.prepareCache = async ({ workPath, entrypoint }) => {
   console.log('preparing cache ...');
-
   const entryDirectory = path.dirname(entrypoint);
   const entryPath = path.join(workPath, entryDirectory);
-  const cacheEntryPath = path.join(cachePath, entryDirectory);
 
   const pkg = await readPackageJson(entryPath);
   const nextVersion = getNextVersion(pkg);
@@ -431,26 +427,18 @@ exports.prepareCache = async ({ cachePath, workPath, entrypoint }) => {
     return {};
   }
 
-  console.log('clearing old cache ...');
-  await removePath(cacheEntryPath);
-  await mkdirp(cacheEntryPath);
-
-  console.log('copying build files for cache ...');
-  await renamePath(entryPath, cacheEntryPath);
-
   console.log('producing cache file manifest ...');
-
-  const cacheEntrypoint = path.relative(cachePath, cacheEntryPath);
+  const cacheEntrypoint = path.relative(workPath, entryPath);
   return {
     ...(await glob(
       path.join(
         cacheEntrypoint,
         'node_modules/{**,!.*,.yarn*,.cache/next-minifier/**}',
       ),
-      cachePath,
+      workPath,
     )),
-    ...(await glob(path.join(cacheEntrypoint, 'package-lock.json'), cachePath)),
-    ...(await glob(path.join(cacheEntrypoint, 'yarn.lock'), cachePath)),
+    ...(await glob(path.join(cacheEntrypoint, 'package-lock.json'), workPath)),
+    ...(await glob(path.join(cacheEntrypoint, 'yarn.lock'), workPath)),
   };
 };
 

--- a/packages/now-node-server/index.js
+++ b/packages/now-node-server/index.js
@@ -169,18 +169,11 @@ exports.build = async ({
   return { [entrypoint]: lambda };
 };
 
-exports.prepareCache = async ({
-  files, entrypoint, workPath, cachePath,
-}) => {
-  await fs.remove(workPath);
-  await downloadInstallAndBundle({ files, entrypoint, workPath: cachePath });
-
-  return {
-    ...(await glob('user/node_modules/**', cachePath)),
-    ...(await glob('user/package-lock.json', cachePath)),
-    ...(await glob('user/yarn.lock', cachePath)),
-    ...(await glob('ncc/node_modules/**', cachePath)),
-    ...(await glob('ncc/package-lock.json', cachePath)),
-    ...(await glob('ncc/yarn.lock', cachePath)),
-  };
-};
+exports.prepareCache = async ({ workPath }) => ({
+  ...(await glob('user/node_modules/**', workPath)),
+  ...(await glob('user/package-lock.json', workPath)),
+  ...(await glob('user/yarn.lock', workPath)),
+  ...(await glob('ncc/node_modules/**', workPath)),
+  ...(await glob('ncc/package-lock.json', workPath)),
+  ...(await glob('ncc/yarn.lock', workPath)),
+});

--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -142,16 +142,13 @@ export async function build({ files, entrypoint, workPath, config }: BuildOption
   return { [entrypoint]: lambda };
 }
 
-export async function prepareCache({ files, entrypoint, workPath, cachePath }: PrepareCacheOptions) {
-  await remove(workPath);
-  await downloadInstallAndBundle({ files, entrypoint, workPath: cachePath });
-
+export async function prepareCache({ workPath }: PrepareCacheOptions) {
   return {
-    ...(await glob('user/node_modules/**', cachePath)),
-    ...(await glob('user/package-lock.json', cachePath)),
-    ...(await glob('user/yarn.lock', cachePath)),
-    ...(await glob('ncc/node_modules/**', cachePath)),
-    ...(await glob('ncc/package-lock.json', cachePath)),
-    ...(await glob('ncc/yarn.lock', cachePath))
+    ...(await glob('user/node_modules/**', workPath)),
+    ...(await glob('user/package-lock.json', workPath)),
+    ...(await glob('user/yarn.lock', workPath)),
+    ...(await glob('ncc/node_modules/**', workPath)),
+    ...(await glob('ncc/package-lock.json', workPath)),
+    ...(await glob('ncc/yarn.lock', workPath))
   };
 }


### PR DESCRIPTION
Considering that `prepareCache()` is executed directly after `build()` is run, it seems that deleting the previous `workPath` and re-installing the dependencies is just extra work, and it would be better to create a cache from the `workPath` artifacts that `build()` just created.

From the perspective of `now dev`, this is ideal because:

 1. The `workPath` shouldn't be deleted since static file assets are served from the `workPath`, so `prepareCache()` deleting this directory is problematic.
 2. Creating the cache quickly becomes an important goal, because it reflects how quickly a developer can iterate on a file, and we don't want them waiting for `yarn` to finish installing dependencies all the time in order to see the change in their project.