### PR TITLE
[now-rust] Don't try and install rust and openssl during development

### DIFF
--- a/packages/now-rust/index.js
+++ b/packages/now-rust/index.js
@@ -256,11 +256,15 @@ exports.build = async (m) => {
   const {
     files, entrypoint, workPath, config, meta,
   } = m;
+  const { isDev } = meta || {};
   console.log('downloading files');
   const downloadedFiles = await download(files, workPath, meta);
   const entryPath = downloadedFiles[entrypoint].fsPath;
 
-  await installRust();
+  if (!isDev) {
+    await installRust();
+  }
+
   const { PATH, HOME } = process.env;
   const rustEnv = {
     ...process.env,


### PR DESCRIPTION
Avoid installing rust and openssl during development since these should already be installed by the user.

Doc updates [docs#863](https://github.com/zeit/docs/pull/863)
Fixes [now-cli#2087](https://github.com/zeit/now-cli/issues/2087)