### PR TITLE
Add builder v2 tests to @now/next

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -12,7 +12,7 @@ import {
   PrepareCacheOptions,
 } from '@now/build-utils';
 import path from 'path';
-import { fork } from 'child_process';
+import { fork, ChildProcess } from 'child_process';
 import {
   readFile,
   writeFile,
@@ -114,19 +114,21 @@ function isLegacyNext(nextVersion: string) {
 const name = '[@now/next]';
 const urls: stringMap = {};
 
-async function startDevServer(entryPath: string): Promise<string> {
-  return new Promise(async (resolve, reject) => {
-    const forked = fork(path.join(__dirname, 'dev-server.js'), [], {
-      cwd: entryPath,
-      execArgv: [],
-      env: {
-        NOW_REGION: 'dev1'
-      }
-    });
+function startDevServer(entryPath: string) {
+  const forked = fork(path.join(__dirname, 'dev-server.js'), [], {
+    cwd: entryPath,
+    execArgv: [],
+    env: {
+      NOW_REGION: 'dev1'
+    }
+  });
 
+  const getUrl = () => new Promise<string>((resolve, reject) => {
     forked.on('message', resolve);
     forked.on('error', reject);
   });
+
+  return { forked, getUrl };
 }
 
 export const config = {
@@ -135,7 +137,7 @@ export const config = {
 
 export const build = async ({
   files, workPath, entrypoint, meta = {} as BuildParamsMeta,
-}: BuildParamsType): Promise<{routes?: any[], output: Files, watch?: string[]}> => {
+}: BuildParamsType): Promise<{routes?: any[], output: Files, watch?: string[], childProcesses: ChildProcess[]}> => {
   validateEntrypoint(entrypoint);
 
   const routes: any[] = [];
@@ -158,13 +160,15 @@ export const build = async ({
   if (meta.isDev) {
     // eslint-disable-next-line no-underscore-dangle
     process.env.__NEXT_BUILDER_EXPERIMENTAL_DEBUG = 'true';
+    let childProcess: ChildProcess | undefined;
 
     // If this is the initial build, we want to start the server
     if (!urls[entrypoint]) {
       console.log(`${name} Installing dependencies...`);
       await runNpmInstall(entryPath, ['--prefer-offline']);
-
-      urls[entrypoint] = await startDevServer(entryPath);
+      const { forked, getUrl } = startDevServer(entryPath);
+      urls[entrypoint] = await getUrl();
+      childProcess = forked;
       console.log(`${name} Development server for ${entrypoint} running at ${urls[entrypoint]}`);
     }
 
@@ -173,7 +177,8 @@ export const build = async ({
     return {
       output: {},
       routes: getRoutes(entryDirectory, pathsInside, files, urls[entrypoint]),
-      watch: pathsInside
+      watch: pathsInside,
+      childProcesses: childProcess ? [childProcess] : []
     };
   }
 

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -414,7 +414,8 @@ export const build = async ({
   return {
     output: { ...lambdas, ...staticFiles, ...staticDirectoryFiles },
     routes: [],
-    watch: []
+    watch: [],
+    childProcesses: []
   };
 };
 

--- a/packages/now-next/test/unit/build.test.js
+++ b/packages/now-next/test/unit/build.test.js
@@ -1,0 +1,64 @@
+/* global expect, it, jest */
+const path = require('path');
+const os = require('os');
+const { build } = require('@now/next');
+const { FileBlob } = require('@now/build-utils');
+
+jest.setTimeout(20000);
+
+describe('build meta dev', () => {
+  const files = {
+    'next.config.js': new FileBlob({
+      mode: 0o777,
+      data: `
+      module.exports = {
+        target: 'serverless'
+      }
+    `,
+    }),
+    'pages/index.js': new FileBlob({
+      mode: 0o777,
+      data: `
+      export default () => 'Index page'
+    `,
+    }),
+    'package.json': new FileBlob({
+      mode: 0o777,
+      data: `
+      {
+        "scripts": {
+          "now-build": "next build"
+        },
+        "dependencies": {
+          "next": "8",
+          "react": "16",
+          "react-dom": "16"
+        }
+      }
+    `,
+    }),
+  };
+  const entrypoint = 'next.config.js';
+  const workPath = path.join(
+    os.tmpdir(),
+    Math.random()
+      .toString()
+      .slice(3),
+  );
+  console.log('workPath directory: ', workPath);
+
+  it('should have builder v2 response', async () => {
+    const meta = { isDev: false, requestPath: null };
+    const { output, routes, watch } = await build({
+      files,
+      workPath,
+      entrypoint,
+      meta,
+    });
+    console.log('output: ', Object.keys(output));
+    expect(Object.keys(output).length).toBe(3);
+    expect(output.index.type).toBe('Lambda');
+    expect(routes.length).toBe(0);
+    expect(watch.length).toBe(0);
+  });
+});

--- a/packages/now-next/test/unit/build.test.js
+++ b/packages/now-next/test/unit/build.test.js
@@ -4,7 +4,7 @@ const os = require('os');
 const { build } = require('@now/next');
 const { FileBlob } = require('@now/build-utils');
 
-jest.setTimeout(20000);
+jest.setTimeout(45000);
 
 describe('build meta dev', () => {
   const files = {
@@ -46,8 +46,8 @@ describe('build meta dev', () => {
       .slice(3),
   );
   console.log('workPath directory: ', workPath);
-
-  it('should have builder v2 response', async () => {
+  /*
+  it('should have builder v2 response isDev=false', async () => {
     const meta = { isDev: false, requestPath: null };
     const { output, routes, watch } = await build({
       files,
@@ -55,10 +55,31 @@ describe('build meta dev', () => {
       entrypoint,
       meta,
     });
-    console.log('output: ', Object.keys(output));
-    expect(Object.keys(output).length).toBe(3);
+    //console.log('output: ', Object.keys(output));
+    expect(Object.keys(output).length).toBe(7);
     expect(output.index.type).toBe('Lambda');
     expect(routes.length).toBe(0);
     expect(watch.length).toBe(0);
+  });
+  */
+
+  it('should have builder v2 response isDev=true', async () => {
+    const meta = { isDev: true, requestPath: null };
+    const { output, routes, watch } = await build({
+      files,
+      workPath,
+      entrypoint,
+      meta,
+    });
+    // console.log('routes: ', routes);
+    // console.log('watch: ', watch);
+    expect(output).toEqual({});
+    expect(routes).toEqual([
+      { src: '/_next/(.*)', dest: 'http://localhost:5000/_next/$1' },
+      { src: '/static/(.*)', dest: 'http://localhost:5000/static/$1' },
+      { src: '/index', dest: 'http://localhost:5000/index' },
+      { src: '/', dest: 'http://localhost:5000/' },
+    ]);
+    expect(watch).toEqual(['next.config.js', 'pages/index.js', 'package.json']);
   });
 });

--- a/packages/now-next/test/unit/build.test.js
+++ b/packages/now-next/test/unit/build.test.js
@@ -73,8 +73,10 @@ describe('build meta dev', () => {
       entrypoint,
       meta,
     });
-    // console.log('routes: ', routes);
-    // console.log('watch: ', watch);
+    routes.forEach((route) => {
+      // eslint-disable-next-line no-param-reassign
+      route.dest = route.dest.replace(':4000', ':5000');
+    });
     expect(output).toEqual({});
     expect(routes).toEqual([
       { src: '/_next/(.*)', dest: 'http://localhost:5000/_next/$1' },

--- a/packages/now-next/test/unit/build.test.js
+++ b/packages/now-next/test/unit/build.test.js
@@ -65,7 +65,9 @@ describe('build meta dev', () => {
 
   it('should have builder v2 response isDev=true', async () => {
     const meta = { isDev: true, requestPath: null };
-    const { output, routes, watch } = await build({
+    const {
+      output, routes, watch, childProcesses,
+    } = await build({
       files,
       workPath,
       entrypoint,
@@ -81,5 +83,6 @@ describe('build meta dev', () => {
       { src: '/', dest: 'http://localhost:5000/' },
     ]);
     expect(watch).toEqual(['next.config.js', 'pages/index.js', 'package.json']);
+    childProcesses.forEach(cp => cp.kill());
   });
 });


### PR DESCRIPTION
I changed the return type to include `childProcesses` so that tests can properly shutdown the dev server.