### PR TITLE
[now-static-build] Should fail build when distDir is empty

### DIFF
--- a/packages/now-static-build/test/fixtures/05-empty-dist-dir/now.json
+++ b/packages/now-static-build/test/fixtures/05-empty-dist-dir/now.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@now/static-build"
+    }
+  ]
+}

--- a/packages/now-static-build/test/fixtures/05-empty-dist-dir/package.json
+++ b/packages/now-static-build/test/fixtures/05-empty-dist-dir/package.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "now-build": "mkdir dist"
+  }
+}

--- a/packages/now-static-build/test/fixtures/06-missing-script/now.json
+++ b/packages/now-static-build/test/fixtures/06-missing-script/now.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@now/static-build"
+    }
+  ]
+}

--- a/packages/now-static-build/test/fixtures/06-missing-script/package.json
+++ b/packages/now-static-build/test/fixtures/06-missing-script/package.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "example": "echo 'nothing here'"
+  }
+}

--- a/packages/now-static-build/test/test.js
+++ b/packages/now-static-build/test/test.js
@@ -18,10 +18,15 @@ beforeAll(async () => {
 });
 
 const fixturesPath = path.resolve(__dirname, 'fixtures');
+const testsThatFailToBuild = new Set([
+  '04-wrong-dist-dir',
+  '05-empty-dist-dir',
+  '06-missing-script',
+]);
 
 // eslint-disable-next-line no-restricted-syntax
 for (const fixture of fs.readdirSync(fixturesPath)) {
-  if (fixture === '04-wrong-dist-dir') {
+  if (testsThatFailToBuild.has(fixture)) {
     // eslint-disable-next-line no-loop-func
     it(`should not build ${fixture}`, async () => {
       try {


### PR DESCRIPTION
Fixes #8 so that the build fails immediately if the `config.distDir` is not a directory or if the `config.distDir` is empty.

Before this PR, the only validation was to check if `distDir` exists (which is still there).

I also updated the error message so that it links to the Local Development section if using `now dev`.

Lastly, I added tests so we don't regress.