### PR TITLE
[now-next] Cache the new Next.js cache location

### DIFF
--- a/packages/now-next/index.js
+++ b/packages/now-next/index.js
@@ -450,6 +450,7 @@ exports.prepareCache = async ({ workPath, entrypoint }) => {
   const cacheEntrypoint = path.relative(workPath, entryPath);
   return {
     ...(await glob(path.join(cacheEntrypoint, 'node_modules/**'), workPath)),
+    ...(await glob(path.join(cacheEntrypoint, '.next/cache/**'), workPath)),
     ...(await glob(path.join(cacheEntrypoint, 'package-lock.json'), workPath)),
     ...(await glob(path.join(cacheEntrypoint, 'yarn.lock'), workPath)),
   };

--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@now/next",
-  "version": "0.1.3-canary.12",
+  "version": "0.1.3-canary.13",
   "license": "MIT",
   "scripts": {
     "build": "tsc"


### PR DESCRIPTION
Next.js will now cache under the `.next/cache` folder. We should pass these contents to the `n+1` build.