### PR TITLE
[now-static-build] Warn when now-dev script is missing

### DIFF
--- a/packages/now-static-build/index.js
+++ b/packages/now-static-build/index.js
@@ -103,6 +103,9 @@ exports.build = async ({
         dest: `http://localhost:${devPort}${srcBase}/$1`,
       });
     } else {
+      if (meta.isDev) {
+        console.log('WARN: "now-dev" script is missing from package.json');
+      }
       // Run the `now-build` script and wait for completion to collect the build
       // outputs
       console.log('running user "now-build" script from `package.json`...');

--- a/packages/now-static-build/index.js
+++ b/packages/now-static-build/index.js
@@ -15,7 +15,7 @@ function validateDistDir(distDir) {
   const distDirName = path.basename(distDir);
   if (!existsSync(distDir)) {
     const message = `Build was unable to create the distDir: ${distDirName}.`
-      + '\nMake sure you mentioned the correct dist directory: https://zeit.co/docs/v2/deployments/official-builders/static-build-now-static-build/#configuring-the-build-output-directory';
+      + '\nMake sure you mentioned the correct dist directory: https://zeit.co/docs/v2/deployments/official-builders/static-build-now-static-build/#local-development';
     throw new Error(message);
   }
 }

--- a/packages/now-static-build/index.js
+++ b/packages/now-static-build/index.js
@@ -106,7 +106,7 @@ exports.build = async ({
       if (meta.isDev) {
         console.log('WARN: "now-dev" script is missing from package.json');
         console.log(
-          'See local development docs http://zeit.co/docs/v2/deployments/official-builders/static-now-static#local-development',
+          'See the local development docs: http://zeit.co/docs/v2/deployments/official-builders/static-now-static#local-development',
         );
       }
       // Run the `now-build` script and wait for completion to collect the build

--- a/packages/now-static-build/index.js
+++ b/packages/now-static-build/index.js
@@ -105,6 +105,9 @@ exports.build = async ({
     } else {
       if (meta.isDev) {
         console.log('WARN: "now-dev" script is missing from package.json');
+        console.log(
+          'See local development docs http://zeit.co/docs/v2/deployments/official-builders/static-now-static#local-development',
+        );
       }
       // Run the `now-build` script and wait for completion to collect the build
       // outputs


### PR DESCRIPTION
This will print a warning so that the user knows about the `now-dev` script in package.json is the preferred way to develop.