### PR TITLE
Link next to next-server when bootstrapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "lerna": "lerna",
-    "bootstrap": "lerna bootstrap",
+    "bootstrap": "lerna bootstrap && lerna link",
     "publish-stable": "lerna version",
     "publish-canary": "lerna version prerelease --preid canary",
     "build": "./.circleci/build.sh",


### PR DESCRIPTION
This makes sure that next-server is linked to next for development (i.e. that next is not using next-server from its node_modules instead, but rather one that is being developed).