### PR TITLE
[now-ruby] Fix ruby publish step

### DIFF
--- a/packages/now-ruby/package.json
+++ b/packages/now-ruby/package.json
@@ -16,10 +16,11 @@
   "scripts": {
     "build": "tsc",
     "test": "tsc && jest",
-    "prepublish": "tsc"
+    "prepublishOnly": "tsc"
   },
   "dependencies": {
     "execa": "^1.0.0",
-    "fs-extra": "^7.0.1"
+    "fs-extra": "^7.0.1",
+    "typescript": "3.5.2"
   }
 }


### PR DESCRIPTION
The `@now/ruby` builder was missing `typescript` as a dependency so `tsc` didn't work