### PR TITLE
[now-next] Add timer to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 
 *                       @styfle
 /packages/now-node      @styfle @tootallnate
-/packages/now-next      @styfle @dav-is
+/packages/now-next      @timer  @dav-is
 /packages/now-go        @styfle @sophearak
 /packages/now-python    @styfle @sophearak
 /packages/now-rust      @styfle @mike-engel @anmonteiro


### PR DESCRIPTION
Because @Timer is 🥇 

Also because I am not involved in most Next.js discussions so no reason for me to review the PRs.