### PR TITLE
Use GitHub Actions for publishing to npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,6 @@ jobs:
       - run:
           name: Tests and Coverage
           command: yarn test-coverage
-      - run:
-          name: Potentially publish releases to npm
-          command: ./.circleci/publish.sh
 workflows:
   version: 2
   build-and-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,6 @@ jobs:
           name: Tests and Coverage
           command: yarn test-coverage
       - run:
-          name: Potentially save npm token
-          command: "([[ ! -z $NPM_TOKEN ]] && echo \"//registry.npmjs.org/:_authToken=$NPM_TOKEN\" >> ~/.npmrc) || echo \"Did not write npm token\""
-      - run:
           name: Potentially publish releases to npm
           command: ./.circleci/publish.sh
 workflows:

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+
 if [ ! -e ~/.npmrc ]; then
   echo "~/.npmrc file does not exist, skipping publish"
   exit 0
@@ -21,4 +23,4 @@ else
   echo "Publishing stable release"
 fi
 
-yarn run lerna publish from-git $npm_tag --yes
+npm run lerna publish from-git $npm_tag --yes

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -23,4 +23,4 @@ else
   echo "Publishing stable release"
 fi
 
-npm run lerna publish from-git $npm_tag --yes
+yarn run lerna publish from-git $npm_tag --yes

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+if [ -z "$NPM_TOKEN" ]; then
+  echo "NPM_TOKEN not found. Did you forget to assign the GitHub Action secret?"
+  exit 1
+fi
+
 echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
 
 if [ ! -e ~/.npmrc ]; then

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,22 +1,22 @@
 workflow "Main" {
   on = "push"
-  resolves = ["npm run publish-from-github"]
+  resolves = ["3. npm run publish-from-github"]
 }
 
-action "npm install" {
+action "1. npm install" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
   args = "install"
 }
 
-action "npm run build" {
+action "2. npm run build" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
-  needs = ["npm install"]
+  needs = ["1. npm install"]
   args = "run build"
 }
 
-action "npm run publish-from-github" {
+action "3. npm run publish-from-github" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
-  needs = ["npm run build"]
-  args = "npm run publish-from-github"
+  needs = ["2. npm run build"]
+  args = "run publish-from-github"
   secrets = ["NPM_TOKEN"]
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -3,8 +3,14 @@ workflow "Main" {
   resolves = ["npm run publish-from-github"]
 }
 
+action "npm install" {
+  uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
+  args = "install"
+}
+
 action "npm run build" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
+  needs = ["npm install"]
   args = "run build"
 }
 

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -11,7 +11,7 @@ action "1. yarn install" {
 
 action "2. yarn run build" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
-  needs = ["1. npm install"]
+  needs = ["1. yarn install"]
   runs = "yarn"
   args = "run build"
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,22 +1,25 @@
 workflow "Main" {
   on = "push"
-  resolves = ["3. npm run publish-from-github"]
+  resolves = ["3. yarn run publish-from-github"]
 }
 
 action "1. npm install" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
+  runs = "yarn"
   args = "install"
 }
 
-action "2. npm run build" {
+action "2. yarn run build" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
   needs = ["1. npm install"]
+  runs = "yarn"
   args = "run build"
 }
 
-action "3. npm run publish-from-github" {
+action "3. yarn run publish-from-github" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
-  needs = ["2. npm run build"]
+  needs = ["2. yarn run build"]
+  runs = "yarn"
   args = "run publish-from-github"
   secrets = ["NPM_TOKEN"]
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,16 +1,10 @@
-workflow "Main" {
+workflow "Publish" {
   on = "push"
   resolves = ["3. yarn run publish-from-github"]
 }
 
-action "0. tag filter" {
-  uses = "actions/bin/filter@master"
-  args = "tag"
-}
-
 action "1. yarn install" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
-  needs = ["0. tag filter"]
   runs = "yarn"
   args = "install"
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -3,7 +3,7 @@ workflow "Main" {
   resolves = ["3. yarn run publish-from-github"]
 }
 
-action "1. npm install" {
+action "1. yarn install" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
   runs = "yarn"
   args = "install"

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,16 @@
+workflow "Main" {
+  on = "push"
+  resolves = ["npm run publish-from-github"]
+}
+
+action "npm run build" {
+  uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
+  args = "run build"
+}
+
+action "npm run publish-from-github" {
+  uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
+  needs = ["npm run build"]
+  args = "npm run publish-from-github"
+  secrets = ["NPM_TOKEN"]
+}

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -3,8 +3,14 @@ workflow "Main" {
   resolves = ["3. yarn run publish-from-github"]
 }
 
+action "0. tag filter" {
+  uses = "actions/bin/filter@master"
+  args = "tag"
+}
+
 action "1. yarn install" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
+  needs = ["0. tag filter"]
   runs = "yarn"
   args = "install"
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bootstrap": "lerna bootstrap",
     "publish-stable": "git checkout master && git pull && lerna version",
     "publish-canary": "git checkout canary && git pull && lerna version prerelease --preid canary",
+    "publish-from-github": "./.circleci/publish.sh",
     "build": "./.circleci/build.sh",
     "lint": "eslint .",
     "codecov": "codecov",


### PR DESCRIPTION
Non-ZEIT Members are unable to run Circle CI for security purposes, in particular the npm publish step.

This PR moves the publish step from Circle CI to GitHub Actions so that we can enable Circle CI for everyone!