### PR TITLE
[now-next] Add generating of dynamic routes for auto exported pages

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -508,7 +508,7 @@ export const build = async ({
     entryDirectory,
     dynamicPages
   ).map(route => {
-    // make sure .html is added to test for now until
+    // make sure .html is added to dest for now until
     // outputting static files to clean routes is available
     if (staticPages[route.dest]) {
       route.dest += '.html';

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -404,11 +404,12 @@ export const build = async ({
       const staticRoute = path.join(entryDirectory, page);
       staticPages[staticRoute] = staticPageFiles[page];
 
-      if (page.startsWith('$') || page.includes('/$')) {
-        dynamicPages.push(page);
+      const pathname = page.replace(/\.html$/, '');
+
+      if (pathname.startsWith('$') || pathname.includes('/$')) {
+        dynamicPages.push(pathname);
       }
 
-      const pathname = page.replace(/\.html$/, '');
       exportedPageRoutes.push({
         src: `^${path.join('/', entryDirectory, pathname)}$`,
         dest: path.join('/', staticRoute),

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -503,6 +503,19 @@ export const build = async ({
     {}
   );
 
+  let dynamicRoutes = getDynamicRoutes(
+    entryPath,
+    entryDirectory,
+    dynamicPages
+  ).map(route => {
+    // make sure .html is added to test for now until
+    // outputting static files to clean routes is available
+    if (staticPages[route.dest]) {
+      route.dest += '.html';
+    }
+    return route;
+  });
+
   return {
     output: {
       ...publicFiles,
@@ -515,7 +528,7 @@ export const build = async ({
       // Static exported pages (.html rewrites)
       ...exportedPageRoutes,
       // Dynamic routes
-      ...getDynamicRoutes(entryPath, entryDirectory, dynamicPages),
+      ...dynamicRoutes,
       // Next.js page lambdas, `static/` folder, reserved assets, and `public/`
       // folder
       { handle: 'filesystem' },

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -404,6 +404,10 @@ export const build = async ({
       const staticRoute = path.join(entryDirectory, page);
       staticPages[staticRoute] = staticPageFiles[page];
 
+      if (page.startsWith('$') || page.includes('/$')) {
+        dynamicPages.push(page);
+      }
+
       const pathname = page.replace(/\.html$/, '');
       exportedPageRoutes.push({
         src: `^${path.join('/', entryDirectory, pathname)}$`,


### PR DESCRIPTION
Since, auto exported pages can be dynamic pages now this adds generating of dynamic routes for them in a production build