### PR TITLE
Pass `meta` to `download()` of `@now/next`

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -160,7 +160,7 @@ export const build = async ({
   const dotNext = path.join(entryPath, '.next');
 
   console.log(`${name} Downloading user files...`);
-  await download(files, workPath);
+  await download(files, workPath, meta);
 
   const pkg = await readPackageJson(entryPath);
   const nextVersion = getNextVersion(pkg);


### PR DESCRIPTION
This makes https://github.com/zeit/now-builders/pull/416 work.