### PR TITLE
[now-build-utils] Set the `mode` when creating the file, not afterwards

### DIFF
--- a/packages/now-build-utils/src/file-fs-ref.ts
+++ b/packages/now-build-utils/src/file-fs-ref.ts
@@ -48,7 +48,7 @@ class FileFsRef implements File {
 
     await new Promise<void>((resolve, reject) => {
       const dest = fs.createWriteStream(fsPath, {
-        mode: parseInt(mode.toString(8).slice(-3), 8)
+        mode: mode & 0o777
       });
       stream.pipe(dest);
       stream.on('error', reject);

--- a/packages/now-build-utils/src/file-fs-ref.ts
+++ b/packages/now-build-utils/src/file-fs-ref.ts
@@ -48,7 +48,7 @@ class FileFsRef implements File {
 
     await new Promise<void>((resolve, reject) => {
       const dest = fs.createWriteStream(fsPath, {
-        mode: mode.toString(8).slice(-3)
+        mode: parseInt(mode.toString(8).slice(-3), 8)
       });
       stream.pipe(dest);
       stream.on('error', reject);

--- a/packages/now-build-utils/src/file-fs-ref.ts
+++ b/packages/now-build-utils/src/file-fs-ref.ts
@@ -47,14 +47,15 @@ class FileFsRef implements File {
     await fs.mkdirp(path.dirname(fsPath));
 
     await new Promise<void>((resolve, reject) => {
-      const dest = fs.createWriteStream(fsPath);
+      const dest = fs.createWriteStream(fsPath, {
+        mode: mode.toString(8).slice(-3)
+      });
       stream.pipe(dest);
       stream.on('error', reject);
       dest.on('finish', resolve);
       dest.on('error', reject);
     });
 
-    await fs.chmod(fsPath, mode.toString(8).slice(-3));
     return new FileFsRef({ mode, fsPath });
   }
 


### PR DESCRIPTION
This is the more proper fix for #373.