### PR TITLE
Add default `shouldServe()` to appropriate builders

### DIFF
--- a/packages/now-bash/index.js
+++ b/packages/now-bash/index.js
@@ -1,10 +1,13 @@
 const execa = require('execa');
 const { join } = require('path');
 const snakeCase = require('snake-case');
-const glob = require('@now/build-utils/fs/glob'); // eslint-disable-line import/no-extraneous-dependencies
-const download = require('@now/build-utils/fs/download'); // eslint-disable-line import/no-extraneous-dependencies
-const { createLambda } = require('@now/build-utils/lambda'); // eslint-disable-line import/no-extraneous-dependencies
-const getWritableDirectory = require('@now/build-utils/fs/get-writable-directory'); // eslint-disable-line import/no-extraneous-dependencies
+const {
+  glob,
+  download,
+  createLambda,
+  getWriteableDirectory,
+  shouldServe,
+} = require('@now/build-utils'); // eslint-disable-line import/no-extraneous-dependencies
 
 exports.config = {
   maxLambdaSize: '10mb',
@@ -15,7 +18,7 @@ exports.analyze = ({ files, entrypoint }) => files[entrypoint].digest;
 exports.build = async ({
   workPath, files, entrypoint, config,
 }) => {
-  const srcDir = await getWritableDirectory();
+  const srcDir = await getWriteableDirectory();
 
   console.log('downloading files...');
   await download(files, srcDir);
@@ -55,3 +58,5 @@ exports.build = async ({
     [entrypoint]: lambda,
   };
 };
+
+exports.shouldServe = shouldServe;

--- a/packages/now-cgi/index.js
+++ b/packages/now-cgi/index.js
@@ -5,6 +5,7 @@ const glob = require('@now/build-utils/fs/glob'); // eslint-disable-line import/
 const download = require('@now/build-utils/fs/download'); // eslint-disable-line import/no-extraneous-dependencies
 const { createLambda } = require('@now/build-utils/lambda'); // eslint-disable-line import/no-extraneous-dependencies
 const getWritableDirectory = require('@now/build-utils/fs/get-writable-directory'); // eslint-disable-line import/no-extraneous-dependencies
+const { shouldServe } = require('@now/build-utils'); // eslint-disable-line import/no-extraneous-dependencies
 
 exports.analyze = ({ files, entrypoint }) => files[entrypoint].digest;
 
@@ -40,3 +41,5 @@ exports.build = async ({ files, entrypoint }) => {
     [entrypoint]: lambda,
   };
 };
+
+exports.shouldServe = shouldServe;

--- a/packages/now-html-minifier/index.js
+++ b/packages/now-html-minifier/index.js
@@ -1,4 +1,4 @@
-const FileBlob = require('@now/build-utils/file-blob.js'); // eslint-disable-line import/no-extraneous-dependencies
+const { FileBlob, shouldServe } = require('@now/build-utils'); // eslint-disable-line import/no-extraneous-dependencies
 const { minify } = require('html-minifier');
 
 const defaultOptions = {
@@ -28,3 +28,5 @@ exports.build = async ({ files, entrypoint, config }) => {
 
   return { [entrypoint]: result };
 };
+
+exports.shouldServe = shouldServe;

--- a/packages/now-lambda/index.js
+++ b/packages/now-lambda/index.js
@@ -1,5 +1,6 @@
 const { Lambda } = require('@now/build-utils/lambda.js'); // eslint-disable-line import/no-extraneous-dependencies
 const streamToBuffer = require('@now/build-utils/fs/stream-to-buffer.js'); // eslint-disable-line import/no-extraneous-dependencies
+const { shouldServe } = require('@now/build-utils'); // eslint-disable-line import/no-extraneous-dependencies
 
 exports.build = async ({ files, entrypoint, config }) => {
   if (!files[entrypoint]) throw new Error('Entrypoint not found in files');
@@ -10,3 +11,5 @@ exports.build = async ({ files, entrypoint, config }) => {
   const lambda = new Lambda({ zipBuffer, handler, runtime });
   return { [entrypoint]: lambda };
 };
+
+exports.shouldServe = shouldServe;

--- a/packages/now-md/index.js
+++ b/packages/now-md/index.js
@@ -1,4 +1,4 @@
-const FileBlob = require('@now/build-utils/file-blob.js'); // eslint-disable-line import/no-extraneous-dependencies
+const { FileBlob, shouldServe } = require('@now/build-utils'); // eslint-disable-line import/no-extraneous-dependencies
 const unified = require('unified');
 const unifiedStream = require('unified-stream');
 const markdown = require('remark-parse');
@@ -38,3 +38,5 @@ exports.build = async ({ files, entrypoint, config }) => {
 
   return { [replacedEntrypoint]: result };
 };
+
+exports.shouldServe = shouldServe;

--- a/packages/now-node-server/index.js
+++ b/packages/now-node-server/index.js
@@ -9,6 +9,7 @@ const {
   runNpmInstall,
   runPackageJsonScript,
 } = require('@now/build-utils/fs/run-user-scripts.js'); // eslint-disable-line import/no-extraneous-dependencies
+const { shouldServe } = require('@now/build-utils'); // eslint-disable-line import/no-extraneous-dependencies
 
 /** @typedef { import('@now/build-utils/file-ref') } FileRef */
 /** @typedef {{[filePath: string]: FileRef}} Files */
@@ -145,3 +146,5 @@ exports.prepareCache = async ({ workPath }) => ({
   ...(await glob('package-lock.json', workPath)),
   ...(await glob('yarn.lock', workPath)),
 });
+
+exports.shouldServe = shouldServe;

--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -11,6 +11,7 @@ import {
   runPackageJsonScript,
   PrepareCacheOptions,
   BuildOptions,
+  shouldServe,
 } from '@now/build-utils';
 
 interface CompilerConfig {
@@ -157,3 +158,5 @@ export async function prepareCache({ workPath }: PrepareCacheOptions) {
     ...(await glob('yarn.lock', workPath)),
   };
 }
+
+export { shouldServe };

--- a/packages/now-optipng/src/index.ts
+++ b/packages/now-optipng/src/index.ts
@@ -1,13 +1,14 @@
 // eslint-disable-line import/no-extraneous-dependencies
-import { 
+import {
   FileBlob,
   BuildOptions,
-  AnalyzeOptions
-} from '@now/build-utils'
-import OptiPng from 'optipng'
-import pipe from 'multipipe'
+  AnalyzeOptions,
+  shouldServe,
+} from '@now/build-utils';
+import OptiPng from 'optipng';
+import pipe from 'multipipe';
 
-export function analyze({ files, entrypoint }: AnalyzeOptions) {
+export function analyze({ files, entrypoint }: AnalyzeOptions) {
   return files[entrypoint].digest;
 }
 
@@ -20,3 +21,5 @@ export async function build({ files, entrypoint }: BuildOptions) {
   const result = await FileBlob.fromStream({ stream });
   return { [entrypoint]: result };
 }
+
+export { shouldServe };

--- a/packages/now-php/index.js
+++ b/packages/now-php/index.js
@@ -1,5 +1,9 @@
 const {
-  createLambda, rename, glob, download,
+  createLambda,
+  rename,
+  glob,
+  download,
+  shouldServe,
 } = require('@now/build-utils'); // eslint-disable-line import/no-extraneous-dependencies
 const path = require('path');
 const { getFiles } = require('@now/php-bridge');
@@ -52,3 +56,5 @@ exports.build = async ({
 
   return { [entrypoint]: lambda };
 };
+
+exports.shouldServe = shouldServe;

--- a/packages/now-python/index.ts
+++ b/packages/now-python/index.ts
@@ -9,6 +9,7 @@ import {
   download,
   glob,
   createLambda,
+  shouldServe,
   BuildOptions,
 } from '@now/build-utils';
 import { downloadAndInstallPip } from './download-and-install-pip';
@@ -159,3 +160,5 @@ export const build = async ({
     [entrypoint]: lambda,
   };
 };
+
+export { shouldServe };

--- a/packages/now-rust/index.js
+++ b/packages/now-rust/index.js
@@ -8,6 +8,7 @@ const glob = require('@now/build-utils/fs/glob.js'); // eslint-disable-line impo
 const { runShellScript } = require('@now/build-utils/fs/run-user-scripts.js'); // eslint-disable-line import/no-extraneous-dependencies
 const FileFsRef = require('@now/build-utils/file-fs-ref.js'); // eslint-disable-line import/no-extraneous-dependencies
 const FileRef = require('@now/build-utils/file-ref.js'); // eslint-disable-line import/no-extraneous-dependencies
+const { shouldServe } = require('@now/build-utils'); // eslint-disable-line import/no-extraneous-dependencies
 const installRust = require('./install-rust.js');
 
 exports.config = {
@@ -367,3 +368,5 @@ exports.getDefaultCache = ({ files, entrypoint }) => {
   });
   return { [targetFolderDir]: defaultCacheRef };
 };
+
+exports.shouldServe = shouldServe;


### PR DESCRIPTION
This adds the default `shouldServe()` implementation to the following builders:

 * `@now/bash`
 * `@now/cgi`
 * `@now/html-minifier`
 * `@now/lambda`
 * `@now/md`
 * `@now/node-server`
 * `@now/node`
 * `@now/optipng`
 * `@now/php`
 * `@now/python`
 * `@now/rust`

The default implementation may be used for these builders because they map 1-1 with their entrypoint file -> output file/lambda.