### PR TITLE
[now-node] Add tests for types exports

### DIFF
--- a/packages/now-node/jest.config.js
+++ b/packages/now-node/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  globals: {
+    'ts-jest': {
+      diagnostics: false,
+    },
+  },
+};

--- a/packages/now-node/jest.config.js
+++ b/packages/now-node/jest.config.js
@@ -1,9 +1,4 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  globals: {
-    'ts-jest': {
-      diagnostics: false,
-    },
-  },
 };

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -25,13 +25,16 @@
   "devDependencies": {
     "@types/content-type": "1.1.3",
     "@types/cookie": "0.3.3",
+    "@types/jest": "24.0.13",
     "@types/node": "11.9.4",
+    "@types/test-listen": "1.1.0",
     "content-type": "1.0.4",
     "cookie": "0.4.0",
     "jest": "24.1.0",
     "node-fetch": "2.6.0",
     "raw-body": "2.4.0",
     "test-listen": "1.1.0",
+    "ts-jest": "24.0.2",
     "typescript": "3.3.3"
   }
 }

--- a/packages/now-node/src/helpers.ts
+++ b/packages/now-node/src/helpers.ts
@@ -3,6 +3,7 @@ import { Stream } from 'stream';
 import getRawBody from 'raw-body';
 import { URL } from 'url';
 import { parse as parseCT } from 'content-type';
+import { RequestListener } from 'http';
 import { NowRequest, NowResponse } from './types';
 
 type NowListener = (req: NowRequest, res: NowResponse) => void | Promise<void>;
@@ -125,8 +126,11 @@ export function sendError(
   res.end();
 }
 
