### PR TITLE
[now-next] Handle statically exported pages

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -290,6 +290,7 @@ export const build = async ({
   }
 
   const lambdas: { [key: string]: Lambda } = {};
+  const staticPages: { [key: string]: string } = {};
 
   if (isLegacy) {
     const filesAfterBuild = await glob('**', entryPath);
@@ -381,10 +382,18 @@ export const build = async ({
         fsPath: path.join(__dirname, 'launcher.js'),
       }),
     };
-    const pages = await glob(
-      '**/*.js',
-      path.join(entryPath, '.next', 'serverless', 'pages')
-    );
+    const pagesDir = path.join(entryPath, '.next', 'serverless', 'pages');
+
+    const pages = await glob('**/*.js', pagesDir);
+    const staticPageFiles = await glob('**/*.html', pagesDir);
+
+    Object.keys(staticPageFiles).forEach((page: string) => {
+      const pathname = page.replace(/\.html$/, '');
+      staticPages[path.join(entryDirectory, pathname)] = path.join(
+        pagesDir,
+        page
+      );
+    });
 
     const pageKeys = Object.keys(pages);
 
@@ -473,6 +482,7 @@ export const build = async ({
     output: {
       ...publicFiles,
       ...lambdas,
+      ...staticPages,
       ...staticFiles,
       ...staticDirectoryFiles,
     },

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -390,6 +390,7 @@ export const build = async ({
     Object.keys(staticPageFiles).forEach((page: string) => {
       const pathname = page.replace(/\.html$/, '');
       staticPages[path.join(entryDirectory, pathname)] = path.join(
+        entryDirectory,
         pagesDir,
         page
       );

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -290,7 +290,7 @@ export const build = async ({
   }
 
   const lambdas: { [key: string]: Lambda } = {};
-  const staticPages: { [key: string]: string } = {};
+  const staticPages: { [key: string]: FileFsRef } = {};
 
   if (isLegacy) {
     const filesAfterBuild = await glob('**', entryPath);
@@ -389,11 +389,7 @@ export const build = async ({
 
     Object.keys(staticPageFiles).forEach((page: string) => {
       const pathname = page.replace(/\.html$/, '');
-      staticPages[path.join(entryDirectory, pathname)] = path.join(
-        entryDirectory,
-        pagesDir,
-        page
-      );
+      staticPages[path.join(entryDirectory, pathname)] = staticPageFiles[page];
     });
 
     const pageKeys = Object.keys(pages);


### PR DESCRIPTION
In the latest Next.js we auto export static pages to HTML when enabled. This adds handling of those created HTML files. 