### PR TITLE
Add coverage to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ tmp
 target/
 .next
 coverage
-.tgz
+*.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 tmp
 target/
 .next
+coverage

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tmp
 target/
 .next
 coverage
+.tgz


### PR DESCRIPTION
The `coverage` should not be committed and it causes errors like this one during publish: https://circleci.com/gh/zeit/now-builders/1857

```
$ lerna publish from-git --npm-tag canary --yes
lerna notice cli v3.5.0
lerna info versioning independent
lerna info Verifying npm credentials
lerna http fetch GET 200 https://registry.npmjs.org/-/whoami 565ms
lerna ERR! EUNCOMMIT Working tree has uncommitted changes, please commit or remove changes before continuing.
```

I also added `*.tgz` just in case.