### PR TITLE
Add fetchTokenWithRetry for bad json response

### DIFF
--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -125,8 +125,7 @@ async function fetchWithAuth (url, opts = {}) {
       if (NOW_TOKEN) {
         token = NOW_TOKEN;
       } else if (NOW_TOKEN_FACTORY_URL) {
-        const resp = await fetch(NOW_TOKEN_FACTORY_URL);
-        token = (await resp.json()).token;
+        token = await fetchTokenWithRetry(NOW_TOKEN_FACTORY_URL);
       } else {
         const authJsonPath = path.join(homedir(), '.now/auth.json');
         token = require(authJsonPath).token;
@@ -137,6 +136,27 @@ async function fetchWithAuth (url, opts = {}) {
   }
 
   return await fetchApi(url, opts);
+}
+
+function fetchTokenWithRetry (url, retries = 3) {
+  return new Promise(async (resolve, reject) => {
+    try {
+      const res = await fetch(url);
+      const data = await res.json();
+      resolve(data.token);
+    } catch (error) {
+      console.log(`Failed to fetch token. Retries remaining: ${retries}`);
+      if (retries === 0) {
+        reject(error);
+        return;
+      }
+      setTimeout(() => {
+        fetchTokenWithRetry(url, retries - 1)
+          .then(resolve)
+          .catch(reject);
+      }, 500);
+    }
+  });
 }
 
 async function fetchApi (url, opts = {}) {

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -77,7 +77,7 @@ async function testDeployment (
   bodies['now.json'] = Buffer.from(JSON.stringify(nowJson));
   delete bodies['probe.js'];
   const { deploymentId, deploymentUrl } = await nowDeploy(bodies, randomness);
-  console.log('deploymentUrl', deploymentUrl);
+  console.log('deploymentUrl', `https://${deploymentUrl}`);
 
   for (const probe of nowJson.probes || []) {
     console.log('testing', JSON.stringify(probe));


### PR DESCRIPTION
This is a quick fix for our token problem by attempting to retry the fetch.

> FetchError: invalid json response body at NOW_TOKEN_FACTORY_URL reason: Unexpected token A in JSON at position 0

The root cause is in the token factory because it throws `Confirmation incomplete` but that will be harder to track down and fix.