### PR TITLE
[tests] Fix duplicate GH Actions

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -15,7 +15,7 @@ action "0. Canary PR not deleted" {
 
 action "1. Canary yarn install" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
-  needs = ["0. Canary filter", ""0. Canary PR not deleted""]
+  needs = ["0. Canary filter", "0. Canary PR not deleted"]
   runs = "yarn"
   args = "install"
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -8,9 +8,14 @@ action "0. Canary filter" {
   args = "branch canary"
 }
 
+action "0. Canary PR not deleted" {
+  uses = "actions/bin/filter@3c0b4f0e63ea54ea5df2914b4fabf383368cd0da"
+  args = "not deleted"
+}
+
 action "1. Canary yarn install" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
-  needs = ["0. Canary filter"]
+  needs = ["0. Canary filter", ""0. Canary PR not deleted""]
   runs = "yarn"
   args = "install"
 }
@@ -41,9 +46,14 @@ action "0. Master filter" {
   args = "branch master"
 }
 
+action "0. Master PR not deleted" {
+  uses = "actions/bin/filter@3c0b4f0e63ea54ea5df2914b4fabf383368cd0da"
+  args = "not deleted"
+}
+
 action "1. Master yarn install" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
-  needs = ["0. Master filter"]
+  needs = ["0. Master filter", "0. Master PR not deleted"]
   runs = "yarn"
   args = "install"
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -10,12 +10,13 @@ action "0. Canary filter" {
 
 action "0. Canary PR not deleted" {
   uses = "actions/bin/filter@3c0b4f0e63ea54ea5df2914b4fabf383368cd0da"
+  needs = ["0. Canary filter"]
   args = "not deleted"
 }
 
 action "1. Canary yarn install" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
-  needs = ["0. Canary filter", "0. Canary PR not deleted"]
+  needs = ["0. Canary PR not deleted"]
   runs = "yarn"
   args = "install"
 }
@@ -48,12 +49,13 @@ action "0. Master filter" {
 
 action "0. Master PR not deleted" {
   uses = "actions/bin/filter@3c0b4f0e63ea54ea5df2914b4fabf383368cd0da"
+  needs = ["0. Master filter"]
   args = "not deleted"
 }
 
 action "1. Master yarn install" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
-  needs = ["0. Master filter", "0. Master PR not deleted"]
+  needs = ["0. Master PR not deleted"]
   runs = "yarn"
   args = "install"
 }


### PR DESCRIPTION
There seems to be a bug with GitHub Actions running twice when a PR is merged. I suspect that deleting the branch is triggering an additional workflow.

This change will ensure the branch is canary AND the push was not a deleted branch.

![image](https://user-images.githubusercontent.com/229881/58709657-a3e51100-8388-11e9-8f1c-e5c8458f5583.png)
