### PR TITLE
[now-next] Add support for /api routes

### DIFF
--- a/packages/now-next/src/launcher.ts
+++ b/packages/now-next/src/launcher.ts
@@ -1,12 +1,16 @@
 if (!process.env.NODE_ENV) {
-  process.env.NODE_ENV = process.env.NOW_REGION === 'dev1' ? 'development' : 'production';
+  process.env.NODE_ENV =
+    process.env.NOW_REGION === 'dev1' ? 'development' : 'production';
 }
 
 const { Server } = require('http');
 const { Bridge } = require('./now__bridge');
 const page = require('./page');
 
-const server = new Server(page.render);
+// page.render is for React rendering
+// page.default is for /api rendering
+// page is for module.exports in /api
+const server = new Server(page.render || page.default || page);
 const bridge = new Bridge(server);
 bridge.listen();
 


### PR DESCRIPTION
This makes sure that https://github.com/zeit/next.js/pull/7296 can be deployed.

Without this PR it would build correctly but then fail at runtime (because `.render` is called)