### PR TITLE
[now-next] Make sure `.html` is appended to dynamic auto exported routes

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -510,7 +510,7 @@ export const build = async ({
   ).map(route => {
     // make sure .html is added to dest for now until
     // outputting static files to clean routes is available
-    if (staticPages[path.join(entryDirectory, route.dest + '.html')]) {
+    if (staticPages[route.dest + '.html']) {
       route.dest += '.html';
     }
     return route;

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -527,11 +527,11 @@ export const build = async ({
     routes: [
       // Static exported pages (.html rewrites)
       ...exportedPageRoutes,
-      // Dynamic routes
-      ...dynamicRoutes,
       // Next.js page lambdas, `static/` folder, reserved assets, and `public/`
       // folder
       { handle: 'filesystem' },
+      // Dynamic routes
+      ...dynamicRoutes,
     ],
     watch: [],
     childProcesses: [],

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -510,8 +510,8 @@ export const build = async ({
   ).map(route => {
     // make sure .html is added to dest for now until
     // outputting static files to clean routes is available
-    if (staticPages[route.dest + '.html']) {
-      route.dest += '.html';
+    if (staticPages[`${route.dest}.html`]) {
+      route.dest = `${route.dest}.html`;
     }
     return route;
   });

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -510,7 +510,7 @@ export const build = async ({
   ).map(route => {
     // make sure .html is added to dest for now until
     // outputting static files to clean routes is available
-    if (staticPages[route.dest]) {
+    if (staticPages[path.join(entryDirectory, route.dest + '.html')]) {
       route.dest += '.html';
     }
     return route;


### PR DESCRIPTION
Makes sure `/$post` becomes `/$post.html` for auto exported dynamic routes