### PR TITLE
[now-rust] config.includeFiles can be `string[]`

### DIFF
--- a/packages/now-rust/index.ts
+++ b/packages/now-rust/index.ts
@@ -119,7 +119,10 @@ async function buildWholeProject(
   return lambdas;
 }
 
-async function gatherExtraFiles(globMatcher: string, entrypoint: string) {
+async function gatherExtraFiles(
+  globMatcher: string | string[] | undefined,
+  entrypoint: string
+) {
   if (!globMatcher) return {};
 
   console.log('gathering extra files for the fs...');


### PR DESCRIPTION
`config.includeFiles` can be of type `string[]`.

Example in the fixtures :
https://github.com/zeit/now-builders/blob/6aeda0363a461069608d0b913bed467525b6feb4/packages/now-rust/test/fixtures/01-include-files/now.json#L8

It is passed to `gatherExtraFiles` as `globMatcher` which had an incorrect type.
