### PR TITLE
Add a `mutable` flag to FileRef

### DIFF
--- a/packages/now-build-utils/src/file-ref.ts
+++ b/packages/now-build-utils/src/file-ref.ts
@@ -31,6 +31,7 @@ export default class FileRef implements File {
   constructor({ mode = 0o100644, digest, mutable = false }: FileRefOptions) {
     assert(typeof mode === 'number');
     assert(typeof digest === 'string');
+    assert(typeof mutable === 'boolean');
     this.type = 'FileRef';
     this.mode = mode;
     this.digest = digest;

--- a/packages/now-build-utils/src/file-ref.ts
+++ b/packages/now-build-utils/src/file-ref.ts
@@ -8,7 +8,7 @@ import { File } from './types';
 interface FileRefOptions {
   mode?: number;
   digest: string;
-  immutable?: boolean;
+  mutable?: boolean;
 }
 
 const semaToDownloadFromS3 = new Sema(5);
@@ -26,15 +26,15 @@ export default class FileRef implements File {
   public type: 'FileRef';
   public mode: number;
   public digest: string;
-  public immutable: boolean;
+  public mutable: boolean;
 
-  constructor({ mode = 0o100644, digest, immutable = true }: FileRefOptions) {
+  constructor({ mode = 0o100644, digest, mutable = false }: FileRefOptions) {
     assert(typeof mode === 'number');
     assert(typeof digest === 'string');
     this.type = 'FileRef';
     this.mode = mode;
     this.digest = digest;
-    this.immutable = immutable;
+    this.mutable = mutable;
   }
 
   async toStreamAsync(): Promise<NodeJS.ReadableStream> {
@@ -42,9 +42,9 @@ export default class FileRef implements File {
     // sha:24be087eef9fac01d61b30a725c1a10d7b45a256
     const digestParts = this.digest.split(':');
     if (digestParts[0] === 'sha') {
-      url = this.immutable
-        ? `https://dmmcy0pwk6bqi.cloudfront.net/${digestParts[1]}`
-        : `https://s3.amazonaws.com/now-files/${digestParts[1]}`;
+      url = this.mutable
+        ? `https://s3.amazonaws.com/now-files/${digestParts[1]}`
+        : `https://dmmcy0pwk6bqi.cloudfront.net/${digestParts[1]}`;
     } else {
       throw new Error('Expected digest to be sha');
     }


### PR DESCRIPTION
Not all files are cacheable (and our default CloudFront configuration assumes this), e.g. builder cache archives.

This PR adds an `immutable` option to `FileRef` (default `true`) -- setting `immutable: false` will download the file fresh from S3.