### PR TITLE
[now-build-utils] Wait for the dev server to print the URL with correct port number

### DIFF
--- a/packages/now-static-build/package.json
+++ b/packages/now-static-build/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "get-port": "5.0.0",
-    "promise-timeout": "1.3.0",
-    "wait-for-port": "0.0.2"
+    "promise-timeout": "1.3.0"
   }
 }


### PR DESCRIPTION
This is an alternative approach to detecting when the dev server is ready to receive HTTP traffic, also bumps the timeout to 5 minutes.