### PR TITLE
[tests] Bump typescript to 3.5.2

### DIFF
--- a/packages/now-build-utils/package.json
+++ b/packages/now-build-utils/package.json
@@ -37,6 +37,6 @@
     "@types/semver": "6.0.0",
     "@types/yazl": "^2.4.1",
     "execa": "^1.0.0",
-    "typescript": "3.3.4000"
+    "typescript": "3.5.2"
   }
 }

--- a/packages/now-go/package.json
+++ b/packages/now-go/package.json
@@ -31,6 +31,6 @@
     "@types/fs-extra": "^5.0.5",
     "@types/node-fetch": "^2.3.0",
     "@types/tar": "^4.0.0",
-    "typescript": "^3.4.2"
+    "typescript": "3.5.2"
   }
 }

--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -28,6 +28,6 @@
     "@types/resolve-from": "^5.0.1",
     "@types/semver": "^6.0.0",
     "jest": "^24.7.1",
-    "typescript": "^3.4.3"
+    "typescript": "3.5.2"
   }
 }

--- a/packages/now-node-bridge/package.json
+++ b/packages/now-node-bridge/package.json
@@ -21,6 +21,6 @@
     "@types/aws-lambda": "8.10.19",
     "@types/node": "11.9.4",
     "jest": "24.1.0",
-    "typescript": "3.3.3"
+    "typescript": "3.5.2"
   }
 }

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -31,6 +31,6 @@
     "cookie": "0.4.0",
     "node-fetch": "2.6.0",
     "test-listen": "1.1.0",
-    "typescript": "3.3.3"
+    "typescript": "3.5.2"
   }
 }

--- a/packages/now-optipng/package.json
+++ b/packages/now-optipng/package.json
@@ -21,6 +21,6 @@
   },
   "devDependencies": {
     "@types/node": "11.9.4",
-    "typescript": "3.3.3"
+    "typescript": "3.5.2"
   }
 }

--- a/packages/now-python/package.json
+++ b/packages/now-python/package.json
@@ -23,6 +23,6 @@
   },
   "devDependencies": {
     "@types/execa": "^0.9.0",
-    "typescript": "3.3.4000"
+    "typescript": "3.5.2"
   }
 }

--- a/packages/now-rust/package.json
+++ b/packages/now-rust/package.json
@@ -26,6 +26,6 @@
   "devDependencies": {
     "@types/execa": "^0.9.0",
     "@types/fs-extra": "^7.0.0",
-    "typescript": "^3.4.5"
+    "typescript": "3.5.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9642,30 +9642,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3.tgz#f1657fc7daa27e1a8930758ace9ae8da31403221"
-  integrity sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==
-
-typescript@3.3.4000:
-  version "3.3.4000"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.4000.tgz#76b0f89cfdbf97827e1112d64f283f1151d6adf0"
-  integrity sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==
-
-typescript@^3.4.2:
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.4.tgz#aac4a08abecab8091a75f10842ffa0631818f785"
-  integrity sha512-xt5RsIRCEaf6+j9AyOBgvVuAec0i92rgCaS3S+UVf5Z/vF2Hvtsw08wtUTJqp4djwznoAgjSxeCcU4r+CcDBJA==
-
-typescript@^3.4.3:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.3.tgz#0eb320e4ace9b10eadf5bc6103286b0f8b7c224f"
-  integrity sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==
-
-typescript@^3.4.5:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
-  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
+typescript@3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
+  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
 
 uglify-js@3.4.x:
   version "3.4.9"


### PR DESCRIPTION
This consolidates all the typescript dependencies to the latest 3.5.2 version.

cc @bluelovers

Closes #616 