### PR TITLE
[now-node-bridge] encode incoming request path when bridging

### DIFF
--- a/packages/now-node-bridge/src/bridge.ts
+++ b/packages/now-node-bridge/src/bridge.ts
@@ -43,6 +43,8 @@ function normalizeNowProxyEvent(event: NowProxyEvent): NowProxyRequest {
   let bodyBuffer: Buffer | null;
   const { method, path, headers, encoding, body } = JSON.parse(event.body);
 
+  const encodedPath = encodeURI(path);
+
   if (body) {
     if (encoding === 'base64') {
       bodyBuffer = Buffer.from(body, encoding);
@@ -55,7 +57,7 @@ function normalizeNowProxyEvent(event: NowProxyEvent): NowProxyRequest {
     bodyBuffer = Buffer.alloc(0);
   }
 
-  return { isApiGateway: false, method, path, headers, body: bodyBuffer };
+  return { isApiGateway: false, method, headers, path: encodedPath, body: bodyBuffer };
 }
 
 function normalizeAPIGatewayProxyEvent(
@@ -63,6 +65,8 @@ function normalizeAPIGatewayProxyEvent(
 ): NowProxyRequest {
   let bodyBuffer: Buffer | null;
   const { httpMethod: method, path, headers, body } = event;
+
+  const encodedPath = encodeURI(path);
 
   if (body) {
     if (event.isBase64Encoded) {
@@ -74,7 +78,7 @@ function normalizeAPIGatewayProxyEvent(
     bodyBuffer = Buffer.alloc(0);
   }
 
-  return { isApiGateway: true, method, path, headers, body: bodyBuffer };
+  return { isApiGateway: true, method, headers, path: encodedPath, body: bodyBuffer };
 }
 
 function normalizeEvent(

--- a/packages/now-node-bridge/test/bridge.test.js
+++ b/packages/now-node-bridge/test/bridge.test.js
@@ -16,20 +16,22 @@ test('port binding', async () => {
 });
 
 test('`APIGatewayProxyEvent` normalizing', async () => {
-  const server = new Server((req, res) => res.end(
-    JSON.stringify({
-      method: req.method,
-      path: req.url,
-      headers: req.headers,
-    }),
-  ));
+  const server = new Server((req, res) =>
+    res.end(
+      JSON.stringify({
+        method: req.method,
+        path: req.url,
+        headers: req.headers
+      })
+    )
+  );
   const bridge = new Bridge(server);
   bridge.listen();
   const result = await bridge.launcher({
     httpMethod: 'GET',
     headers: { foo: 'bar' },
     path: '/apigateway',
-    body: null,
+    body: null
   });
   assert.equal(result.encoding, 'base64');
   assert.equal(result.statusCode, 200);
@@ -41,14 +43,46 @@ test('`APIGatewayProxyEvent` normalizing', async () => {
   server.close();
 });
 
+test('encoded URL', async () => {
+  const server = new Server((req, res) =>
+    res.end(
+      JSON.stringify({
+        method: req.method,
+        path: req.url,
+        headers: req.headers
+      })
+    )
+  );
+  const bridge = new Bridge(server);
+  bridge.listen();
+  const path = '/ hey!';
+  const result = await bridge.launcher({
+    Action: 'Invoke',
+    body: JSON.stringify({
+      method: 'GET',
+      path
+    })
+  });
+  assert.equal(result.encoding, 'base64');
+  assert.equal(result.statusCode, 200);
+  const body = JSON.parse(Buffer.from(result.body, 'base64').toString());
+  assert.equal(body.method, 'GET');
+  const encodedPath = encodeURI(path);
+  assert.equal(body.path, encodedPath);
+
+  server.close();
+});
+
 test('`NowProxyEvent` normalizing', async () => {
-  const server = new Server((req, res) => res.end(
-    JSON.stringify({
-      method: req.method,
-      path: req.url,
-      headers: req.headers,
-    }),
-  ));
+  const server = new Server((req, res) =>
+    res.end(
+      JSON.stringify({
+        method: req.method,
+        path: req.url,
+        headers: req.headers
+      })
+    )
+  );
   const bridge = new Bridge(server);
   bridge.listen();
   const result = await bridge.launcher({
@@ -57,8 +91,8 @@ test('`NowProxyEvent` normalizing', async () => {
       method: 'POST',
       headers: { foo: 'baz' },
       path: '/nowproxy',
-      body: 'body=1',
-    }),
+      body: 'body=1'
+    })
   });
   assert.equal(result.encoding, 'base64');
   assert.equal(result.statusCode, 200);


### PR DESCRIPTION
If request path contains characters other than ASCII characters(like spaces, multibyte characters), node’s http.request refuse to set headers. So encode it.

Ref: #395 