### PR TITLE
[now-go] Use meta in `download()`

### DIFF
--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -83,15 +83,13 @@ Learn more: https://zeit.co/docs/v2/deployments/official-builders/go-now-go/#ent
     const base = dirname(downloadedFiles['now.json'].fsPath);
     const destNow = join(base, '.now', 'cache', basename(entrypoint, '.go'));
     for (const file of parsedAnalyzed.watch) {
-      if (!file.includes('.now')) {
-        if (entrypointArr.length > 0) {
-          await copy(
-            join(base, dirname(entrypoint), file),
-            join(destNow, dirname(entrypoint), file)
-          );
-        } else {
-          await copy(join(base, file), join(destNow, file));
-        }
+      if (entrypointArr.length > 0) {
+        await copy(
+          join(base, dirname(entrypoint), file),
+          join(destNow, dirname(entrypoint), file)
+        );
+      } else {
+        await copy(join(base, file), join(destNow, file));
       }
     }
     downloadedFiles = await glob('**', destNow);

--- a/packages/now-go/util/analyze.go
+++ b/packages/now-go/util/analyze.go
@@ -17,7 +17,7 @@ import (
 var ignoredFoldersRegex []*regexp.Regexp
 
 func init() {
-	ignoredFolders := []string{"vendor", "testdata"}
+	ignoredFolders := []string{"vendor", "testdata", ".now"}
 
 	// Build the regex that matches if a path contains the respective ignored folder
 	// The pattern will look like: (.*/)?vendor/.*, which matches every path that contains a vendor folder


### PR DESCRIPTION
Use `meta` in `download()`. I have to do some tricks to handle `cwd/.now`.

You can try it out here `now-go-test-cwd`