### PR TITLE
[now-node-bridge] Make normalized events consumable by server

### DIFF
--- a/packages/now-node-bridge/src/bridge.ts
+++ b/packages/now-node-bridge/src/bridge.ts
@@ -95,9 +95,13 @@ export class Bridge {
   private server: Server | null;
   private listening: Promise<AddressInfo>;
   private resolveListening: (info: AddressInfo) => void;
+  private proxyReqs: { [key: string]: NowProxyRequest } = {};
+  private reqSeed: number = 0;
+  private shouldStoreProxyRequests: boolean = false;
 
-  constructor(server?: Server) {
+  constructor(server?: Server, shouldStoreProxyRequests: boolean = false) {
     this.server = null;
+    this.shouldStoreProxyRequests = shouldStoreProxyRequests;
     if (server) {
       this.setServer(server);
     }
@@ -144,15 +148,16 @@ export class Bridge {
     context.callbackWaitsForEmptyEventLoop = false;
     const { port } = await this.listening;
 
-    const { isApiGateway, method, path, headers, body } = normalizeEvent(event);
+    const proxyReq = normalizeEvent(event);
+    const { isApiGateway, method, path, headers, body } = proxyReq;
 
-    const opts = {
-      hostname: '127.0.0.1',
-      port,
-      path,
-      method,
-      headers,
-    };
+    if (this.shouldStoreProxyRequests) {
+      const reqId = `${this.reqSeed++}`;
+      this.proxyReqs[reqId] = proxyReq;
+      headers['x-bridge-reqid'] = reqId;
+    }
+
+    const opts = { hostname: '127.0.0.1', port, path, method, headers };
 
     // eslint-disable-next-line consistent-return
     return new Promise((resolve, reject) => {
@@ -191,5 +196,11 @@ export class Bridge {
       if (body) req.write(body);
       req.end();
     });
+  }
+
+  consumeProxyRequest(reqId: string) {
+    const proxyReq = this.proxyReqs[reqId];
+    delete this.proxyReqs[reqId];
+    return proxyReq;
   }
 }

--- a/packages/now-node-bridge/src/bridge.ts
+++ b/packages/now-node-bridge/src/bridge.ts
@@ -154,7 +154,7 @@ export class Bridge {
     if (this.shouldStoreEvents) {
       const reqId = `${this.reqIdSeed++}`;
       this.events[reqId] = normalizedEvent;
-      headers['x-bridge-reqid'] = reqId;
+      headers['x-now-bridge-request-id'] = reqId;
     }
 
     const opts = { hostname: '127.0.0.1', port, path, method, headers };

--- a/packages/now-node-bridge/test/bridge.test.js
+++ b/packages/now-node-bridge/test/bridge.test.js
@@ -108,7 +108,7 @@ test('consumeEvent', async () => {
   );
 
   const headers = mockListener.mock.calls[0][0].headers;
-  const reqId = headers['x-bridge-reqid'];
+  const reqId = headers['x-now-bridge-request-id'];
 
   expect(reqId).toBeTruthy();
 

--- a/packages/now-node-bridge/test/bridge.test.js
+++ b/packages/now-node-bridge/test/bridge.test.js
@@ -84,7 +84,7 @@ test('`NowProxyEvent` normalizing', async () => {
   server.close();
 });
 
-test('consumeProxyRequest', async () => {
+test('consumeEvent', async () => {
   const mockListener = jest.fn((req, res) => {
     res.end('hello');
   });
@@ -112,12 +112,12 @@ test('consumeProxyRequest', async () => {
 
   expect(reqId).toBeTruthy();
 
-  const proxyReq = bridge.consumeProxyRequest(reqId);
-  expect(proxyReq.body.toString()).toBe('body=1');
+  const event = bridge.consumeEvent(reqId);
+  expect(event.body.toString()).toBe('body=1');
 
-  // a proxyRequest can't be consumed multiple times
+  // an event can't be consumed multiple times
   // to avoid memory leaks
-  expect(bridge.consumeProxyRequest(reqId)).toBeUndefined();
+  expect(bridge.consumeEvent(reqId)).toBeUndefined();
 
   server.close();
 });

--- a/packages/now-node-bridge/test/bridge.test.js
+++ b/packages/now-node-bridge/test/bridge.test.js
@@ -83,3 +83,41 @@ test('`NowProxyEvent` normalizing', async () => {
 
   server.close();
 });
+
+test('consumeProxyRequest', async () => {
+  const mockListener = jest.fn((req, res) => {
+    res.end('hello');
+  });
+
+  const server = new Server(mockListener);
+  const bridge = new Bridge(server, true);
+  bridge.listen();
+
+  const context = { callbackWaitsForEmptyEventLoop: true };
+  await bridge.launcher(
+    {
+      Action: 'Invoke',
+      body: JSON.stringify({
+        method: 'POST',
+        headers: { foo: 'baz' },
+        path: '/nowproxy',
+        body: 'body=1',
+      }),
+    },
+    context
+  );
+
+  const headers = mockListener.mock.calls[0][0].headers;
+  const reqId = headers['x-bridge-reqid'];
+
+  expect(reqId).toBeTruthy();
+
+  const proxyReq = bridge.consumeProxyRequest(reqId);
+  expect(proxyReq.body.toString()).toBe('body=1');
+
+  // a proxyRequest can't be consumed multiple times
+  // to avoid memory leaks
+  expect(bridge.consumeProxyRequest(reqId)).toBeUndefined();
+
+  server.close();
+});


### PR DESCRIPTION
This PR is the `now-node-bridge` part of https://github.com/zeit/now-builders/pull/594.

To be able to add `req.body` in listeners and keep compat with express, micro, etc..., we need to make normalized events consumable by a server.

We add a second argument to bridge constructor :
```js
new Bridge(server, true)
// second argument tells bridge to store normalized events
// and send a reqId in `x-now-bridge-request-id` header to consume it
```

Events can be consumed like this :
```js
const event = bridge.consumeEvent(reqId)
```