### PR TITLE
[now-next] Update appending of `.html` to auto exported routes

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -510,7 +510,7 @@ export const build = async ({
   ).map(route => {
     // make sure .html is added to dest for now until
     // outputting static files to clean routes is available
-    if (staticPages[`${route.dest}.html`]) {
+    if (staticPages[`${route.dest}.html`.substr(1)]) {
       route.dest = `${route.dest}.html`;
     }
     return route;


### PR DESCRIPTION
Updates check to make sure it checks without leading slash. Tested at `@ijjk/now-next@0.0.1-dev.7` Example project [here](https://dynamic.jj4.now.sh)