### PR TITLE
Switch branch during publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "lerna": "lerna",
     "bootstrap": "lerna bootstrap",
-    "publish-stable": "lerna version",
-    "publish-canary": "lerna version prerelease --preid canary",
+    "publish-stable": "git checkout master && git pull && lerna version",
+    "publish-canary": "git checkout canary && git pull && lerna version prerelease --preid canary",
     "build": "./.circleci/build.sh",
     "lint": "eslint .",
     "codecov": "codecov",


### PR DESCRIPTION
Going forward, the default branch is now `canary`.

New PRs should be submitted to the `canary` branch. We will publish canary builders from the canary branch.

Periodically we will merge `canary` into `master` and publish stable releases.

This PR will make sure we publish from the correct branch.