### PR TITLE
[now-next] Route 404 to custom Next.js error page

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -514,6 +514,14 @@ export const build = async ({
       // Next.js page lambdas, `static/` folder, reserved assets, and `public/`
       // folder
       { handle: 'filesystem' },
+      ...(isLegacy
+        ? []
+        : [
+            {
+              src: path.join('/', entryDirectory, '.*'),
+              dest: path.join('/', entryDirectory, '_error'),
+            },
+          ]),
     ],
     watch: [],
     childProcesses: [],


### PR DESCRIPTION
Next.js users expect their 404 page to be rendered when deploying to Now.