### PR TITLE
[now-build-utils] Make `download()` a no-op in `now dev`

### DIFF
--- a/packages/now-build-utils/src/fs/download.ts
+++ b/packages/now-build-utils/src/fs/download.ts
@@ -4,11 +4,11 @@ import { File, Files, Meta } from '../types';
 import { remove, mkdirp, readlink, symlink } from 'fs-extra';
 
 export interface DownloadedFiles {
-  [filePath: string]: FileFsRef
+  [filePath: string]: FileFsRef;
 }
 
-const S_IFMT = 61440;   /* 0170000 type of file */
-const S_IFLNK = 40960;  /* 0120000 symbolic link */
+const S_IFMT = 61440; /* 0170000 type of file */
+const S_IFLNK = 40960; /* 0120000 symbolic link */
 
 export function isSymbolicLink(mode: number): boolean {
   return (mode & S_IFMT) === S_IFLNK;
@@ -17,9 +17,9 @@ export function isSymbolicLink(mode: number): boolean {
 async function downloadFile(file: File, fsPath: string): Promise<FileFsRef> {
   const { mode } = file;
   if (mode && isSymbolicLink(mode) && file.type === 'FileFsRef') {
-    const [ target ] = await Promise.all([
+    const [target] = await Promise.all([
       readlink((file as FileFsRef).fsPath),
-      mkdirp(path.dirname(fsPath))
+      mkdirp(path.dirname(fsPath)),
     ]);
     await symlink(target, fsPath);
     return FileFsRef.fromFsPath({ mode, fsPath });
@@ -34,12 +34,25 @@ async function removeFile(basePath: string, fileMatched: string) {
   await remove(file);
 }
 
-export default async function download(files: Files, basePath: string, meta?: Meta): Promise<DownloadedFiles> {
+export default async function download(
+  files: Files,
+  basePath: string,
+  meta?: Meta
+): Promise<DownloadedFiles> {
+  const { isDev = false, filesChanged = null, filesRemoved = null } =
+    meta || {};
+
+  if (isDev) {
+    // In `now dev`, the `download()` function is a no-op because
+    // the `basePath` matches the `cwd` of the dev server, so the
+    // source files are already available.
+    return files as DownloadedFiles;
+  }
+
   const files2: DownloadedFiles = {};
-  const { filesChanged = null, filesRemoved = null } = meta || {};
 
   await Promise.all(
-    Object.keys(files).map(async (name) => {
+    Object.keys(files).map(async name => {
       // If the file does not exist anymore, remove it.
       if (Array.isArray(filesRemoved) && filesRemoved.includes(name)) {
         await removeFile(basePath, name);
@@ -55,7 +68,7 @@ export default async function download(files: Files, basePath: string, meta?: Me
       const fsPath = path.join(basePath, name);
 
       files2[name] = await downloadFile(file, fsPath);
-    }),
+    })
   );
 
   return files2;


### PR DESCRIPTION
This will be necessary for the update in `now dev` to have the builder `workPath` be equal to the `cwd` source directory of the dev server.

Otherwise, unnecessary file modifications are made (copying the source file to itself) and file corruption often occurs.