### PR TITLE
Fix `content-type: application/json` header being added even if body is `undefined`

### DIFF
--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -82,13 +82,13 @@ async function testDeployment (
   for (const probe of nowJson.probes || []) {
     console.log('testing', JSON.stringify(probe));
     const probeUrl = `https://${deploymentUrl}${probe.path}`;
-    const { text, resp } = await fetchDeploymentUrl(probeUrl, {
-      method: probe.method,
-      body: probe.body ? JSON.stringify(probe.body) : undefined,
-      headers: {
-        'content-type': 'application/json',
-      },
-    });
+    const fetchOpts = { method: probe.method, headers: { ...probe.headers } };
+    if (probe.body) {
+      fetchOpts.headers['content-type'] = 'application/json';
+      fetchOpts.body = JSON.stringify(probe.body);
+    }
+    const { text, resp } = await fetchDeploymentUrl(probeUrl, fetchOpts);
+
     if (probe.mustContain) {
       if (!text.includes(probe.mustContain)) {
         await fs.writeFile(path.join(__dirname, 'failed-page.txt'), text);


### PR DESCRIPTION
https://github.com/zeit/now-builders/blob/65afda101f849908097c6f7577dc73e3d36d9960/test/lib/deployment/test-deployment.js#L85-L91

These lines were always sending a `content-type: application/json` header, even if the body is `undefined`.

This PR aims at fixing this.