### PR TITLE
[now-go] Add support for `go.mod` in different `entrypoint` directory

### DIFF
--- a/packages/now-go/test/fixtures/10-go-mod/go.mod
+++ b/packages/now-go/test/fixtures/10-go-mod/go.mod
@@ -1,0 +1,3 @@
+module go-mod
+
+go 1.12

--- a/packages/now-go/test/fixtures/10-go-mod/index.go
+++ b/packages/now-go/test/fixtures/10-go-mod/index.go
@@ -1,0 +1,11 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Handler func
+func Handler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "RANDOMNESS_PLACEHOLDER")
+}

--- a/packages/now-go/test/fixtures/10-go-mod/now.json
+++ b/packages/now-go/test/fixtures/10-go-mod/now.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "index.go", "use": "@now/go" }
+  ],
+  "probes": [
+    { "path": "/", "mustContain": "RANDOMNESS_PLACEHOLDER" }
+  ]
+}

--- a/packages/now-go/test/fixtures/11-go-mod-shared/api/index.go
+++ b/packages/now-go/test/fixtures/11-go-mod-shared/api/index.go
@@ -1,0 +1,12 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"with-shared/shared"
+)
+
+// Handler func
+func Handler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, shared.Say("RANDOMNESS_PLACEHOLDER"))
+}

--- a/packages/now-go/test/fixtures/11-go-mod-shared/go.mod
+++ b/packages/now-go/test/fixtures/11-go-mod-shared/go.mod
@@ -1,0 +1,3 @@
+module with-shared
+
+go 1.12

--- a/packages/now-go/test/fixtures/11-go-mod-shared/now.json
+++ b/packages/now-go/test/fixtures/11-go-mod-shared/now.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "api/*.go", "use": "@now/go" }
+  ],
+  "probes": [
+    { "path": "/api", "mustContain": "RANDOMNESS_PLACEHOLDER" }
+  ]
+}

--- a/packages/now-go/test/fixtures/11-go-mod-shared/shared/shared.go
+++ b/packages/now-go/test/fixtures/11-go-mod-shared/shared/shared.go
@@ -1,0 +1,6 @@
+package shared
+
+// Say func
+func Say(text string) string {
+	return text
+}

--- a/packages/now-go/test/fixtures/12-go-mod-subs/now.json
+++ b/packages/now-go/test/fixtures/12-go-mod-subs/now.json
@@ -1,0 +1,10 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "**/*.go", "use": "@now/go" }
+  ],
+  "probes": [
+    { "path": "/sub-1", "mustContain": "RANDOMNESS_PLACEHOLDER" },
+    { "path": "/sub-2", "mustContain": "RANDOMNESS_PLACEHOLDER" }
+  ]
+}

--- a/packages/now-go/test/fixtures/12-go-mod-subs/sub-1/go.mod
+++ b/packages/now-go/test/fixtures/12-go-mod-subs/sub-1/go.mod
@@ -1,0 +1,3 @@
+module sub-1
+
+go 1.12

--- a/packages/now-go/test/fixtures/12-go-mod-subs/sub-1/index.go
+++ b/packages/now-go/test/fixtures/12-go-mod-subs/sub-1/index.go
@@ -1,0 +1,11 @@
+package sub1
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Handler func
+func Handler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "RANDOMNESS_PLACEHOLDER")
+}

--- a/packages/now-go/test/fixtures/12-go-mod-subs/sub-2/go.mod
+++ b/packages/now-go/test/fixtures/12-go-mod-subs/sub-2/go.mod
@@ -1,0 +1,3 @@
+module sub-2
+
+go 1.12

--- a/packages/now-go/test/fixtures/12-go-mod-subs/sub-2/index.go
+++ b/packages/now-go/test/fixtures/12-go-mod-subs/sub-2/index.go
@@ -1,0 +1,11 @@
+package sub2
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Handler func
+func Handler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "RANDOMNESS_PLACEHOLDER")
+}


### PR DESCRIPTION
Currently, it working fine with `now` but not yet working well with `now dev`.

We will need to update our [analyze.go](https://github.com/zeit/now-builders/blob/canary/packages/now-go/util/analyze.go) to support Go Modules first.