### PR TITLE
[now-static-build] Remove `srcBase` from the proxy pass destination

### DIFF
--- a/packages/now-static-build/index.js
+++ b/packages/now-static-build/index.js
@@ -101,7 +101,7 @@ exports.build = async ({
       }
       routes.push({
         src: `${srcBase}/(.*)`,
-        dest: `http://localhost:${devPort}${srcBase}/$1`,
+        dest: `http://localhost:${devPort}/$1`,
       });
     } else {
       if (meta.isDev) {


### PR DESCRIPTION
The `srcBase` (directory where the entrypoint is located) should not be in the `dest` proxy pass URL.

Consider an entrypoint like `blog/package.json`. The development server will be running within the `blog` directory. A request for `GET /blog/static/foo.js` comes in, so we want to proxy pass to `http://localhost:12345/static/foo.js` rather than `http://localhost:12345/blog/static/foo.js` which would lead to a 404.