### PR TITLE
Update publish instructions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ This is a monorepo containing the [Official Builders](https://zeit.co/docs/v2/de
 
 There are two Channels:
 
-| Channel | Git Branch | npm dist-tag | use example  |
-|---------|-----------|------------|---------------------|
-| Canary  | `canary`  | `@canary`  | `@now/node@canary`  |
-| Stable  | `master`  | `@latest`  | `@now/node@latest`  |
+| Channel | Git Branch | npm dist-tag | use example        |
+| ------- | ---------- | ------------ | ------------------ |
+| Canary  | `canary`   | `@canary`    | `@now/node@canary` |
+| Stable  | `master`   | `@latest`    | `@now/node@latest` |
 
 All PRs should be submitted to the `canary` branch.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ git pull      # make sure you're up to date
 git cherry-pick <PR501_COMMIT_SHA>
 git cherry-pick <PR502_COMMIT_SHA>
 git cherry-pick <PR503_COMMIT_SHA>
+git cherry-pick <PR504_COMMIT_SHA>
 # ... etc ...
 yarn publish-stable
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ There are two Channels:
 
 All PRs should be submitted to the `canary` branch.
 
-Onced a PR is merged into the `canary` branch, it should be published to npm immediately using the Canary Channel.
+Once a PR is merged into the `canary` branch, it should be published to npm immediately using the Canary Channel.
 
 ### Publishing to npm
 

--- a/README.md
+++ b/README.md
@@ -2,28 +2,40 @@
 
 This is a monorepo containing the [Official Builders](https://zeit.co/docs/v2/deployments/builders/overview) provided by the ZEIT team.
 
-There are two branches:
+## Channels
 
-- canary - published to npm as `canary` dist-tag, eg `@now/node@canary`
-- master - published to npm as `latest` dist-tag, eg `@now/node@latest`
+There are two Channels:
+
+| Channel | Git Branch | npm dist-tag | use example  |
+|---------|-----------|------------|---------------------|
+| Canary  | `canary`  | `@canary`  | `@now/node@canary`  |
+| Stable  | `master`  | `@latest`  | `@now/node@latest`  |
+
+All PRs should be submitted to the `canary` branch.
+
+Onced a PR is merged into the `canary` branch, it should be published to npm immediately using the Canary Channel.
 
 ### Publishing to npm
 
-Run the following command to publish modified builders to npm:
-
-For the stable channel use:
-
-```
-yarn publish-stable
-```
-
-For the canary channel use:
+For the Canary Channel, publish the modified Builders to npm with the following:
 
 ```
 yarn publish-canary
 ```
 
-GitHub Actions will take care of publishing the updated packages to npm from there.
+For the Stable Channel, you must cherry pick each commit from canary to master and then deploy the modified Builders:
+
+```
+git checkout master
+git pull      # make sure you're up to date
+git cherry-pick <PR501_COMMIT_SHA>
+git cherry-pick <PR502_COMMIT_SHA>
+git cherry-pick <PR503_COMMIT_SHA>
+# ... etc ...
+yarn publish-stable
+```
+
+After running this publish step, GitHub Actions will take care of publishing the modified Builder packages to npm.
 
 If for some reason GitHub Actions fails to publish the npm package, you may do so
 manually by running `npm publish` from the package directory. Make sure to

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
     "*.ts": [
       "prettier --write",
       "git add"
+    ],
+    "*.md": [
+      "prettier --write",
+      "git add"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
Thanks to @leo for the instructions, we will now follow the same [canary cherry-pick](https://leo.im/2017/canary/) workflow that `now-cli` and `now-desktop` follow.

I also added markdown files to the prettier lint step.