### PR TITLE
[now-node] Change helpers to opt-in

### DIFF
--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -175,7 +175,7 @@ export async function build({
   config,
   meta = {},
 }: BuildOptions) {
-  const shouldAddHelpers = !(config && config.helpers === false);
+  const shouldAddHelpers = config && config.helpers;
 
   const {
     entrypointPath,

--- a/packages/now-node/test/fixtures/15-helpers/now.json
+++ b/packages/now-node/test/fixtures/15-helpers/now.json
@@ -1,13 +1,9 @@
 {
   "version": 2,
   "builds": [
-    { "src": "index.js", "use": "@now/node", "helpers": true },
-    { "src": "ts/index.ts", "use": "@now/node", "helpers": true },
-    {
-      "src": "no-helpers/index.js",
-      "use": "@now/node",
-      "config": { "helpers": false }
-    }
+    { "src": "index.js", "use": "@now/node", "config": { "helpers": true } },
+    { "src": "ts/index.ts", "use": "@now/node", "config": { "helpers": true } },
+    { "src": "no-helpers/index.js", "use": "@now/node" }
   ],
   "probes": [
     {

--- a/packages/now-node/test/fixtures/15-helpers/now.json
+++ b/packages/now-node/test/fixtures/15-helpers/now.json
@@ -1,8 +1,8 @@
 {
   "version": 2,
   "builds": [
-    { "src": "index.js", "use": "@now/node" },
-    { "src": "ts/index.ts", "use": "@now/node" },
+    { "src": "index.js", "use": "@now/node", "helpers": true },
+    { "src": "ts/index.ts", "use": "@now/node", "helpers": true },
     {
       "src": "no-helpers/index.js",
       "use": "@now/node",


### PR DESCRIPTION
PR #577 (released in `@now/node0.8.0`) broke body parsing when using `micro` and other packages.
I have since moved the `latest` dist-tag back to `0.7.4`.

This PR changes the `helpers` config to be opt-in until we can figure out a proper fix on Monday.
If we merge this in soon, I can do another release as `@now/node0.8.1`.