### PR TITLE
Fix static-build local development docs link

### DIFF
--- a/packages/now-static-build/index.js
+++ b/packages/now-static-build/index.js
@@ -107,7 +107,7 @@ exports.build = async ({
       if (meta.isDev) {
         console.log('WARN: "now-dev" script is missing from package.json');
         console.log(
-          'See the local development docs: http://zeit.co/docs/v2/deployments/official-builders/static-now-static#local-development',
+          'See the local development docs: https://zeit.co/docs/v2/deployments/official-builders/static-build-now-static-build/#local-development',
         );
       }
       // Run the `now-build` script and wait for completion to collect the build


### PR DESCRIPTION
This pull request updates the @now/static-build docs link for local development.