### PR TITLE
[now-node-bridge] Disable callbackWaitsForEmptyEventLoop

### DIFF
--- a/packages/now-node-bridge/src/bridge.ts
+++ b/packages/now-node-bridge/src/bridge.ts
@@ -1,10 +1,10 @@
 import { AddressInfo } from 'net';
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import { APIGatewayProxyEvent, Context } from 'aws-lambda';
 import {
   Server,
   IncomingHttpHeaders,
   OutgoingHttpHeaders,
-  request
+  request,
 } from 'http';
 
 interface NowProxyEvent {
@@ -133,25 +133,25 @@ export class Bridge {
 
     return this.server.listen({
       host: '127.0.0.1',
-      port: 0
+      port: 0,
     });
   }
 
   async launcher(
-    event: NowProxyEvent | APIGatewayProxyEvent
+    event: NowProxyEvent | APIGatewayProxyEvent,
+    context: Context
   ): Promise<NowProxyResponse> {
+    context.callbackWaitsForEmptyEventLoop = false;
     const { port } = await this.listening;
 
-    const { isApiGateway, method, path, headers, body } = normalizeEvent(
-      event
-    );
+    const { isApiGateway, method, path, headers, body } = normalizeEvent(event);
 
     const opts = {
       hostname: '127.0.0.1',
       port,
       path,
       method,
-      headers
+      headers,
     };
 
     // eslint-disable-next-line consistent-return
@@ -175,7 +175,7 @@ export class Bridge {
             statusCode: response.statusCode || 200,
             headers: response.headers,
             body: bodyBuffer.toString('base64'),
-            encoding: 'base64'
+            encoding: 'base64',
           });
         });
       });

--- a/packages/now-node-bridge/test/bridge.test.js
+++ b/packages/now-node-bridge/test/bridge.test.js
@@ -16,56 +16,70 @@ test('port binding', async () => {
 });
 
 test('`APIGatewayProxyEvent` normalizing', async () => {
-  const server = new Server((req, res) => res.end(
-    JSON.stringify({
-      method: req.method,
-      path: req.url,
-      headers: req.headers,
-    }),
-  ));
+  const server = new Server((req, res) =>
+    res.end(
+      JSON.stringify({
+        method: req.method,
+        path: req.url,
+        headers: req.headers,
+      })
+    )
+  );
   const bridge = new Bridge(server);
   bridge.listen();
-  const result = await bridge.launcher({
-    httpMethod: 'GET',
-    headers: { foo: 'bar' },
-    path: '/apigateway',
-    body: null,
-  });
+  const context = {};
+  const result = await bridge.launcher(
+    {
+      httpMethod: 'GET',
+      headers: { foo: 'bar' },
+      path: '/apigateway',
+      body: null,
+    },
+    context
+  );
   assert.equal(result.encoding, 'base64');
   assert.equal(result.statusCode, 200);
   const body = JSON.parse(Buffer.from(result.body, 'base64').toString());
   assert.equal(body.method, 'GET');
   assert.equal(body.path, '/apigateway');
   assert.equal(body.headers.foo, 'bar');
+  assert.equal(context.callbackWaitsForEmptyEventLoop, false);
 
   server.close();
 });
 
 test('`NowProxyEvent` normalizing', async () => {
-  const server = new Server((req, res) => res.end(
-    JSON.stringify({
-      method: req.method,
-      path: req.url,
-      headers: req.headers,
-    }),
-  ));
+  const server = new Server((req, res) =>
+    res.end(
+      JSON.stringify({
+        method: req.method,
+        path: req.url,
+        headers: req.headers,
+      })
+    )
+  );
   const bridge = new Bridge(server);
   bridge.listen();
-  const result = await bridge.launcher({
-    Action: 'Invoke',
-    body: JSON.stringify({
-      method: 'POST',
-      headers: { foo: 'baz' },
-      path: '/nowproxy',
-      body: 'body=1',
-    }),
-  });
+  const context = { callbackWaitsForEmptyEventLoop: true };
+  const result = await bridge.launcher(
+    {
+      Action: 'Invoke',
+      body: JSON.stringify({
+        method: 'POST',
+        headers: { foo: 'baz' },
+        path: '/nowproxy',
+        body: 'body=1',
+      }),
+    },
+    context
+  );
   assert.equal(result.encoding, 'base64');
   assert.equal(result.statusCode, 200);
   const body = JSON.parse(Buffer.from(result.body, 'base64').toString());
   assert.equal(body.method, 'POST');
   assert.equal(body.path, '/nowproxy');
   assert.equal(body.headers.foo, 'baz');
+  assert.equal(context.callbackWaitsForEmptyEventLoop, false);
 
   server.close();
 });


### PR DESCRIPTION
It has been requested several times that we should set [callbackWaitsForEmptyEventLoop](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-context.html#nodejs-prog-model-context-properties) to false.

However, I didn't add a test because we don't have any examples of failing code.

Perhaps @joecohens can provide an example.