### PR TITLE
[now-node] Bump ncc to 0.18.3

### DIFF
--- a/packages/now-node-server/package.json
+++ b/packages/now-node-server/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@now/node-bridge": "^1.1.2",
-    "@zeit/ncc": "0.18.2",
+    "@zeit/ncc": "0.18.3",
     "fs-extra": "7.0.1"
   },
   "scripts": {

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@now/node-bridge": "^1.1.2",
-    "@zeit/ncc": "0.18.2",
+    "@zeit/ncc": "0.18.3",
     "fs-extra": "7.0.1"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1135,10 +1135,10 @@
     globby "8.0.0"
     signal-exit "3.0.2"
 
-"@zeit/ncc@0.18.2":
-  version "0.18.2"
-  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.18.2.tgz#b5f721ec1d23bfe531f3568633689ddab7c05638"
-  integrity sha512-liiuVTcxLaOIGQDftpZ2qhSS/vdEbuvmi2tkBWMfIwIyeKd/sh/jw+l8yONT3/unx/sSmfMTDnwfwUlY+saKiw==
+"@zeit/ncc@0.18.3":
+  version "0.18.3"
+  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.18.3.tgz#6a84552c7b6710ab510f71e49546fff4e3b5c545"
+  integrity sha512-QNSNpHoh8medZXbmHHtJRZU3/2oemb3AjMrv/2fXBWCDPDmkDCRkE6V5PRrjdMQFvEN9SerhHWR8pp3IJF6Mww==
 
 JSONStream@^1.0.4, JSONStream@^1.3.4:
   version "1.3.5"


### PR DESCRIPTION
Update to latest version `@zeit/ncc` to [0.18.3](https://github.com/zeit/ncc/releases/tag/0.18.3).

This truncates the output during build errors so that only the error is shown, not the warning.