### PR TITLE
[now-layer] Add entrypoint to BuildLayerResult

### DIFF
--- a/packages/now-layer-node/src/index.ts
+++ b/packages/now-layer-node/src/index.ts
@@ -1,20 +1,29 @@
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { glob } from '@now/build-utils';
+import { glob, Files } from '@now/build-utils';
 import { mkdir, remove, pathExists } from 'fs-extra';
 import { install } from './install';
 
-interface LayerConfig {
+interface BuildLayerConfig {
   runtimeVersion: string;
   platform: string;
   arch: string;
+}
+
+interface BuildLayerMeta {
+  [key: string]: string;
+}
+
+interface BuildLayerResult {
+  files: Files;
+  meta: BuildLayerMeta;
 }
 
 export async function buildLayer({
   runtimeVersion,
   platform,
   arch,
-}: LayerConfig) {
+}: BuildLayerConfig): Promise<BuildLayerResult> {
   const dir = join(
     tmpdir(),
     `now-layer-node-${runtimeVersion}-${platform}-${arch}`
@@ -24,12 +33,9 @@ export async function buildLayer({
     await remove(dir);
   }
   await mkdir(dir);
-  await install(dir, runtimeVersion, platform, arch);
-  const files = await glob(
-    '{bin/node,bin/node.exe,include/**,now-metadata.json}',
-    {
-      cwd: dir,
-    }
-  );
-  return { files };
+  const meta = await install(dir, runtimeVersion, platform, arch);
+  const files = await glob('{bin/node,bin/node.exe,include/**}', {
+    cwd: dir,
+  });
+  return { files, meta };
 }

--- a/packages/now-layer-node/src/index.ts
+++ b/packages/now-layer-node/src/index.ts
@@ -29,12 +29,7 @@ export async function buildLayer({
     await remove(dir);
   }
   await mkdir(dir);
-  const { entrypoint, meta } = await install(
-    dir,
-    runtimeVersion,
-    platform,
-    arch
-  );
+  const { entrypoint } = await install(dir, runtimeVersion, platform, arch);
   const files = await glob('{bin/node,bin/node.exe,include/**}', {
     cwd: dir,
   });

--- a/packages/now-layer-node/src/index.ts
+++ b/packages/now-layer-node/src/index.ts
@@ -16,7 +16,8 @@ interface BuildLayerMeta {
 
 interface BuildLayerResult {
   files: Files;
-  meta: BuildLayerMeta;
+  entrypoint: string;
+  meta?: BuildLayerMeta;
 }
 
 export async function buildLayer({
@@ -33,9 +34,14 @@ export async function buildLayer({
     await remove(dir);
   }
   await mkdir(dir);
-  const meta = await install(dir, runtimeVersion, platform, arch);
+  const { entrypoint, meta } = await install(
+    dir,
+    runtimeVersion,
+    platform,
+    arch
+  );
   const files = await glob('{bin/node,bin/node.exe,include/**}', {
     cwd: dir,
   });
-  return { files, meta };
+  return { files, entrypoint, meta };
 }

--- a/packages/now-layer-node/src/index.ts
+++ b/packages/now-layer-node/src/index.ts
@@ -10,14 +10,9 @@ interface BuildLayerConfig {
   arch: string;
 }
 
-interface BuildLayerMeta {
-  [key: string]: string;
-}
-
 interface BuildLayerResult {
   files: Files;
   entrypoint: string;
-  meta?: BuildLayerMeta;
 }
 
 export async function buildLayer({
@@ -43,5 +38,5 @@ export async function buildLayer({
   const files = await glob('{bin/node,bin/node.exe,include/**}', {
     cwd: dir,
   });
-  return { files, entrypoint, meta };
+  return { files, entrypoint };
 }

--- a/packages/now-layer-node/src/install.ts
+++ b/packages/now-layer-node/src/install.ts
@@ -2,7 +2,7 @@ import { basename, join } from 'path';
 import fetch from 'node-fetch';
 import { extract } from 'tar';
 import pipe from 'promisepipe';
-import { createWriteStream, readFile, chmod } from 'fs-extra';
+import { createWriteStream } from 'fs-extra';
 import { unzip, zipFromFile } from './unzip';
 
 export async function install(
@@ -18,7 +18,6 @@ export async function install(
   if (!res.ok) {
     throw new Error(`HTTP request failed: ${res.status}`);
   }
-  let pathToManifest: string;
   let entrypoint: string;
   if (platform === 'win32') {
     // Put it in the `bin` dir for consistency with the tarballs
@@ -33,7 +32,6 @@ export async function install(
 
     const zipFile = await zipFromFile(zipPath);
     await unzip(zipFile, finalDest, { strip: 1 });
-    pathToManifest = join(dest, 'bin', 'node_modules', 'npm', 'package.json');
     entrypoint = join('bin', 'node.exe');
   } else {
     const extractStream = extract({ strip: 1, C: dest });
@@ -46,20 +44,10 @@ export async function install(
       res.body,
       extractStream
     );
-    pathToManifest = join(dest, 'lib', 'node_modules', 'npm', 'package.json');
     entrypoint = join('bin', 'node');
   }
 
-  if (process.env.platform !== 'win32' && platform === 'win32') {
-    // Windows doesn't have permissions so this allows
-    // the tests run in Mac/Linux against the Windows zip
-    await chmod(pathToManifest, 0o444);
-  }
-
-  const json = await readFile(pathToManifest, 'utf8');
-  const manifest = JSON.parse(json);
-  const npmVersion = manifest.version;
-  return { entrypoint, meta: { npmVersion } };
+  return { entrypoint };
 }
 
 export function getUrl(

--- a/packages/now-layer-node/src/install.ts
+++ b/packages/now-layer-node/src/install.ts
@@ -10,7 +10,7 @@ export async function install(
   version: string,
   platform: string,
   arch: string
-): Promise<{ entrypoint: string; npmVersion: string }> {
+) {
   const tarballUrl = getUrl(version, platform, arch);
   console.log('Downloading from ' + tarballUrl);
   console.log('Downloading to ' + dest);
@@ -59,7 +59,7 @@ export async function install(
   const json = await readFile(pathToManifest, 'utf8');
   const manifest = JSON.parse(json);
   const npmVersion = manifest.version;
-  return { entrypoint, npmVersion };
+  return { entrypoint, meta: { npmVersion } };
 }
 
 export function getUrl(

--- a/packages/now-layer-node/test/test.js
+++ b/packages/now-layer-node/test/test.js
@@ -4,7 +4,7 @@ const { buildLayer } = require('../');
 
 describe('buildLayer', () => {
   it('should get node 10 and metadata for windows', async () => {
-    const { files } = await buildLayer({
+    const { files, meta } = await buildLayer({
       runtimeVersion: '10.16.0',
       platform: 'win32',
       arch: 'x64',
@@ -12,7 +12,7 @@ describe('buildLayer', () => {
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
     expect(names.size).toBeGreaterThan(0);
-    expect(files['now-metadata.json']).toBeTruthy();
+    expect(meta.entrypoint).toBeTruthy();
     expect(names.has('bin/node.exe')).toBeTruthy();
     expect(names.has('bin/npm.cmd')).toBeFalsy();
     expect(names.has('bin/npx.cmd')).toBeFalsy();
@@ -20,7 +20,7 @@ describe('buildLayer', () => {
   });
 
   it('should get node 10 and metadata for macos', async () => {
-    const { files } = await buildLayer({
+    const { files, meta } = await buildLayer({
       runtimeVersion: '10.16.0',
       platform: 'darwin',
       arch: 'x64',
@@ -28,7 +28,7 @@ describe('buildLayer', () => {
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
     expect(names.size).toBeGreaterThan(0);
-    expect(names.has('now-metadata.json')).toBeTruthy();
+    expect(meta.entrypoint).toBeTruthy();
     expect(names.has('bin/node')).toBeTruthy();
     expect(names.has('bin/npm')).toBeFalsy();
     expect(names.has('bin/npx')).toBeFalsy();
@@ -36,7 +36,7 @@ describe('buildLayer', () => {
   });
 
   it('should get node 10 and metadata for linux', async () => {
-    const { files } = await buildLayer({
+    const { files, meta } = await buildLayer({
       runtimeVersion: '10.16.0',
       platform: 'linux',
       arch: 'x64',
@@ -44,7 +44,7 @@ describe('buildLayer', () => {
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
     expect(names.size).toBeGreaterThan(0);
-    expect(names.has('now-metadata.json')).toBeTruthy();
+    expect(meta.entrypoint).toBeTruthy();
     expect(names.has('bin/node')).toBeTruthy();
     expect(names.has('include/node/node.h')).toBeTruthy();
     expect(names.has('bin/npm')).toBeFalsy();

--- a/packages/now-layer-node/test/test.js
+++ b/packages/now-layer-node/test/test.js
@@ -12,7 +12,7 @@ describe('buildLayer', () => {
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
     expect(names.size).toBeGreaterThan(0);
-    expect(meta.entrypoint).toBeTruthy();
+    expect(meta.entrypoint).toBe('bin/node.exe');
     expect(names.has('bin/node.exe')).toBeTruthy();
     expect(names.has('bin/npm.cmd')).toBeFalsy();
     expect(names.has('bin/npx.cmd')).toBeFalsy();
@@ -28,7 +28,7 @@ describe('buildLayer', () => {
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
     expect(names.size).toBeGreaterThan(0);
-    expect(meta.entrypoint).toBeTruthy();
+    expect(meta.entrypoint).toBe('bin/node');
     expect(names.has('bin/node')).toBeTruthy();
     expect(names.has('bin/npm')).toBeFalsy();
     expect(names.has('bin/npx')).toBeFalsy();
@@ -44,7 +44,7 @@ describe('buildLayer', () => {
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
     expect(names.size).toBeGreaterThan(0);
-    expect(meta.entrypoint).toBeTruthy();
+    expect(meta.entrypoint).toBe('bin/node');
     expect(names.has('bin/node')).toBeTruthy();
     expect(names.has('include/node/node.h')).toBeTruthy();
     expect(names.has('bin/npm')).toBeFalsy();

--- a/packages/now-layer-node/test/test.js
+++ b/packages/now-layer-node/test/test.js
@@ -4,7 +4,7 @@ const { buildLayer } = require('../');
 
 describe('buildLayer', () => {
   it('should get node 10 and metadata for windows', async () => {
-    const { files, meta } = await buildLayer({
+    const { files, entrypoint } = await buildLayer({
       runtimeVersion: '10.16.0',
       platform: 'win32',
       arch: 'x64',
@@ -12,7 +12,7 @@ describe('buildLayer', () => {
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
     expect(names.size).toBeGreaterThan(0);
-    expect(meta.entrypoint).toBe('bin/node.exe');
+    expect(entrypoint).toBe('bin/node.exe');
     expect(names.has('bin/node.exe')).toBeTruthy();
     expect(names.has('bin/npm.cmd')).toBeFalsy();
     expect(names.has('bin/npx.cmd')).toBeFalsy();
@@ -20,7 +20,7 @@ describe('buildLayer', () => {
   });
 
   it('should get node 10 and metadata for macos', async () => {
-    const { files, meta } = await buildLayer({
+    const { files, entrypoint } = await buildLayer({
       runtimeVersion: '10.16.0',
       platform: 'darwin',
       arch: 'x64',
@@ -28,7 +28,7 @@ describe('buildLayer', () => {
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
     expect(names.size).toBeGreaterThan(0);
-    expect(meta.entrypoint).toBe('bin/node');
+    expect(entrypoint).toBe('bin/node');
     expect(names.has('bin/node')).toBeTruthy();
     expect(names.has('bin/npm')).toBeFalsy();
     expect(names.has('bin/npx')).toBeFalsy();
@@ -36,7 +36,7 @@ describe('buildLayer', () => {
   });
 
   it('should get node 10 and metadata for linux', async () => {
-    const { files, meta } = await buildLayer({
+    const { files, entrypoint } = await buildLayer({
       runtimeVersion: '10.16.0',
       platform: 'linux',
       arch: 'x64',
@@ -44,7 +44,7 @@ describe('buildLayer', () => {
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
     expect(names.size).toBeGreaterThan(0);
-    expect(meta.entrypoint).toBe('bin/node');
+    expect(entrypoint).toBe('bin/node');
     expect(names.has('bin/node')).toBeTruthy();
     expect(names.has('include/node/node.h')).toBeTruthy();
     expect(names.has('bin/npm')).toBeFalsy();

--- a/packages/now-layer-npm/src/index.ts
+++ b/packages/now-layer-npm/src/index.ts
@@ -16,7 +16,8 @@ interface BuildLayerMeta {
 
 interface BuildLayerResult {
   files: Files;
-  meta: BuildLayerMeta;
+  entrypoint: string;
+  meta?: BuildLayerMeta;
 }
 
 export async function buildLayer({
@@ -33,9 +34,9 @@ export async function buildLayer({
     await remove(dir);
   }
   await mkdir(dir);
-  const meta = await install(dir, runtimeVersion);
+  const { entrypoint } = await install(dir, runtimeVersion);
   const files = await glob('{bin/**,lib/**,node_modules/**}', {
     cwd: dir,
   });
-  return { files, meta };
+  return { files, entrypoint };
 }

--- a/packages/now-layer-npm/src/index.ts
+++ b/packages/now-layer-npm/src/index.ts
@@ -1,20 +1,29 @@
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { glob } from '@now/build-utils';
+import { glob, Files } from '@now/build-utils';
 import { mkdir, remove, pathExists } from 'fs-extra';
 import { install } from './install';
 
-interface LayerConfig {
+interface BuildLayerConfig {
   runtimeVersion: string;
   platform: string;
   arch: string;
+}
+
+interface BuildLayerMeta {
+  [key: string]: string;
+}
+
+interface BuildLayerResult {
+  files: Files;
+  meta: BuildLayerMeta;
 }
 
 export async function buildLayer({
   runtimeVersion,
   platform,
   arch,
-}: LayerConfig) {
+}: BuildLayerConfig): Promise<BuildLayerResult> {
   const dir = join(
     tmpdir(),
     `now-layer-npm-${runtimeVersion}-${platform}-${arch}`
@@ -24,9 +33,9 @@ export async function buildLayer({
     await remove(dir);
   }
   await mkdir(dir);
-  await install(dir, runtimeVersion);
+  const meta = await install(dir, runtimeVersion);
   const files = await glob('{bin/**,lib/**,node_modules/**}', {
     cwd: dir,
   });
-  return { files };
+  return { files, meta };
 }

--- a/packages/now-layer-npm/src/index.ts
+++ b/packages/now-layer-npm/src/index.ts
@@ -10,14 +10,9 @@ interface BuildLayerConfig {
   arch: string;
 }
 
-interface BuildLayerMeta {
-  [key: string]: string;
-}
-
 interface BuildLayerResult {
   files: Files;
   entrypoint: string;
-  meta?: BuildLayerMeta;
 }
 
 export async function buildLayer({

--- a/packages/now-layer-npm/src/install.ts
+++ b/packages/now-layer-npm/src/install.ts
@@ -1,3 +1,4 @@
+import { join } from 'path';
 import fetch from 'node-fetch';
 import { extract } from 'tar';
 import pipe from 'promisepipe';
@@ -20,4 +21,7 @@ export async function install(dest: string, version: string) {
     res.body,
     extractStream
   );
+
+  const entrypoint = join('bin', 'npm-cli.js');
+  return { entrypoint };
 }

--- a/packages/now-layer-npm/src/install.ts
+++ b/packages/now-layer-npm/src/install.ts
@@ -24,6 +24,6 @@ export async function install(dest: string, version: string) {
 
   const pathToManifest = join(dest, 'package.json');
   const manifest = require(pathToManifest);
-  const entrypoint = manifest.bin;
+  const entrypoint = manifest.bin.npm;
   return { entrypoint };
 }

--- a/packages/now-layer-npm/src/install.ts
+++ b/packages/now-layer-npm/src/install.ts
@@ -22,6 +22,8 @@ export async function install(dest: string, version: string) {
     extractStream
   );
 
-  const entrypoint = join('bin', 'npm-cli.js');
+  const pathToManifest = join(dest, 'package.json');
+  const manifest = require(pathToManifest);
+  const entrypoint = manifest.bin;
   return { entrypoint };
 }

--- a/packages/now-layer-npm/test/test.js
+++ b/packages/now-layer-npm/test/test.js
@@ -11,7 +11,7 @@ describe('buildLayer', () => {
     });
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
-    expect(meta.entrypoint).toBeTruthy();
+    expect(meta.entrypoint).toBe('./bin/npm-cli.js');
     expect(names.size).toBeGreaterThan(0);
     expect(names.has('bin/npm.cmd')).toBeTruthy();
     expect(names.has('bin/npx.cmd')).toBeTruthy();
@@ -26,7 +26,7 @@ describe('buildLayer', () => {
     });
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
-    expect(meta.entrypoint).toBeTruthy();
+    expect(meta.entrypoint).toBe('./bin/npm-cli.js');
     expect(names.size).toBeGreaterThan(0);
     expect(names.has('bin/npm')).toBeTruthy();
     expect(names.has('bin/npx')).toBeTruthy();
@@ -41,7 +41,7 @@ describe('buildLayer', () => {
     });
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
-    expect(meta.entrypoint).toBeTruthy();
+    expect(meta.entrypoint).toBe('./bin/npm-cli.js');
     expect(names.size).toBeGreaterThan(0);
     expect(names.has('bin/npm')).toBeTruthy();
     expect(names.has('bin/npx')).toBeTruthy();

--- a/packages/now-layer-npm/test/test.js
+++ b/packages/now-layer-npm/test/test.js
@@ -4,13 +4,14 @@ const { buildLayer } = require('../');
 
 describe('buildLayer', () => {
   it('should get npm 6 but not npm for windows', async () => {
-    const { files } = await buildLayer({
+    const { files, meta } = await buildLayer({
       runtimeVersion: '6.9.0',
       platform: 'win32',
       arch: 'x64',
     });
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
+    expect(meta.entrypoint).toBeTruthy();
     expect(names.size).toBeGreaterThan(0);
     expect(names.has('bin/npm.cmd')).toBeTruthy();
     expect(names.has('bin/npx.cmd')).toBeTruthy();
@@ -18,13 +19,14 @@ describe('buildLayer', () => {
   });
 
   it('should get npm 6 but not npm for macos', async () => {
-    const { files } = await buildLayer({
+    const { files, meta } = await buildLayer({
       runtimeVersion: '6.9.0',
       platform: 'darwin',
       arch: 'x64',
     });
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
+    expect(meta.entrypoint).toBeTruthy();
     expect(names.size).toBeGreaterThan(0);
     expect(names.has('bin/npm')).toBeTruthy();
     expect(names.has('bin/npx')).toBeTruthy();
@@ -32,13 +34,14 @@ describe('buildLayer', () => {
   });
 
   it('should get npm 6 but not npm for linux', async () => {
-    const { files } = await buildLayer({
+    const { files, meta } = await buildLayer({
       runtimeVersion: '6.9.0',
       platform: 'linux',
       arch: 'x64',
     });
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
+    expect(meta.entrypoint).toBeTruthy();
     expect(names.size).toBeGreaterThan(0);
     expect(names.has('bin/npm')).toBeTruthy();
     expect(names.has('bin/npx')).toBeTruthy();

--- a/packages/now-layer-npm/test/test.js
+++ b/packages/now-layer-npm/test/test.js
@@ -4,14 +4,14 @@ const { buildLayer } = require('../');
 
 describe('buildLayer', () => {
   it('should get npm 6 but not npm for windows', async () => {
-    const { files, meta } = await buildLayer({
+    const { files, entrypoint } = await buildLayer({
       runtimeVersion: '6.9.0',
       platform: 'win32',
       arch: 'x64',
     });
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
-    expect(meta.entrypoint).toBe('./bin/npm-cli.js');
+    expect(entrypoint).toBe('./bin/npm-cli.js');
     expect(names.size).toBeGreaterThan(0);
     expect(names.has('bin/npm.cmd')).toBeTruthy();
     expect(names.has('bin/npx.cmd')).toBeTruthy();
@@ -19,14 +19,14 @@ describe('buildLayer', () => {
   });
 
   it('should get npm 6 but not npm for macos', async () => {
-    const { files, meta } = await buildLayer({
+    const { files, entrypoint } = await buildLayer({
       runtimeVersion: '6.9.0',
       platform: 'darwin',
       arch: 'x64',
     });
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
-    expect(meta.entrypoint).toBe('./bin/npm-cli.js');
+    expect(entrypoint).toBe('./bin/npm-cli.js');
     expect(names.size).toBeGreaterThan(0);
     expect(names.has('bin/npm')).toBeTruthy();
     expect(names.has('bin/npx')).toBeTruthy();
@@ -34,14 +34,14 @@ describe('buildLayer', () => {
   });
 
   it('should get npm 6 but not npm for linux', async () => {
-    const { files, meta } = await buildLayer({
+    const { files, entrypoint } = await buildLayer({
       runtimeVersion: '6.9.0',
       platform: 'linux',
       arch: 'x64',
     });
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
-    expect(meta.entrypoint).toBe('./bin/npm-cli.js');
+    expect(entrypoint).toBe('./bin/npm-cli.js');
     expect(names.size).toBeGreaterThan(0);
     expect(names.has('bin/npm')).toBeTruthy();
     expect(names.has('bin/npx')).toBeTruthy();

--- a/packages/now-layer-yarn/src/index.ts
+++ b/packages/now-layer-yarn/src/index.ts
@@ -16,7 +16,8 @@ interface BuildLayerMeta {
 
 interface BuildLayerResult {
   files: Files;
-  meta: BuildLayerMeta;
+  entrypoint: string;
+  meta?: BuildLayerMeta;
 }
 
 export async function buildLayer({
@@ -33,9 +34,9 @@ export async function buildLayer({
     await remove(dir);
   }
   await mkdir(dir);
-  const meta = await install(dir, runtimeVersion);
+  const { entrypoint } = await install(dir, runtimeVersion);
   const files = await glob('{bin/**,lib/**}', {
     cwd: dir,
   });
-  return { files, meta };
+  return { files, entrypoint };
 }

--- a/packages/now-layer-yarn/src/index.ts
+++ b/packages/now-layer-yarn/src/index.ts
@@ -1,20 +1,29 @@
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { glob } from '@now/build-utils';
+import { glob, Files } from '@now/build-utils';
 import { mkdir, remove, pathExists } from 'fs-extra';
 import { install } from './install';
 
-interface LayerConfig {
+interface BuildLayerConfig {
   runtimeVersion: string;
   platform: string;
   arch: string;
+}
+
+interface BuildLayerMeta {
+  [key: string]: string;
+}
+
+interface BuildLayerResult {
+  files: Files;
+  meta: BuildLayerMeta;
 }
 
 export async function buildLayer({
   runtimeVersion,
   platform,
   arch,
-}: LayerConfig) {
+}: BuildLayerConfig): Promise<BuildLayerResult> {
   const dir = join(
     tmpdir(),
     `now-layer-yarn-${runtimeVersion}-${platform}-${arch}`
@@ -24,9 +33,9 @@ export async function buildLayer({
     await remove(dir);
   }
   await mkdir(dir);
-  await install(dir, runtimeVersion);
+  const meta = await install(dir, runtimeVersion);
   const files = await glob('{bin/**,lib/**}', {
     cwd: dir,
   });
-  return { files };
+  return { files, meta };
 }

--- a/packages/now-layer-yarn/src/index.ts
+++ b/packages/now-layer-yarn/src/index.ts
@@ -10,14 +10,9 @@ interface BuildLayerConfig {
   arch: string;
 }
 
-interface BuildLayerMeta {
-  [key: string]: string;
-}
-
 interface BuildLayerResult {
   files: Files;
   entrypoint: string;
-  meta?: BuildLayerMeta;
 }
 
 export async function buildLayer({

--- a/packages/now-layer-yarn/src/install.ts
+++ b/packages/now-layer-yarn/src/install.ts
@@ -24,6 +24,6 @@ export async function install(dest: string, version: string) {
 
   const pathToManifest = join(dest, 'package.json');
   const manifest = require(pathToManifest);
-  const entrypoint = manifest.bin;
+  const entrypoint = manifest.bin.yarn;
   return { entrypoint };
 }

--- a/packages/now-layer-yarn/src/install.ts
+++ b/packages/now-layer-yarn/src/install.ts
@@ -22,6 +22,8 @@ export async function install(dest: string, version: string) {
     extractStream
   );
 
-  const entrypoint = join('bin', 'yarn.js');
+  const pathToManifest = join(dest, 'package.json');
+  const manifest = require(pathToManifest);
+  const entrypoint = manifest.bin;
   return { entrypoint };
 }

--- a/packages/now-layer-yarn/src/install.ts
+++ b/packages/now-layer-yarn/src/install.ts
@@ -1,3 +1,4 @@
+import { join } from 'path';
 import fetch from 'node-fetch';
 import { extract } from 'tar';
 import pipe from 'promisepipe';
@@ -20,4 +21,7 @@ export async function install(dest: string, version: string) {
     res.body,
     extractStream
   );
+
+  const entrypoint = join('bin', 'yarn.js');
+  return { entrypoint };
 }

--- a/packages/now-layer-yarn/test/test.js
+++ b/packages/now-layer-yarn/test/test.js
@@ -4,28 +4,28 @@ const { buildLayer } = require('../');
 
 describe('buildLayer', () => {
   it('should get yarn for windows', async () => {
-    const { files, meta } = await buildLayer({
+    const { files, entrypoint } = await buildLayer({
       runtimeVersion: '1.16.0',
       platform: 'win32',
       arch: 'x64',
     });
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
-    expect(meta.entrypoint).toBe('./bin/yarn.js');
+    expect(entrypoint).toBe('./bin/yarn.js');
     expect(names.size).toBeGreaterThan(0);
     expect(names.has('bin/yarn.cmd')).toBeTruthy();
     expect(names.has('lib/cli.js')).toBeTruthy();
   });
 
   it('should get yarn for macos', async () => {
-    const { files, meta } = await buildLayer({
+    const { files, entrypoint } = await buildLayer({
       runtimeVersion: '1.16.0',
       platform: 'darwin',
       arch: 'x64',
     });
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
-    expect(meta.entrypoint).toBe('./bin/yarn.js');
+    expect(entrypoint).toBe('./bin/yarn.js');
     expect(names.size).toBeGreaterThan(0);
     expect(names.has('bin/yarn')).toBeTruthy();
     expect(names.has('lib/cli.js')).toBeTruthy();
@@ -33,14 +33,14 @@ describe('buildLayer', () => {
   });
 
   it('should get yarn for linux', async () => {
-    const { files, meta } = await buildLayer({
+    const { files, entrypoint } = await buildLayer({
       runtimeVersion: '1.16.0',
       platform: 'linux',
       arch: 'x64',
     });
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
-    expect(meta.entrypoint).toBe('./bin/yarn.js');
+    expect(entrypoint).toBe('./bin/yarn.js');
     expect(names.size).toBeGreaterThan(0);
     expect(names.has('bin/yarn')).toBeTruthy();
     expect(names.has('lib/cli.js')).toBeTruthy();

--- a/packages/now-layer-yarn/test/test.js
+++ b/packages/now-layer-yarn/test/test.js
@@ -4,26 +4,28 @@ const { buildLayer } = require('../');
 
 describe('buildLayer', () => {
   it('should get yarn for windows', async () => {
-    const { files } = await buildLayer({
+    const { files, meta } = await buildLayer({
       runtimeVersion: '1.16.0',
       platform: 'win32',
       arch: 'x64',
     });
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
+    expect(meta.entrypoint).toBeTruthy();
     expect(names.size).toBeGreaterThan(0);
     expect(names.has('bin/yarn.cmd')).toBeTruthy();
     expect(names.has('lib/cli.js')).toBeTruthy();
   });
 
   it('should get yarn for macos', async () => {
-    const { files } = await buildLayer({
+    const { files, meta } = await buildLayer({
       runtimeVersion: '1.16.0',
       platform: 'darwin',
       arch: 'x64',
     });
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
+    expect(meta.entrypoint).toBeTruthy();
     expect(names.size).toBeGreaterThan(0);
     expect(names.has('bin/yarn')).toBeTruthy();
     expect(names.has('lib/cli.js')).toBeTruthy();
@@ -31,13 +33,14 @@ describe('buildLayer', () => {
   });
 
   it('should get yarn for linux', async () => {
-    const { files } = await buildLayer({
+    const { files, meta } = await buildLayer({
       runtimeVersion: '1.16.0',
       platform: 'linux',
       arch: 'x64',
     });
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
+    expect(meta.entrypoint).toBeTruthy();
     expect(names.size).toBeGreaterThan(0);
     expect(names.has('bin/yarn')).toBeTruthy();
     expect(names.has('lib/cli.js')).toBeTruthy();

--- a/packages/now-layer-yarn/test/test.js
+++ b/packages/now-layer-yarn/test/test.js
@@ -11,7 +11,7 @@ describe('buildLayer', () => {
     });
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
-    expect(meta.entrypoint).toBeTruthy();
+    expect(meta.entrypoint).toBe('./bin/yarn.js');
     expect(names.size).toBeGreaterThan(0);
     expect(names.has('bin/yarn.cmd')).toBeTruthy();
     expect(names.has('lib/cli.js')).toBeTruthy();
@@ -25,7 +25,7 @@ describe('buildLayer', () => {
     });
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
-    expect(meta.entrypoint).toBeTruthy();
+    expect(meta.entrypoint).toBe('./bin/yarn.js');
     expect(names.size).toBeGreaterThan(0);
     expect(names.has('bin/yarn')).toBeTruthy();
     expect(names.has('lib/cli.js')).toBeTruthy();
@@ -40,7 +40,7 @@ describe('buildLayer', () => {
     });
     const names = new Set(Object.keys(files));
     expect(names).toBeTruthy();
-    expect(meta.entrypoint).toBeTruthy();
+    expect(meta.entrypoint).toBe('./bin/yarn.js');
     expect(names.size).toBeGreaterThan(0);
     expect(names.has('bin/yarn')).toBeTruthy();
     expect(names.has('lib/cli.js')).toBeTruthy();


### PR DESCRIPTION
This adds `entrypoint` to the return result of each layer which contains a path to the entrypoint, for example the binary for Node or the script for Yarn.

In a future PR, we might want to move this new interface to the `@now/build-utils` package to make it easier to write type safe layers.