### PR TITLE
[now-build-utils] Create zip files with symlinks properly

### DIFF
--- a/packages/now-build-utils/.gitignore
+++ b/packages/now-build-utils/.gitignore
@@ -1,2 +1,3 @@
 dist
 test/symlinks-out
+test/symlinks.zip

--- a/packages/now-build-utils/package.json
+++ b/packages/now-build-utils/package.json
@@ -33,6 +33,7 @@
     "@types/glob": "^7.1.1",
     "@types/node-fetch": "^2.1.6",
     "@types/yazl": "^2.4.1",
+    "execa": "^1.0.0",
     "typescript": "3.3.4000"
   }
 }

--- a/packages/now-build-utils/src/lambda.ts
+++ b/packages/now-build-utils/src/lambda.ts
@@ -1,8 +1,11 @@
 import assert from 'assert';
 import Sema from 'async-sema';
 import { ZipFile } from 'yazl';
-import streamToBuffer from './fs/stream-to-buffer';
+import { readlink } from 'fs-extra';
 import { Files } from './types';
+import FileFsRef from './file-fs-ref';
+import { isSymbolicLink } from './fs/download';
+import streamToBuffer from './fs/stream-to-buffer';
 
 interface Environment {
   [key: string]: string;
@@ -52,22 +55,9 @@ export async function createLambda({
   assert(typeof environment === 'object', '"environment" is not an object');
 
   await sema.acquire();
+
   try {
-    const zipFile = new ZipFile();
-    const zipBuffer = await new Promise<Buffer>((resolve, reject) => {
-      Object.keys(files)
-        .sort()
-        .forEach((name) => {
-          const file = files[name];
-          const stream = file.toStream() as import('stream').Readable;
-          stream.on('error', reject);
-          zipFile.addReadStream(stream, name, { mode: file.mode, mtime });
-        });
-
-      zipFile.end();
-      streamToBuffer(zipFile.outputStream).then(resolve).catch(reject);
-    });
-
+    const zipBuffer = await createZip(files);
     return new Lambda({
       zipBuffer,
       handler,
@@ -77,4 +67,38 @@ export async function createLambda({
   } finally {
     sema.release();
   }
+}
+
+export async function createZip(files: Files): Promise<Buffer> {
+  const names = Object.keys(files).sort();
+
+  const symlinkTargets = new Map<string, string>();
+  for (const name of names) {
+    const file = files[name];
+    if (file.mode && isSymbolicLink(file.mode) && file.type === 'FileFsRef') {
+      const symlinkTarget = await readlink((file as FileFsRef).fsPath);
+      symlinkTargets.set(name, symlinkTarget);
+    }
+  }
+
+  const zipFile = new ZipFile();
+  const zipBuffer = await new Promise<Buffer>((resolve, reject) => {
+    for (const name of names) {
+      const file = files[name];
+      const opts = { mode: file.mode, mtime };
+      const symlinkTarget = symlinkTargets.get(name);
+      if (typeof symlinkTarget === 'string') {
+        zipFile.addBuffer(Buffer.from(symlinkTarget, 'utf8'), name, opts);
+      } else {
+        const stream = file.toStream() as import('stream').Readable;
+        stream.on('error', reject);
+        zipFile.addReadStream(stream, name, opts);
+      }
+    }
+
+    zipFile.end();
+    streamToBuffer(zipFile.outputStream).then(resolve).catch(reject);
+  });
+
+  return zipBuffer;
 }


### PR DESCRIPTION
After #359, creating zip files with symlinks would be corrupted because the "target" of the symlink was actually the file contents.

This commit fixes the zip file construction logic to handle symlinks by placing the target of the symlink as the "contents" of the file in the zip. The unit test relies on GNU `unzip` and checks that it creates the symlink from the produced zip file as expected.