### PR TITLE
[now-node] Improve `@now/node` helpers

### DIFF
--- a/packages/now-node/src/helpers.ts
+++ b/packages/now-node/src/helpers.ts
@@ -146,17 +146,18 @@ export function sendError(
 
 function setLazyProp<T>(req: NowRequest, prop: string, getter: () => T) {
   const opts = { configurable: true, enumerable: true };
+  const optsReset = { ...opts, writable: true };
 
   Object.defineProperty(req, prop, {
     ...opts,
     get: () => {
       const value = getter();
       // we set the property on the object to avoid recalculating it
-      Object.defineProperty(req, prop, { ...opts, writable: true, value });
+      Object.defineProperty(req, prop, { ...optsReset, value });
       return value;
     },
     set: value => {
-      Object.defineProperty(req, prop, { ...opts, writable: true, value });
+      Object.defineProperty(req, prop, { ...optsReset, value });
     },
   });
 }

--- a/packages/now-node/src/helpers.ts
+++ b/packages/now-node/src/helpers.ts
@@ -1,16 +1,16 @@
 import {
   NowRequest,
   NowResponse,
-  RequestCookies,
-  RequestQuery,
-  RequestBody,
+  NowRequestCookies,
+  NowRequestQuery,
+  NowRequestBody,
 } from './types';
 import { Stream } from 'stream';
 import { Server } from 'http';
 import { Bridge } from './bridge';
 
 function getBodyParser(req: NowRequest, body?: Buffer) {
-  return function parseBody(): RequestBody {
+  return function parseBody(): NowRequestBody {
     if (!body || !req.headers['content-type']) {
       return undefined;
     }
@@ -46,7 +46,7 @@ function getBodyParser(req: NowRequest, body?: Buffer) {
 }
 
 function getQueryParser({ url = '/' }: NowRequest) {
-  return function parseQuery(): RequestQuery {
+  return function parseQuery(): NowRequestQuery {
     const { URL } = require('url');
     // we provide a placeholder base url because we only want searchParams
     const params = new URL(url, 'https://n').searchParams;
@@ -61,7 +61,7 @@ function getQueryParser({ url = '/' }: NowRequest) {
 }
 
 function getCookieParser(req: NowRequest) {
-  return function parseCookie(): RequestCookies {
+  return function parseCookie(): NowRequestCookies {
     const header: undefined | string | string[] = req.headers.cookie;
 
     if (!header) {
@@ -182,9 +182,9 @@ export function createServerWithHelpers(
 
       const event = bridge.consumeEvent(reqId);
 
-      setLazyProp<RequestCookies>(req, 'cookies', getCookieParser(req));
-      setLazyProp<RequestQuery>(req, 'query', getQueryParser(req));
-      setLazyProp<RequestBody>(req, 'body', getBodyParser(req, event.body));
+      setLazyProp<NowRequestCookies>(req, 'cookies', getCookieParser(req));
+      setLazyProp<NowRequestQuery>(req, 'query', getQueryParser(req));
+      setLazyProp<NowRequestBody>(req, 'body', getBodyParser(req, event.body));
 
       res.status = statusCode => sendStatusCode(res, statusCode);
       res.send = data => sendData(res, data);
@@ -195,8 +195,7 @@ export function createServerWithHelpers(
       if (err instanceof ApiError) {
         sendError(res, err.statusCode, err.message);
       } else {
-        console.log(err);
-        sendError(res, 500, 'Internal Server Error');
+        throw err;
       }
     }
   });

--- a/packages/now-node/src/types.ts
+++ b/packages/now-node/src/types.ts
@@ -1,13 +1,17 @@
 import { ServerResponse, IncomingMessage } from 'http';
 
+export type RequestCookies = { [key: string]: string };
+export type RequestQuery = { [key: string]: string | string[] };
+export type RequestBody = any;
+
 export type NowRequest = IncomingMessage & {
-  query: { [key: string]: string | string[] };
-  cookies: { [key: string]: string };
-  body: any;
+  query: RequestQuery;
+  cookies: RequestCookies;
+  body: RequestBody;
 };
 
 export type NowResponse = ServerResponse & {
-  send: (body: any) => void;
-  json: (body: any) => void;
-  status: (statusCode: number) => void;
+  send: (body: any) => NowResponse;
+  json: (body: any) => NowResponse;
+  status: (statusCode: number) => NowResponse;
 };

--- a/packages/now-node/src/types.ts
+++ b/packages/now-node/src/types.ts
@@ -1,13 +1,13 @@
 import { ServerResponse, IncomingMessage } from 'http';
 
-export type RequestCookies = { [key: string]: string };
-export type RequestQuery = { [key: string]: string | string[] };
-export type RequestBody = any;
+export type NowRequestCookies = { [key: string]: string };
+export type NowRequestQuery = { [key: string]: string | string[] };
+export type NowRequestBody = any;
 
 export type NowRequest = IncomingMessage & {
-  query: RequestQuery;
-  cookies: RequestCookies;
-  body: RequestBody;
+  query: NowRequestQuery;
+  cookies: NowRequestCookies;
+  body: NowRequestBody;
 };
 
 export type NowResponse = ServerResponse & {

--- a/packages/now-node/test/helpers.test.js
+++ b/packages/now-node/test/helpers.test.js
@@ -279,6 +279,17 @@ it('res.status() should set the status code', async () => {
   expect(res.status).toBe(404);
 });
 
+it('res.status().send() should work', async () => {
+  mockListener.mockImplementation((req, res) => {
+    res.status(404).send('notfound');
+  });
+
+  const res = await fetchWithProxyReq(url);
+
+  expect(res.status).toBe(404);
+  expect(await res.text()).toBe('notfound');
+});
+
 it('res.status().json() should work', async () => {
   mockListener.mockImplementation((req, res) => {
     res.status(404).json({ error: 'not found' });

--- a/packages/now-node/test/helpers.test.js
+++ b/packages/now-node/test/helpers.test.js
@@ -15,6 +15,11 @@ let server;
 let url;
 
 async function fetchWithProxyReq(_url, opts = {}) {
+  if (opts.body) {
+    // eslint-disable-next-line
+    opts = { ...opts, body: Buffer.from(opts.body) };
+  }
+
   consumeEventMock.mockImplementationOnce(() => opts);
 
   return fetch(_url, {
@@ -37,7 +42,7 @@ afterAll(async () => {
   await server.close();
 });
 
-it('createServerWithHelpers should call consumeEvent with the correct reqId', async () => {
+it('should call consumeEvent with the correct reqId', async () => {
   await fetchWithProxyReq(`${url}/`);
 
   expect(consumeEventMock).toHaveBeenLastCalledWith('2');
@@ -46,7 +51,7 @@ it('createServerWithHelpers should call consumeEvent with the correct reqId', as
 it('should not expose the request id header', async () => {
   await fetchWithProxyReq(`${url}/`, { headers: { 'x-test-header': 'ok' } });
 
-  const { headers } = mockListener.mock.calls[0][0];
+  const [{ headers }] = mockListener.mock.calls[0];
 
   expect(headers['x-now-bridge-request-id']).toBeUndefined();
   expect(headers['x-test-header']).toBe('ok');
@@ -59,6 +64,12 @@ it('req.query should reflect querystring in the url', async () => {
     who: 'bill',
     where: 'us',
   });
+});
+
+it('req.query should be {} when there is no querystring', async () => {
+  await fetchWithProxyReq(url);
+  const [{ query }] = mockListener.mock.calls[0];
+  expect(Object.keys(query).length).toBe(0);
 });
 
 it('req.cookies should reflect req.cookie header', async () => {
@@ -74,57 +85,147 @@ it('req.cookies should reflect req.cookie header', async () => {
   });
 });
 
-it('req.body should contain the buffer', async () => {
+it('req.body should be undefined by default', async () => {
+  await fetchWithProxyReq(url);
+  expect(mockListener.mock.calls[0][0].body).toBe(undefined);
+});
+
+it('req.body should be undefined if content-type is not defined', async () => {
   await fetchWithProxyReq(url, {
     method: 'POST',
-    body: Buffer.from('hello'),
+    body: 'hello',
+  });
+  expect(mockListener.mock.calls[0][0].body).toBe(undefined);
+});
+
+it('req.body should be a string when content-type is `text/plain`', async () => {
+  await fetchWithProxyReq(url, {
+    method: 'POST',
+    body: 'hello',
+    headers: { 'content-type': 'text/plain' },
   });
 
-  const { body } = mockListener.mock.calls[0][0];
+  expect(mockListener.mock.calls[0][0].body).toBe('hello');
+});
+
+it('req.body should be a buffer when content-type is `application/octet-stream`', async () => {
+  await fetchWithProxyReq(url, {
+    method: 'POST',
+    body: 'hello',
+    headers: { 'content-type': 'application/octet-stream' },
+  });
+
+  const [{ body }] = mockListener.mock.calls[0];
+
   const str = body.toString();
 
+  expect(Buffer.isBuffer(body)).toBe(true);
   expect(str).toBe('hello');
 });
 
-it('req.body should contained the parsed object when content-type is application/x-www-form-urlencoded', async () => {
+it('req.body should be an object when content-type is `application/x-www-form-urlencoded`', async () => {
   const obj = { who: 'mike' };
 
   await fetchWithProxyReq(url, {
     method: 'POST',
-    body: Buffer.from(qs.encode(obj)),
+    body: qs.encode(obj),
     headers: { 'content-type': 'application/x-www-form-urlencoded' },
   });
 
   expect(mockListener.mock.calls[0][0].body).toMatchObject(obj);
 });
 
-it('req.body should contained the parsed json when content-type is application/json', async () => {
+it('req.body should be an object when content-type is `application/json`', async () => {
   const json = {
     who: 'bill',
     where: 'us',
   };
 
-  mockListener.mockImplementation((req, res) => {
-    res.send('hello');
-  });
-
   await fetchWithProxyReq(url, {
     method: 'POST',
-    body: Buffer.from(JSON.stringify(json)),
+    body: JSON.stringify(json),
     headers: { 'content-type': 'application/json' },
   });
 
   expect(mockListener.mock.calls[0][0].body).toMatchObject(json);
 });
 
+it('should not recalculate req properties twice', async () => {
+  const bodySpy = jest.fn(() => {});
+
+  mockListener.mockImplementation((req, res) => {
+    bodySpy(req.body, req.query, req.cookies);
+    bodySpy(req.body, req.query, req.cookies);
+    res.end();
+  });
+
+  await fetchWithProxyReq(`${url}/?who=bill`, {
+    method: 'POST',
+    body: JSON.stringify({ who: 'mike' }),
+    headers: { 'content-type': 'application/json', cookie: 'who=jim' },
+  });
+
+  // here we test that bodySpy is called twice with exactly the same arguments
+  for (let i = 0; i < 3; i += 1) {
+    expect(bodySpy.mock.calls[0][i]).toBe(bodySpy.mock.calls[1][i]);
+  }
+});
+
+it('should be able to overwrite request properties', async () => {
+  const bodySpy = jest.fn(() => {});
+
+  mockListener.mockImplementation((req, res) => {
+    req.body = 'ok';
+    req.query = 'ok';
+    req.cookies = 'ok';
+    bodySpy(req.body, req.query, req.cookies);
+    res.end();
+  });
+
+  await fetchWithProxyReq(`${url}/?who=bill`, {
+    method: 'POST',
+    body: JSON.stringify({ who: 'mike' }),
+    headers: { 'content-type': 'application/json', cookie: 'who=jim' },
+  });
+
+  for (let i = 0; i < 3; i += 1) {
+    expect(bodySpy.mock.calls[0][i]).toBe('ok');
+  }
+});
+
+it('should be able to try/catch parse errors', async () => {
+  const bodySpy = jest.fn(() => {});
+
+  mockListener.mockImplementation((req, res) => {
+    try {
+      if (req.body === undefined) res.status(400);
+      res.end();
+    } catch (error) {
+      bodySpy(error);
+    }
+  });
+
+  await fetchWithProxyReq(url, {
+    method: 'POST',
+    body: '{"wrong":"json"',
+    headers: { 'content-type': 'application/json' },
+  });
+
+  expect(bodySpy).toHaveBeenCalled();
+
+  const [error] = bodySpy.mock.calls[0];
+  expect(error.message).toBe(/invalid JSON/i);
+  expect(error.statusCode).toBe(400);
+});
+
 it('res.send() should send text', async () => {
   mockListener.mockImplementation((req, res) => {
-    res.send('hello');
+    res.send('hello world');
   });
 
   const res = await fetchWithProxyReq(url);
 
-  expect(await res.text()).toBe('hello');
+  expect(await res.text()).toBe('hello world');
 });
 
 it('res.json() should send json', async () => {
@@ -148,4 +249,15 @@ it('res.status() should set the status code', async () => {
   const res = await fetchWithProxyReq(url);
 
   expect(res.status).toBe(404);
+});
+
+it('res.status().json() should work', async () => {
+  mockListener.mockImplementation((req, res) => {
+    res.status(404).json({ error: 'not found' });
+  });
+
+  const res = await fetchWithProxyReq(url);
+
+  expect(res.status).toBe(404);
+  expect(await res.json()).toMatchObject({ error: 'not found' });
 });


### PR DESCRIPTION
This PR brings a set of improvements to `@now/node`:
- [x] add parser for `text/plain` content-type
- [x] do not set `req.body` to a buffer by default, instead look for `application/octet-stream` content-type
- [x] set `req.body` to undefined by default (body-parser v2 also plans to do so : https://github.com/expressjs/body-parser/issues/288#issuecomment-355399812)
- [x] use getters to lazy load the properties
- [x] method chaining eg. `res.status(200).send('hello')`