### PR TITLE
Develop Next.js app inside workPath

### DIFF
--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@now/node-bridge": "^1.0.2-canary.2",
-    "execa": "^1.0.0",
     "fs-extra": "^7.0.0",
     "get-port": "^5.0.0",
     "resolve-from": "^4.0.0",

--- a/packages/now-next/src/dev-server.ts
+++ b/packages/now-next/src/dev-server.ts
@@ -1,0 +1,50 @@
+import resolveFrom from 'resolve-from';
+import { parse } from 'url';
+import getPort from 'get-port';
+import { createServer } from 'http';
+
+export interface ProcessEnv {
+  [key: string]: string;
+}
+
+async function main(env: ProcessEnv) {
+  const { ENTRY_PATH } = env;
+
+  if (!ENTRY_PATH) {
+    console.error('No ENTRY_PATH defined');
+    process.exit(1);
+
+    return;
+  }
+
+  const next = require(resolveFrom(ENTRY_PATH, 'next'));
+  const app = next({ dev: true, dir: ENTRY_PATH });
+  const handler = app.getRequestHandler();
+
+  const openPort = await getPort({
+    port: [ 5000, 4000 ]
+  });
+
+  const url = `http://localhost:${openPort}`;
+
+  // Prepare for incoming requests
+  await app.prepare();
+
+  createServer((req, res) => {
+    const parsedUrl = parse(req.url || '', true);
+    handler(req, res, parsedUrl);
+  }).listen(openPort, (error: NodeJS.ErrnoException) => {
+    if (error) {
+      console.error(error);
+      process.exit(1);
+
+      return;
+    }
+
+    if (process.send) {
+      process.send(url);
+    }
+  });
+}
+
+main(process.env as ProcessEnv);

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -51,7 +51,6 @@ interface BuildParamsType extends BuildOptions {
 };
 
 export const version = 2;
