### PR TITLE
[now-static-build] Add `now-dev` package.json script

### DIFF
--- a/packages/now-static-build/index.js
+++ b/packages/now-static-build/index.js
@@ -80,14 +80,16 @@ exports.build = async ({
         // will ProxyPass any requests to that development server that come in
         // for this builder.
         await timeout(waitForPort('localhost', devPort), 60 * 1000);
-        console.log('Detected dev server for $j', entrypoint);
+        console.log('Detected dev server for %j', entrypoint);
 
-        const srcBase = `/${mountpoint.replace(/^\.\//, '')}`;
+        let srcBase = mountpoint.replace(/^\.\/?/, '');
+        if (srcBase.length > 0) {
+          srcBase = `/${srcBase}`;
+        }
         routes.push({
-          src: `/${srcBase}/(.*)`,
-          dest: `http://localhost:${devPort}/${srcBase}/$1`,
+          src: `${srcBase}/(.*)`,
+          dest: `http://localhost:${devPort}${srcBase}/$1`,
         });
-        console.error({ routes });
       }
     } else {
       // Run the `now-build` script and wait for completion to collect the build
@@ -101,7 +103,7 @@ exports.build = async ({
       validateDistDir(distPath);
       output = await glob('**', distPath, mountpoint);
     }
-    const watch = [path.join(entrypointFsDirname, '**/*')];
+    const watch = [path.join(mountpoint.replace(/^\.\/?/, ''), '**/*')];
     return { routes, watch, output };
   }
 

--- a/packages/now-static-build/index.js
+++ b/packages/now-static-build/index.js
@@ -29,7 +29,7 @@ exports.build = async ({
   files, entrypoint, workPath, config, meta = {},
 }) => {
   console.log('downloading user files...');
-  await download(files, workPath);
+  await download(files, workPath, meta);
 
   const mountpoint = path.dirname(entrypoint);
   const entrypointFsDirname = path.join(workPath, mountpoint);

--- a/packages/now-static-build/index.js
+++ b/packages/now-static-build/index.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const getPort = require('get-port');
 const { promisify } = require('util');
-const timeout = require('promise-timeout');
+const { timeout } = require('promise-timeout');
 const { existsSync, readFileSync } = require('fs');
 const waitForPort = promisify(require('wait-for-port'));
 const {

--- a/packages/now-static-build/index.js
+++ b/packages/now-static-build/index.js
@@ -98,9 +98,9 @@ exports.build = async ({
           `An error running "now-build" script in "${entrypoint}"`,
         );
       }
+      validateDistDir(distPath);
       output = await glob('**', distPath, mountpoint);
     }
-    validateDistDir(distPath);
     const watch = [path.join(entrypointFsDirname, '**/*')];
     return { routes, watch, output };
   }

--- a/packages/now-static-build/index.js
+++ b/packages/now-static-build/index.js
@@ -45,7 +45,6 @@ exports.build = async ({
 
     const pkgPath = path.join(workPath, entrypoint);
     const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
-    console.log({ pkg });
 
     let output = {};
     const routes = [];
@@ -56,7 +55,6 @@ exports.build = async ({
         // Run the `now-dev` script out-of-bounds, since it is assumed that
         // it will launch a dev server that never "completes"
         const devPort = await getPort();
-        console.log({ devPort });
         const opts = {
           env: { ...process.env, PORT: String(devPort) },
         };
@@ -79,7 +77,13 @@ exports.build = async ({
         // Now wait for the server to have listened on `$PORT`, after which we
         // will ProxyPass any requests to that development server that come in
         // for this builder.
-        await timeout(waitForPort('localhost', devPort), 60 * 1000);
+        try {
+          await timeout(waitForPort('localhost', devPort), 60 * 1000);
+        } catch (err) {
+          throw new Error(
+            `Failed to detect a server running on port ${devPort}`,
+          );
+        }
         console.log('Detected dev server for %j', entrypoint);
 
         let srcBase = mountpoint.replace(/^\.\/?/, '');

--- a/packages/now-static-build/index.js
+++ b/packages/now-static-build/index.js
@@ -101,7 +101,7 @@ exports.build = async ({
       output = await glob('**', distPath, mountpoint);
     }
     validateDistDir(distPath);
-    const watch = path.join(entrypointFsDirname, '**/*');
+    const watch = [ path.join(entrypointFsDirname, '**/*') ];
     return { routes, watch, output };
   }
 

--- a/packages/now-static-build/index.js
+++ b/packages/now-static-build/index.js
@@ -57,6 +57,7 @@ exports.build = async ({
         // Run the `now-dev` script out-of-bounds, since it is assumed that
         // it will launch a dev server that never "completes"
         devPort = await getPort();
+        nowDevScriptPorts.set(entrypoint, devPort);
         const opts = {
           env: { ...process.env, PORT: String(devPort) },
         };
@@ -87,7 +88,6 @@ exports.build = async ({
         }
 
         console.log('Detected dev server for %j', entrypoint);
-        nowDevScriptPorts.set(entrypoint, devPort);
       }
 
       let srcBase = mountpoint.replace(/^\.\/?/, '');

--- a/packages/now-static-build/index.js
+++ b/packages/now-static-build/index.js
@@ -58,7 +58,7 @@ exports.build = async ({
         const devPort = await getPort();
         console.log({ devPort });
         const opts = {
-          env: { PORT: String(devPort) },
+          env: { ...process.env, PORT: String(devPort) },
         };
         const promise = runPackageJsonScript(
           entrypointFsDirname,
@@ -101,7 +101,7 @@ exports.build = async ({
       output = await glob('**', distPath, mountpoint);
     }
     validateDistDir(distPath);
-    const watch = [ path.join(entrypointFsDirname, '**/*') ];
+    const watch = [path.join(entrypointFsDirname, '**/*')];
     return { routes, watch, output };
   }
 

--- a/packages/now-static-build/package.json
+++ b/packages/now-static-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@now/static-build",
-  "version": "0.4.19-dev.3",
+  "version": "0.4.19-canary.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/now-static-build/package.json
+++ b/packages/now-static-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@now/static-build",
-  "version": "0.4.19-canary.2",
+  "version": "0.4.19-dev.3",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,5 +9,10 @@
   },
   "scripts": {
     "test": "jest"
+  },
+  "dependencies": {
+    "get-port": "5.0.0",
+    "promise-timeout": "1.3.0",
+    "wait-for-port": "0.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3789,17 +3789,17 @@ get-pkg-repo@^1.0.0:
     parse-github-repo-url "^1.3.0"
     through2 "^2.0.0"
 
-get-port@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
-  integrity sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=
-
-get-port@^5.0.0:
+get-port@5.0.0, get-port@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.0.0.tgz#aa22b6b86fd926dd7884de3e23332c9f70c031a6"
   integrity sha512-imzMU0FjsZqNa6BqOjbbW6w5BivHIuQKopjpPqcnx0AVHJQKCxK1O+Ab3OrVXhrekqfVMjwA9ZYu062R+KcIsQ==
   dependencies:
     type-fest "^0.3.0"
+
+get-port@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
+  integrity sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=
 
 get-proxy@^1.0.1:
   version "1.1.0"
@@ -7967,6 +7967,11 @@ promise-retry@^1.1.1:
     err-code "^1.0.0"
     retry "^0.10.0"
 
+promise-timeout@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/promise-timeout/-/promise-timeout-1.3.0.tgz#d1c78dd50a607d5f0a5207410252a3a0914e1014"
+  integrity sha512-5yANTE0tmi5++POym6OgtFmwfDvOXABD9oj/jLQr5GPEyuNEb7jH4wbbANJceJid49jwhi1RddxnhnEAb/doqg==
+
 prompts@^0.1.9:
   version "0.1.14"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-0.1.14.tgz#a8e15c612c5c9ec8f8111847df3337c9cbd443b2"
@@ -9943,6 +9948,11 @@ w3c-hr-time@^1.0.1:
   integrity sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=
   dependencies:
     browser-process-hrtime "^0.1.2"
+
+wait-for-port@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/wait-for-port/-/wait-for-port-0.0.2.tgz#bb5ff253436b9933ab9d65c00d584dc68c4d531a"
+  integrity sha1-u1/yU0NrmTOrnWXADVhNxoxNUxo=
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
This will cause `now dev` to run the `now-dev` script as defined in the `package.json` file.

`now dev` sets the `PORT` env variable for use in the `now-dev` script, which is expected to launch a file watching server (for example `hugo dev`) on the specified `$PORT`. `now dev` wait for this port to be bound before returning the `build()` function with the generated assets.

The `watch` array is just "watch everything in the `path.dirname(entrypoint)`" so any file changed within that directory will trigger a "re-sync" of the source files that `now dev` is working with, which the user spawned static build watcher should pick up on and return the updated assets.

Depends on https://github.com/zeit/now-builders/pull/417 in order to pass the `PORT` env var to the `now-dev` script.
Depends on https://github.com/zeit/now-cli/pull/2216.
(Probably) Depends on https://github.com/zeit/now-cli/pull/2217.