### PR TITLE
[now-next] Cache Flying Shuttle directory

### DIFF
--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -452,7 +452,7 @@ exports.prepareCache = async ({ workPath, entrypoint }) => {
     ...(await glob(
       path.join(
         cacheEntrypoint,
-        'node_modules/{**,!.*,.yarn*,.cache/next-minifier/**}',
+        'node_modules/{**,!.*,.yarn*,.cache/next-minifier/**,.cache/next-flying-shuttle/**}',
       ),
       workPath,
     )),


### PR DESCRIPTION
This feature isn't landed in Next.js yet -- but this is the path it'll use.
We should land this and get it out in a canary sooner than later, so it "just works" with newer Next.js versions.