-export function addHelpers(listener: NowListener): NowListener {
-  return async function(req, res) {
+export function addHelpers(listener: NowListener): RequestListener {
+  return async function(_req, _res) {
+    const req = _req as NowRequest;
+    const res = _res as NowResponse;
+
     try {
       req.cookies = parseCookies(req.headers.cookie || '');
       req.query = parseQuery(req);

--- a/packages/now-node/test/helpers.test.ts
+++ b/packages/now-node/test/helpers.test.ts
@@ -1,16 +1,24 @@
 /* global beforeAll, beforeEach, afterAll, expect, it, jest */
 import fetch from 'node-fetch';
-import { createServer } from 'http';
+import { createServer, Server } from 'http';
 import listen from 'test-listen';
 import { mocked } from 'ts-jest/utils';
 
+import { NowRequest, NowResponse } from '../src/index';
 import { addHelpers } from '../src/helpers';
 
-const mockListener = mocked(jest.fn(), true);
+const mockListener = mocked(
+  jest.fn(
+    (req: NowRequest, res: NowResponse): void => {
+      res.status(200);
+    }
+  ),
+  true
+);
 const listener = addHelpers(mockListener);
 
-let server: any;
-let url: any;
+let server: Server;
+let url: string;
 
 beforeAll(async () => {
   server = createServer(listener);
@@ -26,7 +34,7 @@ afterAll(async () => {
 });
 
 it('req.query should reflect querystring in the url', async () => {
-  mockListener.mockImplementation((req, res) => {
+  mockListener.mockImplementation((req: NowRequest, res: NowResponse) => {
     res.send('hello');
   });
 

--- a/packages/now-node/test/helpers.test.ts
+++ b/packages/now-node/test/helpers.test.ts
@@ -4,7 +4,10 @@ import { createServer, Server } from 'http';
 import listen from 'test-listen';
 import { mocked } from 'ts-jest/utils';
 
+// we intentionally import these types from src/index
+// to test that they are exported
 import { NowRequest, NowResponse } from '../src/index';
+
 import { addHelpers } from '../src/helpers';
 
 const mockListener = mocked(

--- a/packages/now-node/test/helpers.test.ts
+++ b/packages/now-node/test/helpers.test.ts
@@ -1,15 +1,16 @@
 /* global beforeAll, beforeEach, afterAll, expect, it, jest */
-const listen = require('test-listen');
-const { createServer } = require('http');
-const fetch = require('node-fetch');
+import fetch from 'node-fetch';
+import { createServer } from 'http';
+import listen from 'test-listen';
+import { mocked } from 'ts-jest/utils';
 
-const { addHelpers } = require('../dist/helpers');
+import { addHelpers } from '../src/helpers';
 
-const mockListener = jest.fn();
+const mockListener = mocked(jest.fn(), true);
 const listener = addHelpers(mockListener);
 
-let server;
-let url;
+let server: any;
+let url: any;
 
 beforeAll(async () => {
   server = createServer(listener);
@@ -104,7 +105,7 @@ it('res.json() should send json', async () => {
   const res = await fetch(url);
 
   expect(res.headers.get('content-type').includes('application/json')).toBe(
-    true,
+    true
   );
   expect(await res.json()).toMatchObject({ who: 'bill' });
 });

--- a/packages/now-node/test/helpers.test.ts
+++ b/packages/now-node/test/helpers.test.ts
@@ -8,12 +8,7 @@ import { NowRequest, NowResponse } from '../src/index';
 import { addHelpers } from '../src/helpers';
 
 const mockListener = mocked(
-  jest.fn(
-    (req: NowRequest, res: NowResponse): void => {
-      res.status(200);
-    }
-  ),
-  true
+  jest.fn((req: NowRequest, res: NowResponse): void => {})
 );
 const listener = addHelpers(mockListener);
 
@@ -34,7 +29,7 @@ afterAll(async () => {
 });
 
 it('req.query should reflect querystring in the url', async () => {
-  mockListener.mockImplementation((req: NowRequest, res: NowResponse) => {
+  mockListener.mockImplementation((req, res) => {
     res.send('hello');
   });
 
@@ -111,10 +106,9 @@ it('res.json() should send json', async () => {
   });
 
   const res = await fetch(url);
+  const contentType = res.headers.get('content-type') || '';
 
-  expect(res.headers.get('content-type').includes('application/json')).toBe(
-    true
-  );
+  expect(contentType.includes('application/json')).toBe(true);
   expect(await res.json()).toMatchObject({ who: 'bill' });
 });
 

--- a/packages/now-node/tsconfig.json
+++ b/packages/now-node/tsconfig.json
@@ -8,10 +8,7 @@
     "outDir": "dist",
     "sourceMap": false,
     "declaration": true,
-    "typeRoots": [
-      "./@types",
-      "./node_modules/@types"
-    ]
+    "typeRoots": ["./@types", "./node_modules/@types"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1016,6 +1016,18 @@
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz#1eb8c033e98cf4e1a4cedcaf8bcafe8cb7591e85"
   integrity sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==
 
+"@types/jest-diff@*":
+  version "20.0.1"
+  resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
+  integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
+
+"@types/jest@24.0.13":
+  version "24.0.13"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.13.tgz#10f50b64cb05fb02411fbba49e9042a3a11da3f9"
+  integrity sha512-3m6RPnO35r7Dg+uMLj1+xfZaOgIHHHut61djNjzwExXN4/Pm9has9C6I1KMYSfz7mahDhWUOVg4HW/nZdv5Pww==
+  dependencies:
+    "@types/jest-diff" "*"
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -1108,6 +1120,13 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/tar/-/tar-4.0.0.tgz#e3239d969eeb693a012200613860d0eb871c94f0"
   integrity sha512-YybbEHNngcHlIWVCYsoj7Oo1JU9JqONuAlt1LlTH/lmL8BMhbzdFUgReY87a05rY1j8mfK47Del+TCkaLAXwLw==
+  dependencies:
+    "@types/node" "*"
+
+"@types/test-listen@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/test-listen/-/test-listen-1.1.0.tgz#db7e5b0e277b4a3ee7b90770dae1a41b186458af"
+  integrity sha512-y6ZfbSzYHniCeY6ZAzsQjSAdJInNVoEz4Uhsb81W+RCoNYA59yoG/+XbqPqCPj2KCU3Wa6RFWSozutkGIHIsNQ==
   dependencies:
     "@types/node" "*"
 
@@ -1908,6 +1927,13 @@ browser-resolve@^1.11.3:
   dependencies:
     resolve "1.1.7"
 
+bs-logger@0.x:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
+  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
+  dependencies:
+    fast-json-stable-stringify "2.x"
+
 bser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
@@ -1938,7 +1964,7 @@ buffer-fill@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
   integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
 
-buffer-from@^1.0.0:
+buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
@@ -3549,7 +3575,7 @@ fast-glob@^2.0.2:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
@@ -6309,17 +6335,17 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
-  integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
-
-json5@^2.1.0:
+json5@2.x, json5@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
   integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
   dependencies:
     minimist "^1.2.0"
+
+json5@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+  integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -6801,6 +6827,11 @@ make-dir@^1.0.0, make-dir@^1.3.0:
   dependencies:
     pify "^3.0.0"
 
+make-error@1.x:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
+  integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==
+
 make-fetch-happen@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-4.0.1.tgz#141497cb878f243ba93136c83d8aba12c216c083"
@@ -7104,7 +7135,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
+mkdirp@0.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -8636,6 +8667,13 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
+resolve@1.x:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
+  integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
+  dependencies:
+    path-parse "^1.0.6"
+
 resolve@^1.3.2:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
@@ -8825,6 +8863,11 @@ semver@^4.0.3:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
   integrity sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=
+
+semver@^5.5:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
+  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
 
 semver@~5.3.0:
   version "5.3.0"
@@ -9718,6 +9761,21 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.3.tgz#e29bd1614c6458d44869fc28b255ab7857ef7c24"
   integrity sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==
 
+ts-jest@24.0.2:
+  version "24.0.2"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.0.2.tgz#8dde6cece97c31c03e80e474c749753ffd27194d"
+  integrity sha512-h6ZCZiA1EQgjczxq+uGLXQlNgeg02WWJBbeT8j6nyIBRQdglqbvzDoHahTEIiS6Eor6x8mK6PfZ7brQ9Q6tzHw==
+  dependencies:
+    bs-logger "0.x"
+    buffer-from "1.x"
+    fast-json-stable-stringify "2.x"
+    json5 "2.x"
+    make-error "1.x"
+    mkdirp "0.x"
+    resolve "1.x"
+    semver "^5.5"
+    yargs-parser "10.x"
+
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
@@ -10343,6 +10401,13 @@ yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
+
+yargs-parser@10.x:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
+  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
+  dependencies:
+    camelcase "^4.1.0"
 
 yargs-parser@^11.1.1:
   version "11.1.1"


### PR DESCRIPTION
This PR :
- translate existing helpers tests in ts
- make tests fail if types `NowRequest` and `NowResponse` are not exported from `index.ts`