### PR TITLE
[now-node] Make helpers opt-out instead of opt-in

### DIFF
--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -175,7 +175,7 @@ export async function build({
   config,
   meta = {},
 }: BuildOptions) {
-  const shouldAddHelpers = config && config.helpers;
+  const shouldAddHelpers = !(config && config.helpers === false);
 
   const {
     entrypointPath,

--- a/packages/now-node/test/fixtures/15-helpers/now.json
+++ b/packages/now-node/test/fixtures/15-helpers/now.json
@@ -1,19 +1,15 @@
 {
   "version": 2,
   "builds": [
-    { "src": "index.js", "use": "@now/node", "config": { "helpers": true } },
-    { "src": "ts/index.ts", "use": "@now/node", "config": { "helpers": true } },
+    { "src": "index.js", "use": "@now/node" },
+    { "src": "ts/index.ts", "use": "@now/node" },
+    { "src": "express-compat/index.js", "use": "@now/node" },
+    { "src": "micro-compat/index.js", "use": "@now/node" },
     {
-      "src": "express-compat/index.js",
+      "src": "no-helpers/index.js",
       "use": "@now/node",
-      "config": { "helpers": true }
-    },
-    {
-      "src": "micro-compat/index.js",
-      "use": "@now/node",
-      "config": { "helpers": true }
-    },
-    { "src": "no-helpers/index.js", "use": "@now/node" }
+      "config": { "helpers": false }
+    }
   ],
   "probes": [
     {


### PR DESCRIPTION
Now that helpers are not breaking existing applications (https://github.com/zeit/now-builders/pull/594), we can make helpers opt-out again.