### PR TITLE
Add comment to fsPath about absolute path

### DIFF
--- a/packages/now-build-utils/src/types.ts
+++ b/packages/now-build-utils/src/types.ts
@@ -5,6 +5,9 @@ export interface File {
   type: string;
   mode: number;
   toStream: () => NodeJS.ReadableStream;
+  /**
+   * The absolute path to the file in the filesystem
+   */
   fsPath?: string;
 }
 


### PR DESCRIPTION
This will make it clear the `fsPath` is an absolute path, not a relative path.