-export const requiresInitialBuild = true;
 
 /**
  * Read package.json from files
@@ -115,45 +114,6 @@ function isLegacyNext(nextVersion: string) {
   }
 
   return true;
-}
-
-function pageExists(name: string, pages: Files, entry: string) {
-  const pageWhere = (key: string) => Object.prototype.hasOwnProperty.call(pages, key);
-  const inPages = (...names: string[]) => {
-    let exists = false;
-    while (names.length >= 1) {
-      if (pageWhere(`${entry ? `${entry}/` : ''}pages/${names[0]}`)) {
-        exists = true;
-        break;
-      }
-      names.shift();
-    }
-
-    return exists;
-  };
-
-  if (name === '' || name === '/') {
-    return inPages(
-      'index.js',
-      'index.ts',
-      'index.jsx',
-      'index.tsx',
-      'index.mdx',
-    );
-  }
-
-  return inPages(
-    `${name}.js`,
-    `${name}.ts`,
-    `${name}.jsx`,
-    `${name}.tsx`,
-    `${name}.mdx`,
-    `${name}/index.js`,
-    `${name}/index.ts`,
-    `${name}/index.jsx`,
-    `${name}/index.tsx`,
-    `${name}/index.mdx`,
-  );
 }
 
 const name = '[@now/next]';
@@ -502,34 +462,4 @@ export const prepareCache = async ({ workPath, entrypoint }: PrepareCacheOptions
   };
   console.log('cache file manifest produced');
   return cache;
-};
-
-export const shouldServe = async ({ entrypoint, files, requestPath }: {entrypoint: string, files: Files, requestPath: string}) => {
-  const entry = path.dirname(entrypoint);
-  const entryDirectory = entry === '.' ? '' : `${entry}/`;
-
-  if (new RegExp(`^${entryDirectory}static/.+$`).test(requestPath)) return true;
-
-  const pages = includeOnlyEntryDirectory(
-    files,
-    path.join(entryDirectory, 'pages'),
-  );
-
-  const isClientPage = new RegExp(
-    `^${entryDirectory}_next/static/unoptimized-build/pages/(.+)\\.js$`,
-  );
-  if (isClientPage.test(requestPath)) {
-    const requestedPage = requestPath.match(isClientPage);
-    if (!requestedPage) return false;
-    if (requestedPage[1] === '_error' || requestedPage[1] === '_document' || requestedPage[1] === '_app') return true;
-    return pageExists(requestedPage[1], pages, entryDirectory);
-  }
-
-  if (new RegExp(`^${entryDirectory}_next.+$`).test(requestPath)) return true;
-
-  return pageExists(
-    requestPath.endsWith('/') ? requestPath.slice(0, -1) : requestPath,
-    pages,
-    entryDirectory,
-  );
 };

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -33,7 +33,8 @@ import {
   normalizePackageJson,
   onlyStaticDirectory,
   getNextConfig,
-  getWatchers,
+  getPathsInside,
+  getRoutes,
   stringMap,
 } from './utils';
 
@@ -231,19 +232,12 @@ export const build = async ({
       console.log(`${name} Development server for ${entrypoint} running at ${urls[entrypoint]}`);
     }
 
-    if (uponRequest) {
-      routes.push({
-        // This property is not allowed to contain GET parameters, as they
-        // contain a ?, which is a regex operator.
-        src: url.parse(`/${meta.requestPath}`).pathname,
-        dest: `${urls[entrypoint]}/${meta.requestPath}`
-      });
-    }
+    const pathsInside = getPathsInside(entryDirectory, files)
 
     return {
-      routes,
       output: {},
-      watch: await getWatchers(entryDirectory, files)
+      routes: getRoutes(entryDirectory, pathsInside, files, urls[entrypoint]),
+      watch: pathsInside
     };
   }
 
@@ -477,8 +471,8 @@ export const build = async ({
   );
 
   return {
-    routes,
     output: { ...lambdas, ...staticFiles, ...staticDirectoryFiles },
+    routes: [],
     watch: []
   };
 };

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -131,18 +131,17 @@ async function getNextConfig(workPath: string, entryPath: string) {
   return null;
 }
 
-async function getWatchers(nextPath: string) {
+async function getWatchers(entryDirectory: string, files: Files) {
   const watch: string[] = [];
-  const manifest = path.join(nextPath, 'compilation-modules.json');
 
-  try {
-    const { pages } = JSON.parse(await fs.readFile(manifest, 'utf8'));
+  for (const file of Object.keys(files)) {
+    // If the file is outside of the entrypoint directory, we do
+    // not want to monitor it for changes.
+    if (path.relative(entryDirectory, file).startsWith('..')) {
+      continue;
+    }
 
-    Object.keys(pages).forEach(page => pages[page].forEach((dep: string) => {
-      watch.push(dep);
-    }));
-  } catch (e) {
-    if (e.code !== 'ENOENT') throw e;
+    watch.push(file);
   }
 
   return watch;

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -196,10 +196,10 @@ function getRoutes(entryDirectory: string, pathsInside: string[], files: Files, 
     });
 
     if (pageName.endsWith('index')) {
-      const resolvedIndex = pageName.replace('index', '');
+      const resolvedIndex = pageName.replace('/index', '');
 
       routes.push({
-        src: `${prefix}${resolvedIndex}`,
+        src: `${prefix}${resolvedIndex || '/'}`,
         dest: `${url}/${resolvedIndex}`
       });
     }

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -194,6 +194,15 @@ function getRoutes(entryDirectory: string, pathsInside: string[], files: Files, 
       src: `${prefix}${pageName}`,
       dest: `${url}/${pageName}`
     });
+
+    if (pageName.endsWith('index')) {
+      const resolvedIndex = pageName.replace('index', '');
+
+      routes.push({
+        src: `${prefix}${resolvedIndex}`,
+        dest: `${url}/${resolvedIndex}`
+      });
+    }
   }
 
   return routes;

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -131,13 +131,17 @@ async function getNextConfig(workPath: string, entryPath: string) {
   return null;
 }
 
-async function getWatchers(entryDirectory: string, files: Files) {
+function pathIsInside(firstPath: string, secondPath: string) {
+  return !path.relative(firstPath, secondPath).startsWith('..');
+}
+
+function getPathsInside(entryDirectory: string, files: Files) {
   const watch: string[] = [];
 
   for (const file of Object.keys(files)) {
     // If the file is outside of the entrypoint directory, we do
     // not want to monitor it for changes.
-    if (path.relative(entryDirectory, file).startsWith('..')) {
+    if (!pathIsInside(entryDirectory, file)) {
       continue;
     }
 
@@ -145,6 +149,54 @@ async function getWatchers(entryDirectory: string, files: Files) {
   }
 
   return watch;
+}
+
+function getRoutes(entryDirectory: string, pathsInside: string[], files: Files, url: string): any[] {
+  const filesInside: Files = {};
+  const prefix = entryDirectory === `.` ? `/` : `${entryDirectory}/`;
+
+  for (const file of Object.keys(files)) {
+    if (!pathsInside.includes(file)) {
+      continue;
+    }
+
+    filesInside[file] = files[file];
+  }
+
+  const routes: any[] = [
+    {
+      src: `${prefix}_next/(.*)`,
+      dest: `${url}/_next/$1`
+    },
+    {
+      src: `${prefix}static/(.*)`,
+      dest: `${url}/static/$1`
+    }
+  ];
+
+  for (const file of Object.keys(filesInside)) {
+    const relativePath = path.relative(entryDirectory, file);
+    const isPage = pathIsInside('pages', relativePath);
+
+    if (!isPage) {
+      continue;
+    }
+
+    const relativeToPages = path.relative('pages', relativePath);
+    const extension = path.extname(relativeToPages);
+    const pageName = relativeToPages.replace(extension, '');
+
+    if (pageName.startsWith('_')) {
+      continue;
+    }
+
+    routes.push({
+      src: `${prefix}${pageName}`,
+      dest: `${url}/${pageName}`
+    });
+  }
+
+  return routes;
 }
 
 export {
@@ -155,6 +207,7 @@ export {
   normalizePackageJson,
   onlyStaticDirectory,
   getNextConfig,
-  getWatchers,
+  getPathsInside,
+  getRoutes,
   stringMap,
 };

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -153,7 +153,7 @@ function getPathsInside(entryDirectory: string, files: Files) {
 
 function getRoutes(entryDirectory: string, pathsInside: string[], files: Files, url: string): any[] {
   const filesInside: Files = {};
-  const prefix = entryDirectory === `.` ? `/` : `${entryDirectory}/`;
+  const prefix = entryDirectory === `.` ? `/` : `/${entryDirectory}/`;
 
   for (const file of Object.keys(files)) {
     if (!pathsInside.includes(file)) {
@@ -196,10 +196,10 @@ function getRoutes(entryDirectory: string, pathsInside: string[], files: Files, 
     });
 
     if (pageName.endsWith('index')) {
-      const resolvedIndex = pageName.replace('/index', '');
+      const resolvedIndex = pageName.replace('/index', '').replace('index', '');
 
       routes.push({
-        src: `${prefix}${resolvedIndex || '/'}`,
+        src: `${prefix}${resolvedIndex}`,
         dest: `${url}/${resolvedIndex}`
       });
     }


### PR DESCRIPTION
Currently, `next dev` is starting inside the `cwd` of the `entrypoint`. Since that leaves behind nasty temporary files, we decided to move it into the `workPath`.