### PR TITLE
[now-node] 'config.includeFiles' accepts a string

### DIFF
--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -14,11 +14,11 @@ import {
 } from '@now/build-utils';
 
 interface CompilerConfig {
-  includeFiles?: string[]
+  includeFiles?: string | string[];
 }
 
 interface DownloadOptions {
-  files: Files,
+  files: Files;
   entrypoint: string;
   workPath: string;
   npmArguments?: string[];
@@ -28,7 +28,7 @@ async function downloadInstallAndBundle({
   files,
   entrypoint,
   workPath,
-  npmArguments = []
+  npmArguments = [],
 }: DownloadOptions) {
   console.log('downloading user files...');
   const downloadedFiles = await download(files, workPath);
@@ -41,15 +41,27 @@ async function downloadInstallAndBundle({
   return { entrypointPath, entrypointFsDirname };
 }
 
-async function compile(entrypointPath: string, entrypoint: string, config: CompilerConfig): Promise<Files> {
+async function compile(
+  entrypointPath: string,
+  entrypoint: string,
+  config: CompilerConfig
+): Promise<Files> {
   const input = entrypointPath;
   const inputDir = dirname(input);
   const rootIncludeFiles = inputDir.split(sep).pop() || '';
   const ncc = require('@zeit/ncc');
-  const { code, map, assets } = await ncc(input, { sourceMap: true, sourceMapRegister: true });
+  const { code, map, assets } = await ncc(input, {
+    sourceMap: true,
+    sourceMapRegister: true,
+  });
 
   if (config && config.includeFiles) {
-    for (const pattern of config.includeFiles) {
+    const includeFiles =
+      typeof config.includeFiles === 'string'
+        ? [config.includeFiles]
+        : config.includeFiles;
+
+    for (const pattern of includeFiles) {
       const files = await glob(pattern, inputDir);
 
       for (const assetName of Object.keys(files)) {
@@ -61,12 +73,12 @@ async function compile(entrypointPath: string, entrypoint: string, config: Compi
         // if asset contain directory
         // no need to use `rootIncludeFiles`
         if (assetName.includes(sep)) {
-          fullPath = assetName
+          fullPath = assetName;
         }
 
         assets[fullPath] = {
-          'source': data,
-          'permissions': mode
+          source: data,
+          permissions: mode,
         };
       }
     }
@@ -75,7 +87,9 @@ async function compile(entrypointPath: string, entrypoint: string, config: Compi
   const preparedFiles: Files = {};
   // move all user code to 'user' subdirectory
   preparedFiles[entrypoint] = new FileBlob({ data: code });
-  preparedFiles[`${entrypoint.replace('.ts', '.js')}.map`] = new FileBlob({ data: map });
+  preparedFiles[`${entrypoint.replace('.ts', '.js')}.map`] = new FileBlob({
+    data: map,
+  });
   // eslint-disable-next-line no-restricted-syntax
   for (const assetName of Object.keys(assets)) {
     const { source: data, permissions: mode } = assets[assetName];
@@ -87,16 +101,24 @@ async function compile(entrypointPath: string, entrypoint: string, config: Compi
 }
 
 export const config = {
-  maxLambdaSize: '5mb'
+  maxLambdaSize: '5mb',
 };
 
-export async function build({ files, entrypoint, workPath, config }: BuildOptions) {
+export async function build({
+  files,
+  entrypoint,
+  workPath,
+  config,
+}: BuildOptions) {
   const {
     entrypointPath,
-    entrypointFsDirname
-  } = await downloadInstallAndBundle(
-    { files, entrypoint, workPath, npmArguments: ['--prefer-offline'] }
-  );
+    entrypointFsDirname,
+  } = await downloadInstallAndBundle({
+    files,
+    entrypoint,
+    workPath,
+    npmArguments: ['--prefer-offline'],
+  });
 
   console.log('running user script...');
   await runPackageJsonScript(entrypointFsDirname, 'now-build');
@@ -110,19 +132,19 @@ export async function build({ files, entrypoint, workPath, config }: BuildOption
     '// PLACEHOLDER',
     [
       `listener = require("./${entrypoint}");`,
-      'if (listener.default) listener = listener.default;'
+      'if (listener.default) listener = listener.default;',
     ].join(' ')
   );
 
   const launcherFiles = {
     'launcher.js': new FileBlob({ data: launcherData }),
-    'bridge.js': new FileFsRef({ fsPath: require('@now/node-bridge') })
+    'bridge.js': new FileFsRef({ fsPath: require('@now/node-bridge') }),
   };
 
   const lambda = await createLambda({
     files: { ...preparedFiles, ...launcherFiles },
     handler: 'launcher.launcher',
-    runtime: 'nodejs8.10'
+    runtime: 'nodejs8.10',
   });
 
   return { [entrypoint]: lambda };
@@ -132,6 +154,6 @@ export async function prepareCache({ workPath }: PrepareCacheOptions) {
   return {
     ...(await glob('node_modules/**', workPath)),
     ...(await glob('package-lock.json', workPath)),
-    ...(await glob('yarn.lock', workPath))
+    ...(await glob('yarn.lock', workPath)),
   };
 }

--- a/packages/now-node/test/fixtures/09-include-files/accepts-string.js
+++ b/packages/now-node/test/fixtures/09-include-files/accepts-string.js
@@ -1,0 +1,7 @@
+const edge = require('edge.js');
+
+module.exports = (req, resp) => {
+  edge.registerViews('templates');
+
+  resp.end(edge.render('accepts-string', { name: 'String!' }));
+};

--- a/packages/now-node/test/fixtures/09-include-files/now.json
+++ b/packages/now-node/test/fixtures/09-include-files/now.json
@@ -18,12 +18,23 @@
           "root.edge"
         ]
       }
+    },
+    {
+      "src": "accepts-string.js",
+      "use": "@now/node",
+      "config": {
+        "includeFiles": "templates/accepts-string.edge"
+      }
     }
   ],
   "probes": [
     {
       "path": "/",
       "mustContain": "hello Now!"
+    },
+    {
+      "path": "/accepts-string.js",
+      "mustContain": "hello String!"
     },
     {
       "path": "/root.js",

--- a/packages/now-node/test/fixtures/09-include-files/templates/accepts-string.edge
+++ b/packages/now-node/test/fixtures/09-include-files/templates/accepts-string.edge
@@ -1,0 +1,1 @@
+hello {{ name }}


### PR DESCRIPTION
For the record, most of the changes in `index.ts` have been made automatically by the linter. Actual modifications I've made are located at lines [17](https://github.com/flawyte/now-builders/blob/bea5dee215ff5f7386fde456d4a00db4712b9d91/packages/now-node/src/index.ts#L17) and [59-64](https://github.com/flawyte/now-builders/blob/bea5dee215ff5f7386fde456d4a00db4712b9d91/packages/now-node/src/index.ts#L59-L64).

I could have refactored the code in the loop to an independent function that would be called directly if `includeFiles` is a string, and otherwise called within the loop, but I though that just turning `includeFiles` into an array if it's a string and then let the loop do the job like before would be simpler and overall better.

Please let me know if there's anything missing.