### PR TITLE
Merge master into canary

### DIFF
--- a/packages/now-rust/index.js
+++ b/packages/now-rust/index.js
@@ -256,11 +256,15 @@ exports.build = async (m) => {
   const {
     files, entrypoint, workPath, config, meta,
   } = m;
+  const { isDev } = meta || {};
   console.log('downloading files');
   const downloadedFiles = await download(files, workPath, meta);
   const entryPath = downloadedFiles[entrypoint].fsPath;
 
-  await installRust();
+  if (!isDev) {
+    await installRust();
+  }
+
   const { PATH, HOME } = process.env;
   const rustEnv = {
     ...process.env,


### PR DESCRIPTION
PR #532 was accidentally merged into `master` instead of `canary`.

This makes sure we have this change on canary branch.

@mike-engel In the future, PRs should be submitted to `canary` branch.