### PR TITLE
[now-node] Bump ncc to 0.18.1

### DIFF
--- a/packages/now-node-server/package.json
+++ b/packages/now-node-server/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@now/node-bridge": "^1.0.2-canary.2",
-    "@zeit/ncc": "0.17.3",
+    "@zeit/ncc": "0.18.1",
     "fs-extra": "7.0.1"
   },
   "scripts": {

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@now/node-bridge": "^1.0.2-canary.2",
-    "@zeit/ncc": "0.17.3",
+    "@zeit/ncc": "0.18.1",
     "fs-extra": "7.0.1"
   },
   "scripts": {

--- a/packages/now-node/test/fixtures/14-stack-trace-ts/now.json
+++ b/packages/now-node/test/fixtures/14-stack-trace-ts/now.json
@@ -6,7 +6,7 @@
   "probes": [
     {
       "path": "/",
-      "mustContain": "index.ts:6"
+      "mustContain": "index.ts:4"
     }
   ]
 }

--- a/packages/now-node/test/fixtures/14-stack-trace-ts/tsconfig.json
+++ b/packages/now-node/test/fixtures/14-stack-trace-ts/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
       "strict": true,
       "esModuleInterop": true,
+      "sourceMap": true,
       "lib": ["esnext"],
       "target": "esnext",
       "module": "commonjs"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,10 +1107,10 @@
     globby "8.0.0"
     signal-exit "3.0.2"
 
-"@zeit/ncc@0.17.3":
-  version "0.17.3"
-  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.17.3.tgz#a6ec83933d209ac2956d642db772838515d93077"
-  integrity sha512-WV1pZZx3vj7E6HMGPKlwqIrCHNtn21C7kvwRNXKQovhpaU/q5iRCAlQ9Peijd1cDUTfakDKb8e8Kp7IRI8Hp3A==
+"@zeit/ncc@0.18.1":
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.18.1.tgz#1723884210c792ba702ec6dccb390f387f0a3ba6"
+  integrity sha512-Tq13BzK+hAWBZY+VvncRZzpE5PHGks3kn2XJ+bcWSXgTZb4rTR/CTV1YYXilNNkX//jC1sziuM167FhLzFu2XA==
 
 JSONStream@^1.0.4, JSONStream@^1.3.4:
   version "1.3.5"


### PR DESCRIPTION
This bumps `@zeit/ncc` to the latest version which fixes source maps for TypeScript. 

I also updated the `14-stack-trace-ts` test to be accurate. When I added this test originally, it was off by 2 lines just because it was better than off by 50 lines. Now we show the proper line number 🎉 