### PR TITLE
Make `download()` dedupe

### DIFF
--- a/packages/now-build-utils/src/fs/download.ts
+++ b/packages/now-build-utils/src/fs/download.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import FileFsRef from '../file-fs-ref';
-import { File, Files } from '../types';
+import { File, Files, Meta } from '../types';
 import { mkdirp, readlink, symlink } from 'fs-extra';
 
 export interface DownloadedFiles {
@@ -29,13 +29,20 @@ async function downloadFile(file: File, fsPath: string): Promise<FileFsRef> {
   }
 }
 
-export default async function download(files: Files, basePath: string): Promise<DownloadedFiles> {
+export default async function download(files: Files, basePath: string, meta?: Meta): Promise<DownloadedFiles> {
   const files2: DownloadedFiles = {};
+  const { filesChanged = [], filesRemoved = [] } = meta || {};
 
   await Promise.all(
     Object.keys(files).map(async (name) => {
+      // If a file didn't change, do not re-download it.
+      if (!filesChanged.includes(name)) {
+        return;
+      }
+
       const file = files[name];
       const fsPath = path.join(basePath, name);
+
       files2[name] = await downloadFile(file, fsPath);
     }),
   );

--- a/packages/now-build-utils/src/fs/download.ts
+++ b/packages/now-build-utils/src/fs/download.ts
@@ -31,12 +31,12 @@ async function downloadFile(file: File, fsPath: string): Promise<FileFsRef> {
 
 async function removeFile(basePath: string, fileMatched: string) {
   const file = path.join(basePath, fileMatched);
-  await fs.remove(file);
+  await remove(file);
 }
 
 export default async function download(files: Files, basePath: string, meta?: Meta): Promise<DownloadedFiles> {
   const files2: DownloadedFiles = {};
-  const { filesChanged, filesRemoved } = meta || {};
+  const { filesChanged = null, filesRemoved = null } = meta || {};
 
   await Promise.all(
     Object.keys(files).map(async (name) => {


### PR DESCRIPTION
Like this, we're not re-downloading files that didn't change.

**It's only missing deletion of files.**