### PR TITLE
[now-node] Fix faulty behavior when request's body is empty and content-type is `application/json`

### DIFF
--- a/packages/now-node/src/helpers.ts
+++ b/packages/now-node/src/helpers.ts
@@ -9,9 +9,9 @@ import { Stream } from 'stream';
 import { Server } from 'http';
 import { Bridge } from './bridge';
 
-function getBodyParser(req: NowRequest, body?: Buffer) {
+function getBodyParser(req: NowRequest, body: Buffer) {
   return function parseBody(): NowRequestBody {
-    if (!body || !req.headers['content-type']) {
+    if (!req.headers['content-type']) {
       return undefined;
     }
 

--- a/packages/now-node/test/helpers.test.js
+++ b/packages/now-node/test/helpers.test.js
@@ -159,6 +159,21 @@ it('req.body should be an object when content-type is `application/json`', async
   expect(mockListener.mock.calls[0][0].body).toMatchObject(json);
 });
 
+it('should throw error when body is empty and content-type is `application/json`', async () => {
+  mockListener.mockImplementation((req, res) => {
+    console.log(req.body);
+    res.end();
+  });
+
+  const res = await fetchWithProxyReq(url, {
+    method: 'POST',
+    body: '',
+    headers: { 'content-type': 'application/json' },
+  });
+
+  expect(res.status).toBe(400);
+});
+
 it('should not recalculate req properties twice', async () => {
   const bodySpy = jest.fn(() => {});
 


### PR DESCRIPTION
This PR aims at fixing the edge case where a request is sent and :
- content-type is `application/json`
- body is empty (no body or '')

Previously, `req.body` would be `undefined`. After this PR, request fails with `400 Invalid JSON` error.