### PR TITLE
[now-next] Fix erroneous `.next` folder message

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -166,7 +166,7 @@ export const build = async ({
 
   const entryDirectory = path.dirname(entrypoint);
   const entryPath = path.join(workPath, entryDirectory);
-  const dotNext = path.join(entryPath, '.next');
+  const dotNextStatic = path.join(entryPath, '.next/static');
 
   console.log(`${name} Downloading user files...`);
   await download(files, workPath, meta);
@@ -227,7 +227,7 @@ export const build = async ({
     };
   }
 
-  if (await pathExists(dotNext)) {
+  if (await pathExists(dotNextStatic)) {
     console.warn(
       'WARNING: You should not upload the `.next` directory. See https://zeit.co/docs/v2/deployments/official-builders/next-js-now-next/ for more details.'
     );


### PR DESCRIPTION
We now store the `.next/cache` folder so we need to check for the `static` folder to know if the user uploaded something they should've excluded.

---

Fixes https://github.com/zeit/now-builders/issues/605