### PR TITLE
Pipe stdio for Next.js in dev mode

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -124,6 +124,7 @@ function startDevServer(entryPath: string) {
     cwd: entryPath,
     execArgv: [],
     // This property name is weird, but it pipes stdio
+    // https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options
     silent: true,
     env: {
       NOW_REGION: 'dev1',

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -123,6 +123,8 @@ function startDevServer(entryPath: string) {
   const forked = fork(path.join(__dirname, 'dev-server.js'), [], {
     cwd: entryPath,
     execArgv: [],
+    // This property name is weird, but it pipes stdio
+    silent: true,
     env: {
       NOW_REGION: 'dev1',
     },


### PR DESCRIPTION
As per the [Node.js docs](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options), this property disables logging for the child and instead pipes it to parent.