### PR TITLE
[now-go] Add option to use private Git for `go get`

### DIFF
--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -1,5 +1,6 @@
 import { join, sep, dirname, basename } from 'path';
 import { readFile, writeFile, pathExists, move, copy } from 'fs-extra';
+import { homedir } from 'os';
 import execa from 'execa';
 
 import {
@@ -36,7 +37,7 @@ async function initPrivateGit(username: string, token: string, host: string) {
     'config',
     '--global',
     'credential.helper',
-    `store --file ${path.join(os.homedir(), '.git-credentials')`,
+    `store --file ${join(homedir(), '.git-credentials')}`,
   ]);
 
   await writeFile(

--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -32,7 +32,7 @@ interface BuildParamsType extends BuildOptions {
 }
 
 // Initialize private git repo for Go Modules
-async function initPrivateGit(username: string, token: string, host: string) {
+async function initPrivateGit(credentials: string) {
   await execa('git', [
     'config',
     '--global',
@@ -40,10 +40,7 @@ async function initPrivateGit(username: string, token: string, host: string) {
     `store --file ${join(homedir(), '.git-credentials')}`,
   ]);
 
-  await writeFile(
-    `${process.env.HOME}/.git-credentials`,
-    `https://${username}:${token}@${host}`
-  );
+  await writeFile(join(homedir(), '.git-credentials'), credentials);
 }
 
 export const version = 2;
@@ -59,17 +56,9 @@ export async function build({
   workPath,
   meta = {} as BuildParamsMeta,
 }: BuildParamsType) {
-  if (
-    process.env.GIT_USERNAME &&
-    process.env.GIT_TOKEN &&
-    process.env.GIT_HOST
-  ) {
-    console.log('Initialize Git...');
-    await initPrivateGit(
-      process.env.GIT_USERNAME,
-      process.env.GIT_TOKEN,
-      process.env.GIT_HOST
-    );
+  if (process.env.GIT_CREDENTIALS) {
+    console.log('Initialize Git credentials...');
+    await initPrivateGit(process.env.GIT_CREDENTIALS);
   }
 
   console.log('Downloading user files...');

--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -36,7 +36,7 @@ async function initPrivateGit(username: string, token: string, host: string) {
     'config',
     '--global',
     'credential.helper',
-    `store --file ${process.env.HOME}/.git-credentials`,
+    `store --file ${path.join(os.homedir(), '.git-credentials')`,
   ]);
 
   await writeFile(

--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -56,7 +56,7 @@ export async function build({
   workPath,
   meta = {} as BuildParamsMeta,
 }: BuildParamsType) {
-  if (process.env.GIT_CREDENTIALS) {
+  if (process.env.GIT_CREDENTIALS && !meta.isDev) {
     console.log('Initialize Git credentials...');
     await initPrivateGit(process.env.GIT_CREDENTIALS);
   }


### PR DESCRIPTION
This PR will add support private git repos.

Fixes #316 

This environment variable needs to be in the build instead of the runtime like this in `now.json`:

```json
{
    "build": {
        "env": {
            "GIT_CREDENTIALS": "https://username:token@github.com"
        }
    }
}
```

Supports any Git provider (GitHub, Bitbucket, GitLab) as well as self-host Git server.