### PR TITLE
now/node: move ncc to npm dependencies

### DIFF
--- a/packages/now-node-server/index.js
+++ b/packages/now-node-server/index.js
@@ -5,7 +5,6 @@ const FileFsRef = require('@now/build-utils/file-fs-ref.js'); // eslint-disable-
 const fs = require('fs-extra');
 const glob = require('@now/build-utils/fs/glob.js'); // eslint-disable-line import/no-extraneous-dependencies
 const path = require('path');
-const rename = require('@now/build-utils/fs/rename.js'); // eslint-disable-line import/no-extraneous-dependencies
 const {
   runNpmInstall,
   runPackageJsonScript,
@@ -31,40 +30,19 @@ async function downloadInstallAndBundle(
   { files, entrypoint, workPath },
   { npmArguments = [] } = {},
 ) {
-  const userPath = path.join(workPath, 'user');
-  const nccPath = path.join(workPath, 'ncc');
-
   console.log('downloading user files...');
-  const downloadedFiles = await download(files, userPath);
+  const downloadedFiles = await download(files, workPath);
 
   console.log("installing dependencies for user's code...");
-  const entrypointFsDirname = path.join(userPath, path.dirname(entrypoint));
+  const entrypointFsDirname = path.join(workPath, path.dirname(entrypoint));
   await runNpmInstall(entrypointFsDirname, npmArguments);
-
-  console.log('writing ncc package.json...');
-  await download(
-    {
-      'package.json': new FileBlob({
-        data: JSON.stringify({
-          license: 'UNLICENSED',
-          dependencies: {
-            '@zeit/ncc': '0.17.3',
-          },
-        }),
-      }),
-    },
-    nccPath,
-  );
-
-  console.log('installing dependencies for ncc...');
-  await runNpmInstall(nccPath, npmArguments);
-  return [downloadedFiles, userPath, nccPath, entrypointFsDirname];
+  return [downloadedFiles, entrypointFsDirname];
 }
 
-async function compile(workNccPath, downloadedFiles, entrypoint, config) {
+async function compile(workPath, downloadedFiles, entrypoint, config) {
   const input = downloadedFiles[entrypoint].fsPath;
   const inputDir = path.dirname(input);
-  const ncc = require(path.join(workNccPath, 'node_modules/@zeit/ncc'));
+  const ncc = require('@zeit/ncc');
   const { code, assets } = await ncc(input, { sourceMap: true });
 
   if (config && config.includeFiles) {
@@ -91,13 +69,13 @@ async function compile(workNccPath, downloadedFiles, entrypoint, config) {
   const preparedFiles = {};
   const blob = new FileBlob({ data: code });
   // move all user code to 'user' subdirectory
-  preparedFiles[path.join('user', entrypoint)] = blob;
+  preparedFiles[entrypoint] = blob;
   // eslint-disable-next-line no-restricted-syntax
   for (const assetName of Object.keys(assets)) {
     const { source: data, permissions: mode } = assets[assetName];
     const blob2 = new FileBlob({ data, mode });
     preparedFiles[
-      path.join('user', path.dirname(entrypoint), assetName)
+      path.join(path.dirname(entrypoint), assetName)
     ] = blob2;
   }
 
@@ -117,8 +95,6 @@ exports.build = async ({
 }) => {
   const [
     downloadedFiles,
-    workUserPath,
-    workNccPath,
     entrypointFsDirname,
   ] = await downloadInstallAndBundle(
     { files, entrypoint, workPath },
@@ -132,13 +108,11 @@ exports.build = async ({
   let preparedFiles;
 
   if (config && config.bundle === false) {
-    // move all user code to 'user' subdirectory
-    preparedFiles = await glob('**', workUserPath);
-    preparedFiles = rename(preparedFiles, name => path.join('user', name));
+    preparedFiles = await glob('**', workPath);
   } else {
     console.log('compiling entrypoint with ncc...');
     preparedFiles = await compile(
-      workNccPath,
+      workPath,
       downloadedFiles,
       entrypoint,
       config,
@@ -150,8 +124,7 @@ exports.build = async ({
   launcherData = launcherData.replace(
     '// PLACEHOLDER',
     [
-      'process.chdir("./user");',
-      `require("./${path.join('user', entrypoint)}");`,
+      `require("./${entrypoint}");`,
     ].join(' '),
   );
 
@@ -170,10 +143,7 @@ exports.build = async ({
 };
 
 exports.prepareCache = async ({ workPath }) => ({
-  ...(await glob('user/node_modules/**', workPath)),
-  ...(await glob('user/package-lock.json', workPath)),
-  ...(await glob('user/yarn.lock', workPath)),
-  ...(await glob('ncc/node_modules/**', workPath)),
-  ...(await glob('ncc/package-lock.json', workPath)),
-  ...(await glob('ncc/yarn.lock', workPath)),
+  ...(await glob('node_modules/**', workPath)),
+  ...(await glob('package-lock.json', workPath)),
+  ...(await glob('yarn.lock', workPath)),
 });

--- a/packages/now-node-server/launcher.js
+++ b/packages/now-node-server/launcher.js
@@ -24,7 +24,8 @@ try {
     );
     process.exit(1);
   } else {
-    throw err;
+    console.error(err);
+    process.exit(1);
   }
 }
 

--- a/packages/now-node-server/package.json
+++ b/packages/now-node-server/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@now/node-bridge": "^1.0.1",
+    "@zeit/ncc": "0.17.3",
     "fs-extra": "7.0.1"
   },
   "scripts": {

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@now/node-bridge": "^1.0.1",
+    "@zeit/ncc": "0.17.3",
     "fs-extra": "7.0.1"
   },
   "scripts": {

--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -1,6 +1,5 @@
 import { join, dirname } from 'path';
 import { remove, readFile } from 'fs-extra';
-import ncc from '@zeit/ncc';
 import {
   glob,
   download,
@@ -45,6 +44,7 @@ async function downloadInstallAndBundle({
 async function compile(entrypointPath: string, entrypoint: string, config: CompilerConfig): Promise<Files> {
   const input = entrypointPath;
   const inputDir = dirname(input);
+  const ncc = require('@zeit/ncc');
   const { code, assets } = await ncc(input);
 
   if (config && config.includeFiles) {
@@ -86,7 +86,7 @@ export async function build({ files, entrypoint, workPath, config }: BuildOption
   const {
     entrypointPath,
     entrypointFsDirname
- } = await downloadInstallAndBundle(
+  } = await downloadInstallAndBundle(
     { files, entrypoint, workPath, npmArguments: ['--prefer-offline'] }
   );
 

--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -67,12 +67,12 @@ async function compile(entrypointPath: string, entrypoint: string, config: Compi
   const preparedFiles: Files = {};
   const blob = new FileBlob({ data: code });
   // move all user code to 'user' subdirectory
-  preparedFiles[join('user', entrypoint)] = blob;
+  preparedFiles[entrypoint] = blob;
   // eslint-disable-next-line no-restricted-syntax
   for (const assetName of Object.keys(assets)) {
     const { source: data, permissions: mode } = assets[assetName];
     const blob2 = new FileBlob({ data, mode });
-    preparedFiles[join('user', dirname(entrypoint), assetName)] = blob2;
+    preparedFiles[join(dirname(entrypoint), assetName)] = blob2;
   }
 
   return preparedFiles;
@@ -101,8 +101,7 @@ export async function build({ files, entrypoint, workPath, config }: BuildOption
   launcherData = launcherData.replace(
     '// PLACEHOLDER',
     [
-      'process.chdir("./user");',
-      `listener = require("./${join('user', entrypoint)}");`,
+      `listener = require("./${entrypoint}");`,
       'if (listener.default) listener = listener.default;'
     ].join(' ')
   );

--- a/packages/now-node/src/launcher.ts
+++ b/packages/now-node/src/launcher.ts
@@ -15,7 +15,8 @@ try {
     console.error('Did you forget to add it to "dependencies" in `package.json`?');
     process.exit(1);
   } else {
-    throw err;
+    console.error(err);
+    process.exit(1);
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -834,6 +834,11 @@
     globby "8.0.0"
     signal-exit "3.0.2"
 
+"@zeit/ncc@0.17.3":
+  version "0.17.3"
+  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.17.3.tgz#a6ec83933d209ac2956d642db772838515d93077"
+  integrity sha512-WV1pZZx3vj7E6HMGPKlwqIrCHNtn21C7kvwRNXKQovhpaU/q5iRCAlQ9Peijd1cDUTfakDKb8e8Kp7IRI8Hp3A==
+
 JSONStream@^1.0.4, JSONStream@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"


### PR DESCRIPTION
This PR moves the installation of `ncc` from `build` function to `npm install` stage of the whole builder. This is needed for further caching approach being developed now.