### PR TITLE
[WIP] Bumps ncc to 0.19.1

### DIFF
--- a/packages/now-node-server/index.js
+++ b/packages/now-node-server/index.js
@@ -46,10 +46,14 @@ async function compile(workPath, downloadedFiles, entrypoint, config) {
   const input = downloadedFiles[entrypoint].fsPath;
   const inputDir = path.dirname(input);
   const ncc = require('@zeit/ncc');
-  const { code, map, assets } = await ncc(input, {
+  const { map, assets, ...results } = await ncc(input, {
     sourceMap: true,
     sourceMapRegister: true,
   });
+  const code = results.files
+    .values()
+    .map(file => file.source)
+    .join('\n');
 
   if (config && config.includeFiles) {
     const includeFiles = typeof config.includeFiles === 'string'

--- a/packages/now-node-server/package.json
+++ b/packages/now-node-server/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@now/node-bridge": "1.2.0-canary.1",
-    "@zeit/ncc": "0.18.5",
+    "@zeit/ncc": "0.19.1",
     "fs-extra": "7.0.1"
   },
   "scripts": {

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@now/node-bridge": "1.2.0-canary.1",
     "@types/node": "*",
-    "@zeit/ncc": "0.18.5",
+    "@zeit/ncc": "0.19.1",
     "@zeit/ncc-watcher": "1.0.3",
     "fs-extra": "7.0.1"
   },

--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -105,7 +105,11 @@ async function compile(
       sourceMap: true,
       sourceMapRegister: true,
     });
-    code = result.code;
+
+    code = Object.values(result.files)
+      .map((file: any) => file.source)
+      .join('\n');
+
     map = result.map;
     assets = result.assets;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,7 +1166,12 @@
   dependencies:
     "@zeit/ncc" "^0.18.5"
 
-"@zeit/ncc@0.18.5", "@zeit/ncc@^0.18.5":
+"@zeit/ncc@0.19.1":
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.19.1.tgz#8914765cff5ddef5645f56de3ce244d3e5000e58"
+  integrity sha512-E7Erja/jzyE8tjfhMgSl+uDX200CGVfSKNcYYiZY2Ds2yHkD9ktDslu6qYZVoBw5ftzHSzv39J40u6mecno1wg==
+
+"@zeit/ncc@^0.18.5":
   version "0.18.5"
   resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.18.5.tgz#5687df6c32f1a2e2486aa110b3454ccebda4fb9c"
   integrity sha512-F+SbvEAh8rchiRXqQbmD1UmbePY7dCOKTbvfFtbVbK2xMH/tyri5YKfNxXKK7eL9EWkkbqB3NTVQO6nokApeBA==


### PR DESCRIPTION
Upgrading the builders to 0.19.1 is necessary for user to be able to use up to date firebase dependencies (see https://github.com/zeit/ncc/issues/412)