### PR TITLE
[now-go] Fix failing build when go.mod exists in a subfolder

### DIFF
--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -136,9 +136,10 @@ Learn more: https://zeit.co/docs/v2/deployments/official-builders/go-now-go/#ent
       isGoModInRootDir = true;
       goModPath = fileDirname;
     } else if (file.includes('go.mod')) {
-      isGoModExist = true;
       if (entrypointDirname === fileDirname) {
+        isGoModExist = true;
         goModPath = fileDirname;
+        break;
       }
     }
   }

--- a/packages/now-go/test/fixtures/14-go-mod-sub/api/index.go
+++ b/packages/now-go/test/fixtures/14-go-mod-sub/api/index.go
@@ -1,0 +1,12 @@
+package nested
+
+import (
+	"fmt"
+	"net/http"
+	"with-nested/shared"
+)
+
+// Handler func
+func Handler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, shared.Say("lol:RANDOMNESS_PLACEHOLDER"))
+}

--- a/packages/now-go/test/fixtures/14-go-mod-sub/api/index.go
+++ b/packages/now-go/test/fixtures/14-go-mod-sub/api/index.go
@@ -1,12 +1,11 @@
-package nested
+package handler
 
 import (
 	"fmt"
 	"net/http"
-	"with-nested/shared"
 )
 
 // Handler func
 func Handler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, shared.Say("lol:RANDOMNESS_PLACEHOLDER"))
+	fmt.Fprintf(w, "hello:RANDOMNESS_PLACEHOLDER")
 }

--- a/packages/now-go/test/fixtures/14-go-mod-sub/now.json
+++ b/packages/now-go/test/fixtures/14-go-mod-sub/now.json
@@ -1,0 +1,5 @@
+{
+  "version": 2,
+  "builds": [{ "src": "api/**/*.go", "use": "@now/go" }],
+  "probes": [{ "path": "/api", "mustContain": "RANDOMNESS_PLACEHOLDER" }]
+}

--- a/packages/now-go/test/fixtures/14-go-mod-sub/other-folder/go.mod
+++ b/packages/now-go/test/fixtures/14-go-mod-sub/other-folder/go.mod
@@ -1,0 +1,3 @@
+module other-folder
+
+go 1.12

--- a/packages/now-go/test/fixtures/14-go-mod-sub/other-folder/index.go
+++ b/packages/now-go/test/fixtures/14-go-mod-sub/other-folder/index.go
@@ -1,0 +1,11 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Handler func
+func Handler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "hello:RANDOMNESS_PLACEHOLDER")
+}


### PR DESCRIPTION
If the directory structure is the following:
```
/api/index.go
/other-folder/index.go
/other-folder/go.mod
```

Then the build will fail.

Build would fail because `isGoModExist` would be set to true without `goModPath` being filled.

This PR fixes that.