### PR TITLE
Wait for Next.js dev server to run before continuing

### DIFF
--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@now/next",
-  "version": "0.2.0-canary.39",
+  "version": "0.3.0-dev.56",
   "license": "MIT",
   "main": "./dist/index",
   "scripts": {

--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@now/next",
-  "version": "0.3.0-dev.56",
+  "version": "0.2.0-canary.39",
   "license": "MIT",
   "main": "./dist/index",
   "scripts": {


### PR DESCRIPTION
Like this, we ensure that no `routes` are provided as long as `next dev` is not running.