### PR TITLE
Run only tests for packages that changed

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,37 @@
+const childProcess = require('child_process');
+const path = require('path');
+
+const command = 'git diff HEAD~1 --name-only';
+const diff = childProcess.execSync(command).toString();
+
+const changed = diff
+  .split('\n')
+  .filter(item => Boolean(item) && item.includes('packages/'))
+  .map(item => path.relative('packages', item).split('/')[0]);
+
+const matches = [];
+
+if (changed.length > 0) {
+  console.log('The following packages have changed:');
+
+  changed.map((item) => {
+    matches.push(item);
+    console.log(item);
+
+    return null;
+  });
+} else {
+  matches.push('now-node');
+  console.log(`No packages changed, defaulting to ${matches[0]}`);
+}
+
+const testMatch = Array.from(new Set(matches)).map(
+  item => `**/${item}/**/?(*.)+(spec|test).[jt]s?(x)`,
+);
+
 module.exports = {
   testEnvironment: 'node',
+  testMatch,
   collectCoverageFrom: [
     'packages/(!test)/**/*.{js,jsx}',
     '!**/node_modules/**',


### PR DESCRIPTION
With this PR, we ensure only the tests for packages that changed are run.

If no packages changed, the tests for `now-node` are run to see if the testing infrastructure still works after the change the commit author made.

For example, this is the log for the current PR:

![image](https://user-images.githubusercontent.com/6170607/58035609-7054ec00-7b29-11e9-91b1-abe6e4087fe2.png)

If a change was made, this is how it would look:

![image](https://user-images.githubusercontent.com/6170607/58035676-94183200-7b29-11e9-9016-bd0a98a56c9c.png)
