### PR TITLE
[now-node-bridge] Refactor to handle `unhandledRejection` events

### DIFF
--- a/packages/now-node-bridge/package.json
+++ b/packages/now-node-bridge/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "npm run build && jest",
+    "test": "npm run build && node test/unhandled-error.js && jest",
     "prepublish": "npm run build"
   },
   "devDependencies": {

--- a/packages/now-node-bridge/test/bridge.test.js
+++ b/packages/now-node-bridge/test/bridge.test.js
@@ -8,7 +8,7 @@ test('port binding', async () => {
   bridge.listen();
 
   // Test port binding
-  const info = await bridge.listening;
+  const info = await bridge.listening.promise;
   assert.equal(info.address, '127.0.0.1');
   assert.equal(typeof info.port, 'number');
 
@@ -16,20 +16,22 @@ test('port binding', async () => {
 });
 
 test('`APIGatewayProxyEvent` normalizing', async () => {
-  const server = new Server((req, res) => res.end(
-    JSON.stringify({
-      method: req.method,
-      path: req.url,
-      headers: req.headers,
-    }),
-  ));
+  const server = new Server((req, res) =>
+    res.end(
+      JSON.stringify({
+        method: req.method,
+        path: req.url,
+        headers: req.headers
+      })
+    )
+  );
   const bridge = new Bridge(server);
   bridge.listen();
   const result = await bridge.launcher({
     httpMethod: 'GET',
     headers: { foo: 'bar' },
     path: '/apigateway',
-    body: null,
+    body: null
   });
   assert.equal(result.encoding, 'base64');
   assert.equal(result.statusCode, 200);
@@ -42,13 +44,15 @@ test('`APIGatewayProxyEvent` normalizing', async () => {
 });
 
 test('`NowProxyEvent` normalizing', async () => {
-  const server = new Server((req, res) => res.end(
-    JSON.stringify({
-      method: req.method,
-      path: req.url,
-      headers: req.headers,
-    }),
-  ));
+  const server = new Server((req, res) =>
+    res.end(
+      JSON.stringify({
+        method: req.method,
+        path: req.url,
+        headers: req.headers
+      })
+    )
+  );
   const bridge = new Bridge(server);
   bridge.listen();
   const result = await bridge.launcher({
@@ -57,8 +61,8 @@ test('`NowProxyEvent` normalizing', async () => {
       method: 'POST',
       headers: { foo: 'baz' },
       path: '/nowproxy',
-      body: 'body=1',
-    }),
+      body: 'body=1'
+    })
   });
   assert.equal(result.encoding, 'base64');
   assert.equal(result.statusCode, 200);

--- a/packages/now-node-bridge/test/unhandled-error.js
+++ b/packages/now-node-bridge/test/unhandled-error.js
@@ -1,0 +1,35 @@
+const assert = require('assert');
+const { Server } = require('http');
+const { Bridge } = require('../bridge');
+
+async function main() {
+  let err;
+  const server = new Server(async (req, res) => {
+    throw new Error('unhandled');
+  });
+  const bridge = new Bridge(server);
+  bridge.listen();
+
+  try {
+    await bridge.launcher({
+      Action: 'Invoke',
+      body: JSON.stringify({
+        method: 'GET',
+        headers: {},
+        path: '/'
+      })
+    });
+  } catch (_err) {
+    err = _err;
+  }
+
+  assert(err);
+  assert.equal(err.message, 'unhandled');
+
+  server.close();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Currently, if you have an async handler function that throws an error, an `unhandledRejection` event occurs and the HTTP request never completes and hangs until the browser or lambda invoke timeout is reached.

The commit makes it such that the lambda invoke returns the error properly so that the HTTP request will return a 502 quickly. This involves using the "deferred promise" pattern to reject the lambda promise during the `unhandledRejection` event, and some logic to tear down the connected socket.

The test case is a standalone node script because jest does some magic behind the scenes to fail the test when an `unhandledRejection` event happens, even though we have our own listener that does handle it.