### PR TITLE
[now-static-build] Fix @now/static-build nested build

### DIFF
--- a/packages/now-static-build/index.js
+++ b/packages/now-static-build/index.js
@@ -58,6 +58,7 @@ exports.build = async ({
         devPort = await getPort();
         nowDevScriptPorts.set(entrypoint, devPort);
         const opts = {
+          cwd: entrypointFsDirname,
           env: { ...process.env, PORT: String(devPort) },
         };
         const child = spawn('yarn', ['run', 'now-dev'], opts);


### PR DESCRIPTION
Hi, I have encountered an issue with @now/static-build described at https://spectrum.chat/zeit/now/issue-with-now-static-build-builder~08b8ad28-bbba-47a0-82e8-812cdcc65cc6

TL/DR, when package.json resides in a directory, `now dev` fails.

I _think_ I have found the issue, but I would need help testing it guys. I literally have no idea how testing this might work.

Thanks!