### PR TITLE
[now-build-utils] Fix EMFILE by wrapping FS calls

### DIFF
--- a/packages/now-build-utils/package.json
+++ b/packages/now-build-utils/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@types/cross-spawn": "6.0.0",
     "async-retry": "1.2.3",
-    "async-sema": "2.1.4",
+    "async-sema": "3.0.0",
     "cross-spawn": "6.0.5",
     "end-of-stream": "1.4.1",
     "fs-extra": "7.0.0",

--- a/packages/now-build-utils/src/file-fs-ref.ts
+++ b/packages/now-build-utils/src/file-fs-ref.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import fs from 'fs-extra';
 import multiStream from 'multistream';
 import path from 'path';
-import Sema from 'async-sema';
+import { Sema } from 'async-sema';
 import { File } from './types';
 
 const semaToPreventEMFILE = new Sema(20);
@@ -31,7 +31,10 @@ class FileFsRef implements File {
     this.fsPath = fsPath;
   }
 
-  static async fromFsPath({ mode, fsPath }: FileFsRefOptions): Promise<FileFsRef> {
+  static async fromFsPath({
+    mode,
+    fsPath,
+  }: FileFsRefOptions): Promise<FileFsRef> {
     let m = mode;
     if (!m) {
       const stat = await fs.lstat(fsPath);
@@ -40,7 +43,11 @@ class FileFsRef implements File {
     return new FileFsRef({ mode: m, fsPath });
   }
 
-  static async fromStream({ mode = 0o100644, stream, fsPath }: FromStreamOptions): Promise<FileFsRef> {
+  static async fromStream({
+    mode = 0o100644,
+    stream,
+    fsPath,
+  }: FromStreamOptions): Promise<FileFsRef> {
     assert(typeof mode === 'number');
     assert(typeof stream.pipe === 'function'); // is-stream
     assert(typeof fsPath === 'string');
@@ -48,7 +55,7 @@ class FileFsRef implements File {
 
     await new Promise<void>((resolve, reject) => {
       const dest = fs.createWriteStream(fsPath, {
-        mode: mode & 0o777
+        mode: mode & 0o777,
       });
       stream.pipe(dest);
       stream.on('error', reject);
@@ -72,15 +79,15 @@ class FileFsRef implements File {
     let flag = false;
 
     // eslint-disable-next-line consistent-return
-    return multiStream((cb) => {
+    return multiStream(cb => {
       if (flag) return cb(null, null);
       flag = true;
 
       this.toStreamAsync()
-        .then((stream) => {
+        .then(stream => {
           cb(null, stream);
         })
-        .catch((error) => {
+        .catch(error => {
           cb(error, null);
         });
     });

--- a/packages/now-build-utils/src/file-ref.ts
+++ b/packages/now-build-utils/src/file-ref.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import fetch from 'node-fetch';
 import multiStream from 'multistream';
 import retry from 'async-retry';
-import Sema from 'async-sema';
+import { Sema } from 'async-sema';
 import { File } from './types';
 
 interface FileRefOptions {
@@ -58,14 +58,14 @@ export default class FileRef implements File {
           const resp = await fetch(url);
           if (!resp.ok) {
             const error = new BailableError(
-              `download: ${resp.status} ${resp.statusText} for ${url}`,
+              `download: ${resp.status} ${resp.statusText} for ${url}`
             );
             if (resp.status === 403) error.bail = true;
             throw error;
           }
           return resp.body;
         },
-        { factor: 1, retries: 3 },
+        { factor: 1, retries: 3 }
       );
     } finally {
       // console.timeEnd(`downloading ${url}`);
@@ -77,15 +77,15 @@ export default class FileRef implements File {
     let flag = false;
 
     // eslint-disable-next-line consistent-return
-    return multiStream((cb) => {
+    return multiStream(cb => {
       if (flag) return cb(null, null);
       flag = true;
 
       this.toStreamAsync()
-        .then((stream) => {
+        .then(stream => {
           cb(null, stream);
         })
-        .catch((error) => {
+        .catch(error => {
           cb(error, null);
         });
     });

--- a/packages/now-build-utils/src/fs/fs-sema.ts
+++ b/packages/now-build-utils/src/fs/fs-sema.ts
@@ -10,7 +10,7 @@ import {
   readFile as readFile1,
   Stats,
 } from 'fs-extra';
-import Sema from 'async-sema';
+import { Sema } from 'async-sema';
 
 const sema = new Sema(20);
 

--- a/packages/now-build-utils/src/fs/fs-sema.ts
+++ b/packages/now-build-utils/src/fs/fs-sema.ts
@@ -1,0 +1,32 @@
+import {
+  remove as remove1,
+  mkdirp as mkdirp1,
+  readlink as readlink1,
+  symlink as symlink1,
+} from 'fs-extra';
+import Sema from 'async-sema';
+
+const sema = new Sema(20);
+
+export async function remove(dir: string) {
+  await sema.acquire();
+  return remove1(dir);
+}
+
+export async function mkdirp(dir: string) {
+  await sema.acquire();
+  return mkdirp1(dir);
+}
+
+export async function readlink(path: string | Buffer) {
+  await sema.acquire();
+  return readlink1(path);
+}
+
+export async function symlink(
+  srcpath: string | Buffer,
+  dstpath: string | Buffer
+) {
+  await sema.acquire();
+  return symlink1(srcpath, dstpath);
+}

--- a/packages/now-build-utils/src/fs/fs-sema.ts
+++ b/packages/now-build-utils/src/fs/fs-sema.ts
@@ -3,24 +3,44 @@ import {
   mkdirp as mkdirp1,
   readlink as readlink1,
   symlink as symlink1,
+  lstat as lstat1,
+  stat as stat1,
+  chmod as chmod1,
+  pathExists as pathExists1,
+  readFile as readFile1,
+  Stats,
 } from 'fs-extra';
 import Sema from 'async-sema';
 
 const sema = new Sema(20);
 
+export { Stats };
+
 export async function remove(dir: string) {
   await sema.acquire();
-  return remove1(dir);
+  try {
+    return remove1(dir);
+  } finally {
+    sema.release();
+  }
 }
 
 export async function mkdirp(dir: string) {
   await sema.acquire();
-  return mkdirp1(dir);
+  try {
+    return mkdirp1(dir);
+  } finally {
+    sema.release();
+  }
 }
 
 export async function readlink(path: string | Buffer) {
   await sema.acquire();
-  return readlink1(path);
+  try {
+    return readlink1(path);
+  } finally {
+    sema.release();
+  }
 }
 
 export async function symlink(
@@ -28,5 +48,57 @@ export async function symlink(
   dstpath: string | Buffer
 ) {
   await sema.acquire();
-  return symlink1(srcpath, dstpath);
+  try {
+    return symlink1(srcpath, dstpath);
+  } finally {
+    sema.release();
+  }
+}
+
+export async function lstat(path: string | Buffer) {
+  await sema.acquire();
+  try {
+    return lstat1(path);
+  } finally {
+    sema.release();
+  }
+}
+
+export async function stat(path: string | Buffer) {
+  await sema.acquire();
+  try {
+    return stat1(path);
+  } finally {
+    sema.release();
+  }
+}
+
+export async function chmod(path: string | Buffer, mode: string | number) {
+  await sema.acquire();
+  try {
+    return chmod1(path, mode);
+  } finally {
+    sema.release();
+  }
+}
+
+export async function pathExists(path: string) {
+  await sema.acquire();
+  try {
+    return pathExists1(path);
+  } finally {
+    sema.release();
+  }
+}
+
+export async function readFile(
+  file: string | number | Buffer,
+  encoding: string
+) {
+  await sema.acquire();
+  try {
+    return readFile1(file, encoding);
+  } finally {
+    sema.release();
+  }
 }

--- a/packages/now-build-utils/src/fs/get-writable-directory.ts
+++ b/packages/now-build-utils/src/fs/get-writable-directory.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { mkdirp } from 'fs-extra';
+import { mkdirp } from './fs-sema';
 
 export default async function getWritableDirectory() {
   const name = Math.floor(Math.random() * 0x7fffffff).toString(16);

--- a/packages/now-build-utils/src/fs/glob.ts
+++ b/packages/now-build-utils/src/fs/glob.ts
@@ -2,18 +2,22 @@ import path from 'path';
 import assert from 'assert';
 import vanillaGlob_ from 'glob';
 import { promisify } from 'util';
-import { lstat, Stats } from 'fs-extra';
+import { lstat, Stats } from './fs-sema';
 import FileFsRef from '../file-fs-ref';
 
 type GlobOptions = vanillaGlob_.IOptions;
 
 interface FsFiles {
-  [filePath: string]: FileFsRef
+  [filePath: string]: FileFsRef;
 }
 
 const vanillaGlob = promisify(vanillaGlob_);
 
-export default async function glob(pattern: string, opts: GlobOptions | string, mountpoint?: string): Promise<FsFiles> {
+export default async function glob(
+  pattern: string,
+  opts: GlobOptions | string,
+  mountpoint?: string
+): Promise<FsFiles> {
   let options: GlobOptions;
   if (typeof opts === 'string') {
     options = { cwd: opts };
@@ -23,7 +27,7 @@ export default async function glob(pattern: string, opts: GlobOptions | string, 
 
   if (!options.cwd) {
     throw new Error(
-      'Second argument (basePath) must be specified for names of resulting files',
+      'Second argument (basePath) must be specified for names of resulting files'
     );
   }
 
@@ -45,7 +49,7 @@ export default async function glob(pattern: string, opts: GlobOptions | string, 
     let stat: Stats = options.statCache![fsPath] as Stats;
     assert(
       stat,
-      `statCache does not contain value for ${relativePath} (resolved to ${fsPath})`,
+      `statCache does not contain value for ${relativePath} (resolved to ${fsPath})`
     );
     if (stat.isFile()) {
       const isSymlink = options.symlinks![fsPath];

--- a/packages/now-build-utils/src/fs/run-user-scripts.ts
+++ b/packages/now-build-utils/src/fs/run-user-scripts.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import fs from 'fs-extra';
+import { stat, chmod, pathExists, readFile } from './fs-sema';
 import path from 'path';
 import spawn from 'cross-spawn';
 import { SpawnOptions } from 'child_process';
@@ -36,11 +36,11 @@ function spawnAsync(
 }
 
 async function chmodPlusX(fsPath: string) {
-  const s = await fs.stat(fsPath);
+  const s = await stat(fsPath);
   const newMode = s.mode | 64 | 8 | 1; // eslint-disable-line no-bitwise
   if (s.mode === newMode) return;
   const base8 = newMode.toString(8).slice(-3);
-  await fs.chmod(fsPath, base8);
+  await chmod(fsPath, base8);
 }
 
 export async function runShellScript(fsPath: string) {
@@ -62,16 +62,14 @@ async function scanParentDirs(destPath: string, scriptName?: string) {
   while (true) {
     const packageJsonPath = path.join(currentDestPath, 'package.json');
     // eslint-disable-next-line no-await-in-loop
-    if (await fs.pathExists(packageJsonPath)) {
+    if (await pathExists(packageJsonPath)) {
       // eslint-disable-next-line no-await-in-loop
-      const packageJson = JSON.parse(
-        await fs.readFile(packageJsonPath, 'utf8')
-      );
+      const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'));
       hasScript = Boolean(
         packageJson.scripts && scriptName && packageJson.scripts[scriptName]
       );
       // eslint-disable-next-line no-await-in-loop
-      hasPackageLockJson = await fs.pathExists(
+      hasPackageLockJson = await pathExists(
         path.join(currentDestPath, 'package-lock.json')
       );
       break;

--- a/packages/now-build-utils/src/lambda.ts
+++ b/packages/now-build-utils/src/lambda.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import Sema from 'async-sema';
+import { Sema } from 'async-sema';
 import { ZipFile } from 'yazl';
 import { readlink } from './fs/fs-sema';
 import { Files } from './types';

--- a/packages/now-build-utils/src/lambda.ts
+++ b/packages/now-build-utils/src/lambda.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import Sema from 'async-sema';
 import { ZipFile } from 'yazl';
-import { readlink } from 'fs-extra';
+import { readlink } from './fs/fs-sema';
 import { Files } from './types';
 import FileFsRef from './file-fs-ref';
 import { isSymbolicLink } from './fs/download';
@@ -32,9 +32,7 @@ export class Lambda {
   public runtime: string;
   public environment: Environment;
 
-  constructor({
-    zipBuffer, handler, runtime, environment,
-  }: LambdaOptions) {
+  constructor({ zipBuffer, handler, runtime, environment }: LambdaOptions) {
     this.type = 'Lambda';
     this.zipBuffer = zipBuffer;
     this.handler = handler;
@@ -47,7 +45,10 @@ const sema = new Sema(10);
 const mtime = new Date(1540000000000);
 
 export async function createLambda({
-  files, handler, runtime, environment = {},
+  files,
+  handler,
+  runtime,
+  environment = {},
 }: CreateLambdaOptions): Promise<Lambda> {
   assert(typeof files === 'object', '"files" must be an object');
   assert(typeof handler === 'string', '"handler" is not a string');
@@ -97,7 +98,9 @@ export async function createZip(files: Files): Promise<Buffer> {
     }
 
     zipFile.end();
-    streamToBuffer(zipFile.outputStream).then(resolve).catch(reject);
+    streamToBuffer(zipFile.outputStream)
+      .then(resolve)
+      .catch(reject);
   });
 
   return zipBuffer;

--- a/packages/now-build-utils/src/types.ts
+++ b/packages/now-build-utils/src/types.ts
@@ -2,7 +2,7 @@ import FileRef from './file-ref';
 import FileFsRef from './file-fs-ref';
 
 export interface File {
-  type: string;
+  type: 'FileFsRef' | 'FileRef' | 'FileBlob';
   mode: number;
   toStream: () => NodeJS.ReadableStream;
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1459,12 +1459,10 @@ async-retry@1.2.3:
   dependencies:
     retry "0.12.0"
 
-async-sema@2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/async-sema/-/async-sema-2.1.4.tgz#3f5aa091d0a763354045ee899a5d17ffb69251af"
-  integrity sha512-NKdMgXT9RfmkscybzytzK/6uGF4cL8Mt3PSeO9QHXYKs3oFWkUwIepnAkzLWkqttOdDDFoED3c8kriS8RzP+ow==
-  dependencies:
-    double-ended-queue "2.1.0-0"
+async-sema@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/async-sema/-/async-sema-3.0.0.tgz#9e22d6783f0ab66a1cf330e21a905e39b3b3a975"
+  integrity sha512-zyCMBDl4m71feawrxYcVbHxv/UUkqm4nKJiLu3+l9lfiQha6jQ/9dxhrXLnzzBXVFqCTDwiUkZOz9XFbdEGQsg==
 
 async@^2.1.4, async@^2.5.0:
   version "2.6.1"
@@ -2938,11 +2936,6 @@ dot-prop@^4.2.0:
   integrity sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==
   dependencies:
     is-obj "^1.0.0"
-
-double-ended-queue@2.1.0-0:
-  version "2.1.0-0"
-  resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
-  integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
 
 download@^4.0.0, download@^4.1.2:
   version "4.4.3"


### PR DESCRIPTION
Fixes #451

We use `Sema` in the `File` toStream() calls but we don't use it for symlinks or any other FileSystem calls.

This wraps `fs-extra` to prevent `EMFILE` errors.

I also bumped `async-sema` to the latest version.