### PR TITLE
[now-go] Show error when using `package main` with `go.mod`

### DIFF
--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -163,6 +163,11 @@ Learn more: https://zeit.co/docs/v2/deployments/official-builders/go-now-go/#ent
   // using `go.mod` way building the handler
   const packageName = parsedAnalyzed.packageName;
   const isGoModExist = await pathExists(join(entrypointDirname, 'go.mod'));
+
+  if (isGoModExist && packageName === 'main') {
+    throw new Error('Please change `package main` to `package handler`');
+  }
+
   if (packageName !== 'main') {
     const go = await createGo(
       goPath,


### PR DESCRIPTION
Fixes #528

I go with show error message approach rather than update the `entrypoint` src file for user. I think it more concrete this way, letting user know exactly what's happened.

Let me know your thought on this 🙏 