### PR TITLE
[now-go] Improve speed for `now dev`

### DIFF
--- a/packages/now-go/go-helpers.ts
+++ b/packages/now-go/go-helpers.ts
@@ -122,7 +122,6 @@ export async function createGo(
   if (!isDev) {
     await createGoPathTree(goPath, platform, arch);
   }
-  await createGoPathTree(goPath, platform, arch);
   return new GoWrapper(env, opts);
 }
 

--- a/packages/now-go/go-helpers.ts
+++ b/packages/now-go/go-helpers.ts
@@ -125,6 +125,7 @@ export async function downloadGo(
 
   if (process.env.GOPATH === undefined && !isGoExist) {
     debug('Downloading `go` URL: %o', url);
+    console.log('Downloading Go ...');
     const res = await fetch(url);
 
     if (!res.ok) {

--- a/packages/now-go/go-helpers.ts
+++ b/packages/now-go/go-helpers.ts
@@ -121,27 +121,31 @@ export async function downloadGo(
   debug('Installing `go` v%s to %o for %s %s', version, dir, platform, arch);
 
   const url = getGoUrl(version, platform, arch);
-  const isGoExist = await pathExists(join(dir, 'bin', 'go'));
 
-  if (process.env.GOPATH === undefined && !isGoExist) {
-    debug('Downloading `go` URL: %o', url);
-    console.log('Downloading Go ...');
-    const res = await fetch(url);
+  // if we found GOPATH in ENV, use it
+  if (process.env.GOPATH !== undefined) {
+    return createGo(dir, platform, arch);
+  } else {
+    const isGoExist = await pathExists(join(dir, 'bin'));
+    if (!isGoExist) {
+      debug('Downloading `go` URL: %o', url);
+      console.log('Downloading Go ...');
+      const res = await fetch(url);
 
-    if (!res.ok) {
-      throw new Error(`Failed to download: ${url} (${res.status})`);
+      if (!res.ok) {
+        throw new Error(`Failed to download: ${url} (${res.status})`);
+      }
+
+      // TODO: use a zip extractor when `ext === "zip"`
+      await mkdirp(dir);
+      await new Promise((resolve, reject) => {
+        res.body
+          .on('error', reject)
+          .pipe(tar.extract({ cwd: dir, strip: 1 }))
+          .on('error', reject)
+          .on('finish', resolve);
+      });
     }
-
-    // TODO: use a zip extractor when `ext === "zip"`
-    await mkdirp(dir);
-    await new Promise((resolve, reject) => {
-      res.body
-        .on('error', reject)
-        .pipe(tar.extract({ cwd: dir, strip: 1 }))
-        .on('error', reject)
-        .on('finish', resolve);
-    });
+    return createGo(dir, platform, arch);
   }
-
-  return createGo(dir, platform, arch);
 }

--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -61,11 +61,7 @@ export async function build({
   console.log(`Parsing AST for "${entrypoint}"`);
   let analyzed: string;
   try {
-    analyzed = await getAnalyzedEntrypoint(
-      downloadedFiles[entrypoint].fsPath,
-      goPath,
-      meta.isDev
-    );
+    analyzed = await getAnalyzedEntrypoint(downloadedFiles[entrypoint].fsPath);
   } catch (err) {
     console.log(`Failed to parse AST for "${entrypoint}"`);
     throw err;
@@ -101,8 +97,7 @@ export async function build({
       {
         cwd: entrypointDirname,
       },
-      true,
-      meta.isDev
+      true
     );
     if (!isGoModExist) {
       try {
@@ -225,8 +220,7 @@ export async function build({
       {
         cwd: entrypointDirname,
       },
-      false,
-      meta.isDev
+      false
     );
     const origianlMainGoContents = await readFile(
       join(__dirname, 'main.go'),

--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -8,7 +8,7 @@ import {
   getWriteableDirectory,
   BuildOptions,
   shouldServe,
-  Files
+  Files,
 } from '@now/build-utils';
 
 import { createGo, getAnalyzedEntrypoint } from './go-helpers';
@@ -61,7 +61,11 @@ export async function build({
   console.log(`Parsing AST for "${entrypoint}"`);
   let analyzed: string;
   try {
-    analyzed = await getAnalyzedEntrypoint(downloadedFiles[entrypoint].fsPath);
+    analyzed = await getAnalyzedEntrypoint(
+      downloadedFiles[entrypoint].fsPath,
+      goPath,
+      meta.isDev
+    );
   } catch (err) {
     console.log(`Failed to parse AST for "${entrypoint}"`);
     throw err;
@@ -97,7 +101,8 @@ export async function build({
       {
         cwd: entrypointDirname,
       },
-      true
+      true,
+      meta.isDev
     );
     if (!isGoModExist) {
       try {
@@ -220,7 +225,8 @@ export async function build({
       {
         cwd: entrypointDirname,
       },
-      false
+      false,
+      meta.isDev
     );
     const origianlMainGoContents = await readFile(
       join(__dirname, 'main.go'),


### PR DESCRIPTION
This will make `@now/go` faster for `now dev`.

- if user have `Go` in their dev machine, we use that.
- if user don't have `Go`, download it once, and reuse it.