### PR TITLE
[now-next] Remove leading slash from _next static files

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -481,7 +481,9 @@ export const build = async ({
   const staticFiles = Object.keys(nextStaticFiles).reduce(
     (mappedFiles, file) => ({
       ...mappedFiles,
-      [scopeToEntry(`_next/static/${file}`)]: nextStaticFiles[file],
+      [path.join(entryDirectory, `_next/static/${file}`)]: nextStaticFiles[
+        file
+      ],
     }),
     {}
   );


### PR DESCRIPTION
This specific part can't have a leading slash