### PR TITLE
[now-node] Move `@types/node` to dependencies

### DIFF
--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@now/node-bridge": "1.2.0-canary.1",
+    "@types/node": "*",
     "@zeit/ncc": "0.18.5",
     "@zeit/ncc-watcher": "1.0.3",
     "fs-extra": "7.0.1"
@@ -25,7 +26,6 @@
   "devDependencies": {
     "@types/content-type": "1.1.3",
     "@types/cookie": "0.3.3",
-    "@types/node": "11.9.4",
     "@types/test-listen": "1.1.0",
     "content-type": "1.0.4",
     "cookie": "0.4.0",

--- a/packages/now-node/src/helpers.ts
+++ b/packages/now-node/src/helpers.ts
@@ -132,7 +132,12 @@ export function createServerWithHelpers(
 
       const event = bridge.consumeEvent(reqId);
 
-      req.cookies = parseCookies(req.headers.cookie || '');
+      let cookies = req.headers.cookie;
+      if (Array.isArray(cookies)) {
+        cookies = cookies.join(';');
+      }
+
+      req.cookies = parseCookies(cookies || '');
       req.query = parseQuery(req);
       req.body = parseBody(req, event.body);
 


### PR DESCRIPTION
We export `NowRequest` and `NowResponse` types that depends on `@types/node` from `@now/node`.

`@types/node` is moved to dependencies for this reason.