### PR TITLE
Set target env variable

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -257,6 +257,7 @@ export const build = async ({
     env: {
       ...process.env,
       NODE_OPTIONS: `--max_old_space_size=${memoryToConsume}`,
+      __NEXT_BUILDER_EXPERIMENTAL_TARGET: 'serverless',
     },
   } as SpawnOptions);
 


### PR DESCRIPTION
Set `__NEXT_BUILDER_EXPERIMENTAL_TARGET` to `serverless` so the user doesn't need to set it manually