### PR TITLE
Use prepublishOnly

### DIFF
--- a/packages/now-build-utils/package.json
+++ b/packages/now-build-utils/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "tsc",
     "test": "tsc && jest",
-    "prepublish": "tsc"
+    "prepublishOnly": "tsc"
   },
   "devDependencies": {
     "@types/async-retry": "^1.2.1",

--- a/packages/now-cgi/package.json
+++ b/packages/now-cgi/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "best -I test/*.js",
-    "prepublish": "./build.sh"
+    "prepublishOnly": "./build.sh"
   },
   "files": [
     "index.js",

--- a/packages/now-go/package.json
+++ b/packages/now-go/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc",
     "test": "tsc && jest",
-    "prepublish": "tsc"
+    "prepublishOnly": "tsc"
   },
   "files": [
     "*.js",

--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -5,8 +5,8 @@
   "main": "./dist/index",
   "scripts": {
     "build": "./getBridgeTypes.sh && tsc",
-    "test": "npm run build && jest",
-    "prepublish": "yarn run build"
+    "test": "./getBridgeTypes.sh && tsc && jest",
+    "prepublishOnly": "./getBridgeTypes.sh && tsc"
   },
   "repository": {
     "type": "git",

--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -5,8 +5,8 @@
   "main": "./dist/index",
   "scripts": {
     "build": "./getBridgeTypes.sh && tsc",
-    "test": "./getBridgeTypes.sh && tsc && jest",
-    "prepublishOnly": "./getBridgeTypes.sh && tsc"
+    "test": "yarn build && jest",
+    "prepublishOnly": "yarn build"
   },
   "repository": {
     "type": "git",

--- a/packages/now-node-bridge/package.json
+++ b/packages/now-node-bridge/package.json
@@ -14,8 +14,8 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "npm run build && jest",
-    "prepublish": "npm run build"
+    "test": "tsc && jest",
+    "prepublishOnly": "tsc"
   },
   "devDependencies": {
     "@types/aws-lambda": "8.10.19",

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -15,8 +15,8 @@
   },
   "scripts": {
     "build": "./build.sh",
-    "test": "npm run build && jest",
-    "prepublish": "npm run build"
+    "test": "./build.sh && jest",
+    "prepublishOnly": "./build.sh"
   },
   "files": [
     "dist"

--- a/packages/now-python/package.json
+++ b/packages/now-python/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsc",
     "test": "tsc && jest",
-    "prepublish": "tsc"
+    "prepublishOnly": "tsc"
   },
   "dependencies": {
     "execa": "^1.0.0",


### PR DESCRIPTION
Since npm@1.1.71, the npm CLI has run the `prepublish` script.

- `prepublish`: Run BEFORE the package is packed and published, as well as on local npm install without any arguments.
- `prepublishOnly`: Run BEFORE the package is prepared and packed, ONLY on npm publish.

[See the docs](https://docs.npmjs.com/misc/scripts)

We already have a `build` step so we can utilize `prepublishOnly`.