### PR TITLE
Added missing `workPath` type property

### DIFF
--- a/packages/now-build-utils/src/types.ts
+++ b/packages/now-build-utils/src/types.ts
@@ -1,4 +1,4 @@
-import FileRef from "./file-ref";
+import FileRef from './file-ref';
 import FileFsRef from './file-fs-ref';
 
 export interface File {
@@ -9,11 +9,11 @@ export interface File {
 }
 
 export interface Files {
-  [filePath: string]: File
+  [filePath: string]: File;
 }
 
 export interface Config {
-  [key: string]: string
+  [key: string]: string;
 }
 
 export interface Meta {
@@ -29,7 +29,7 @@ export interface AnalyzeOptions {
    */
   files: {
     [filePath: string]: FileRef;
-  }
+  };
 
   /**
    * Name of entrypoint file for this particular build job. Value
@@ -51,7 +51,6 @@ export interface AnalyzeOptions {
    */
   config: Config;
 }
-
 
 export interface BuildOptions {
   /**
@@ -138,8 +137,14 @@ export interface ShouldServeOptions {
    * All source files of the project
    */
   files: {
-    [path: string]: FileFsRef
+    [path: string]: FileFsRef;
   };
+
+  /**
+   * A writable temporary directory where you are encouraged to perform your
+   * build process. This directory will be populated with the restored cache.
+   */
+  workPath: string;
 
   /**
    * An arbitrary object passed by the user in the build definition defined


### PR DESCRIPTION
The `workPath` property was missing from the `ShouldServeOptions`.