### PR TITLE
[now-next] Humanize message about `now-build`

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -259,14 +259,15 @@ export const build = async ({
     console.log('normalized package.json result: ', packageJson);
     await writePackageJson(entryPath, packageJson);
   } else if (!pkg.scripts || !pkg.scripts['now-build']) {
-    console.warn(
-      'WARNING: "now-build" script not found. Adding \'"now-build": "next build"\' to "package.json" automatically'
+    console.log(
+      'Your application is being built using `next build`. ' +
+        'If you need to define a different build step, please create a `now-build` script in your `package.json` ' +
+        '(e.g. `{ "scripts": { "now-build": "npm run prepare && next build" } }`).'
     );
     pkg.scripts = {
       'now-build': 'next build',
       ...(pkg.scripts || {}),
     };
-    console.log('normalized package.json result: ', pkg);
     await writePackageJson(entryPath, pkg);
   }
 


### PR DESCRIPTION
Some users read this message as a warning that required action (the captain caps lock WARNING didn't help).

Users should never need to define a `now-build` script unless they grow out of running `next build`.

Fixes #363