### PR TITLE
Increase heap size for Next.js builds

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,4 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "trailingComma": "es5"
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
       "prettier --write",
       "eslint --fix",
       "git add"
+    ],
+    "*.ts": [
+      "prettier --write",
+      "git add"
     ]
   },
   "devDependencies": {

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -12,7 +12,7 @@ import {
   PrepareCacheOptions,
 } from '@now/build-utils';
 import path from 'path';
-import { fork, ChildProcess } from 'child_process';
+import { fork, ChildProcess, SpawnOptions } from 'child_process';
 import {
   readFile,
   writeFile,
@@ -35,15 +35,15 @@ import {
 } from './utils';
 
 interface BuildParamsMeta {
-  isDev: boolean | undefined
-};
+  isDev: boolean | undefined;
+}
 
 interface BuildParamsType extends BuildOptions {
-  files: Files,
-  entrypoint: string,
-  workPath: string,
-  meta: BuildParamsMeta,
-};
+  files: Files;
+  entrypoint: string;
+  workPath: string;
+  meta: BuildParamsMeta;
+}
 
 export const version = 2;
 
@@ -67,7 +67,7 @@ async function readPackageJson(entryPath: string) {
 async function writePackageJson(workPath: string, packageJson: Object) {
   await writeFile(
     path.join(workPath, 'package.json'),
-    JSON.stringify(packageJson, null, 2),
+    JSON.stringify(packageJson, null, 2)
   );
 }
 
@@ -77,11 +77,14 @@ async function writePackageJson(workPath: string, packageJson: Object) {
 async function writeNpmRc(workPath: string, token: string) {
   await writeFile(
     path.join(workPath, '.npmrc'),
-    `//registry.npmjs.org/:_authToken=${token}`,
+    `//registry.npmjs.org/:_authToken=${token}`
   );
 }
 
-function getNextVersion(packageJson: {dependencies?: {[key: string]: string},devDependencies?: {[key:string]:string}}) {
+function getNextVersion(packageJson: {
+  dependencies?: { [key: string]: string };
+  devDependencies?: { [key: string]: string };
+}) {
   let nextVersion;
   if (packageJson.dependencies && packageJson.dependencies.next) {
     nextVersion = packageJson.dependencies.next;
@@ -119,14 +122,15 @@ function startDevServer(entryPath: string) {
     cwd: entryPath,
     execArgv: [],
     env: {
-      NOW_REGION: 'dev1'
-    }
+      NOW_REGION: 'dev1',
+    },
   });
 
-  const getUrl = () => new Promise<string>((resolve, reject) => {
-    forked.on('message', resolve);
-    forked.on('error', reject);
-  });
+  const getUrl = () =>
+    new Promise<string>((resolve, reject) => {
+      forked.on('message', resolve);
+      forked.on('error', reject);
+    });
 
   return { forked, getUrl };
 }
@@ -136,8 +140,16 @@ export const config = {
 };
 
 export const build = async ({
-  files, workPath, entrypoint, meta = {} as BuildParamsMeta,
-}: BuildParamsType): Promise<{routes?: any[], output: Files, watch?: string[], childProcesses: ChildProcess[]}> => {
+  files,
+  workPath,
+  entrypoint,
+  meta = {} as BuildParamsMeta,
+}: BuildParamsType): Promise<{
+  routes?: any[];
+  output: Files;
+  watch?: string[];
+  childProcesses: ChildProcess[];
+}> => {
   validateEntrypoint(entrypoint);
 
   const routes: any[] = [];
@@ -153,7 +165,7 @@ export const build = async ({
 
   if (!nextVersion) {
     throw new Error(
-      'No Next.js version could be detected in "package.json". Make sure `"next"` is installed in "dependencies" or "devDependencies"',
+      'No Next.js version could be detected in "package.json". Make sure `"next"` is installed in "dependencies" or "devDependencies"'
     );
   }
 
@@ -169,22 +181,26 @@ export const build = async ({
       const { forked, getUrl } = startDevServer(entryPath);
       urls[entrypoint] = await getUrl();
       childProcess = forked;
-      console.log(`${name} Development server for ${entrypoint} running at ${urls[entrypoint]}`);
+      console.log(
+        `${name} Development server for ${entrypoint} running at ${
+          urls[entrypoint]
+        }`
+      );
     }
 
-    const pathsInside = getPathsInside(entryDirectory, files)
+    const pathsInside = getPathsInside(entryDirectory, files);
 
     return {
       output: {},
       routes: getRoutes(entryDirectory, pathsInside, files, urls[entrypoint]),
       watch: pathsInside,
-      childProcesses: childProcess ? [childProcess] : []
+      childProcesses: childProcess ? [childProcess] : [],
     };
   }
 
   if (await pathExists(dotNext)) {
     console.warn(
-      'WARNING: You should not upload the `.next` directory. See https://zeit.co/docs/v2/deployments/official-builders/next-js-now-next/ for more details.',
+      'WARNING: You should not upload the `.next` directory. See https://zeit.co/docs/v2/deployments/official-builders/next-js-now-next/ for more details.'
     );
   }
 
@@ -206,7 +222,7 @@ export const build = async ({
     }
 
     console.warn(
-      "WARNING: your application is being deployed in @now/next's legacy mode. http://err.sh/zeit/now-builders/now-next-legacy-mode",
+      "WARNING: your application is being deployed in @now/next's legacy mode. http://err.sh/zeit/now-builders/now-next-legacy-mode"
     );
 
     console.log('normalizing package.json');
@@ -215,7 +231,7 @@ export const build = async ({
     await writePackageJson(entryPath, packageJson);
   } else if (!pkg.scripts || !pkg.scripts['now-build']) {
     console.warn(
-      'WARNING: "now-build" script not found. Adding \'"now-build": "next build"\' to "package.json" automatically',
+      'WARNING: "now-build" script not found. Adding \'"now-build": "next build"\' to "package.json" automatically'
     );
     pkg.scripts = {
       'now-build': 'next build',
@@ -234,7 +250,9 @@ export const build = async ({
   await runNpmInstall(entryPath, ['--prefer-offline']);
 
   console.log('running user script...');
-  await runPackageJsonScript(entryPath, 'now-build');
+  await runPackageJsonScript(entryPath, 'now-build', {
+    env: { ...process.env, NODE_OPTIONS: '--max_old_space_size=8192' },
+  } as SpawnOptions);
 
   if (isLegacy) {
     console.log('running npm install --production...');
@@ -245,7 +263,7 @@ export const build = async ({
     await unlinkFile(path.join(entryPath, '.npmrc'));
   }
 
-  const lambdas: {[key: string]: Lambda} = {};
+  const lambdas: { [key: string]: Lambda } = {};
 
   if (isLegacy) {
     const filesAfterBuild = await glob('**', entryPath);
@@ -255,11 +273,11 @@ export const build = async ({
     try {
       buildId = await readFile(
         path.join(entryPath, '.next', 'BUILD_ID'),
-        'utf8',
+        'utf8'
       );
     } catch (err) {
       console.error(
-        'BUILD_ID not found in ".next". The "package.json" "build" script did not run "next build"',
+        'BUILD_ID not found in ".next". The "package.json" "build" script did not run "next build"'
       );
       throw new Error('Missing BUILD_ID');
     }
@@ -267,12 +285,12 @@ export const build = async ({
     const dotNextServerRootFiles = await glob('.next/server/*', entryPath);
     const nodeModules = excludeFiles(
       await glob('node_modules/**', entryPath),
-      file => file.startsWith('node_modules/.cache'),
+      file => file.startsWith('node_modules/.cache')
     );
     const launcherFiles = {
       'now__bridge.js': new FileFsRef({ fsPath: require('@now/node-bridge') }),
     };
-    const nextFiles: {[key: string]: FileFsRef} = {
+    const nextFiles: { [key: string]: FileFsRef } = {
       ...nodeModules,
       ...dotNextRootFiles,
       ...dotNextServerRootFiles,
@@ -283,13 +301,13 @@ export const build = async ({
     }
     const pages = await glob(
       '**/*.js',
-      path.join(entryPath, '.next', 'server', 'static', buildId, 'pages'),
+      path.join(entryPath, '.next', 'server', 'static', buildId, 'pages')
     );
     const launcherPath = path.join(__dirname, 'legacy-launcher.js');
     const launcherData = await readFile(launcherPath, 'utf8');
 
     await Promise.all(
-      Object.keys(pages).map(async (page) => {
+      Object.keys(pages).map(async page => {
         // These default pages don't have to be handled as they'd always 404
         if (['_app.js', '_error.js', '_document.js'].includes(page)) {
           return;
@@ -298,7 +316,7 @@ export const build = async ({
         const pathname = page.replace(/\.js$/, '');
         const launcher = launcherData.replace(
           'PATHNAME_PLACEHOLDER',
-          `/${pathname.replace(/(^|\/)index$/, '')}`,
+          `/${pathname.replace(/(^|\/)index$/, '')}`
         );
 
         const pageFiles = {
@@ -327,7 +345,7 @@ export const build = async ({
           runtime: 'nodejs8.10',
         });
         console.log(`Created lambda for page: "${page}"`);
-      }),
+      })
     );
   } else {
     console.log('preparing lambda files...');
@@ -339,7 +357,7 @@ export const build = async ({
     };
     const pages = await glob(
       '**/*.js',
-      path.join(entryPath, '.next', 'serverless', 'pages'),
+      path.join(entryPath, '.next', 'serverless', 'pages')
     );
 
     const pageKeys = Object.keys(pages);
@@ -354,14 +372,14 @@ export const build = async ({
       }
 
       throw new Error(
-        'No serverless pages were built. https://err.sh/zeit/now-builders/now-next-no-serverless-pages-built',
+        'No serverless pages were built. https://err.sh/zeit/now-builders/now-next-no-serverless-pages-built'
       );
     }
 
     // An optional assets folder that is placed alongside every page entrypoint
     const assets = await glob(
       'assets/**',
-      path.join(entryPath, '.next', 'serverless'),
+      path.join(entryPath, '.next', 'serverless')
     );
 
     const assetKeys = Object.keys(assets);
@@ -371,7 +389,7 @@ export const build = async ({
     }
 
     await Promise.all(
-      pageKeys.map(async (page) => {
+      pageKeys.map(async page => {
         // These default pages don't have to be handled as they'd always 404
         if (['_app.js', '_error.js', '_document.js'].includes(page)) {
           return;
@@ -390,43 +408,48 @@ export const build = async ({
           runtime: 'nodejs8.10',
         });
         console.log(`Created lambda for page: "${page}"`);
-      }),
+      })
     );
   }
 
   const nextStaticFiles = await glob(
     '**',
-    path.join(entryPath, '.next', 'static'),
+    path.join(entryPath, '.next', 'static')
   );
   const staticFiles = Object.keys(nextStaticFiles).reduce(
     (mappedFiles, file) => ({
       ...mappedFiles,
-      [path.join(entryDirectory, `_next/static/${file}`)]: nextStaticFiles[file],
+      [path.join(entryDirectory, `_next/static/${file}`)]: nextStaticFiles[
+        file
+      ],
     }),
-    {},
+    {}
   );
 
   const staticDirectoryFiles = onlyStaticDirectory(
     includeOnlyEntryDirectory(files, entryDirectory),
-    entryDirectory,
+    entryDirectory
   );
 
   return {
     output: { ...lambdas, ...staticFiles, ...staticDirectoryFiles },
     routes: [],
     watch: [],
-    childProcesses: []
+    childProcesses: [],
   };
 };
 
-export const prepareCache = async ({ workPath, entrypoint }: PrepareCacheOptions) => {
+export const prepareCache = async ({
+  workPath,
+  entrypoint,
+}: PrepareCacheOptions) => {
   console.log('preparing cache ...');
   const entryDirectory = path.dirname(entrypoint);
   const entryPath = path.join(workPath, entryDirectory);
 
   const pkg = await readPackageJson(entryPath);
   const nextVersion = getNextVersion(pkg);
-  if (!nextVersion) throw new Error('Could not parse Next.js version')
+  if (!nextVersion) throw new Error('Could not parse Next.js version');
   const isLegacy = isLegacyNext(nextVersion);
 
   if (isLegacy) {


### PR DESCRIPTION
- fixed Prettier not running for TypeScript files
- adjusted Prettier config to match ESLint better (trailing comma)
- increased user script heap size to system memory - `128mb` reserve

Line of interest: https://github.com/zeit/now-builders/pull/419/files#diff-a4e14c2c5a53127f6f33ece5e544e848R254