### PR TITLE
[now-build-utils] Enhance node version selection

### DIFF
--- a/packages/now-build-utils/src/fs/node-version.ts
+++ b/packages/now-build-utils/src/fs/node-version.ts
@@ -1,0 +1,39 @@
+import { intersects } from 'semver';
+import { NodeVersion } from '../types';
+
+const supportedOptions: NodeVersion[] = [
+  { major: 10, range: '10.x', runtime: 'nodejs10.x' },
+  { major: 8, range: '8.x', runtime: 'nodejs8.10' },
+];
+
+// This version should match Fargate's default in the PATH
+export const defaultSelection = supportedOptions[supportedOptions.length - 1];
+
+export async function getSupportedNodeVersion(
+  engineRange?: string
+): Promise<NodeVersion> {
+  let selection = defaultSelection;
+
+  if (!engineRange) {
+    console.log(
+      'missing `engines` in `package.json`, using default node v' +
+        selection.major
+    );
+  } else {
+    for (let o of supportedOptions) {
+      if (intersects(o.range, engineRange)) {
+        selection = o;
+        console.log(
+          'found `engines` in `package.json`, selecting node v' +
+            selection.major
+        );
+        return selection; // the array is ordered so break early to use the first (largest) match
+      }
+    }
+    console.log(
+      'WARNING: version of `engines` in `package.json` is not supported, using default node v' +
+        selection.major
+    );
+  }
+  return selection;
+}

--- a/packages/now-build-utils/src/index.ts
+++ b/packages/now-build-utils/src/index.ts
@@ -21,6 +21,8 @@ import {
   runNpmInstall,
   runShellScript,
   enginesMatch,
+  getNodeVersion,
+  getSpawnOptions,
 } from './fs/run-user-scripts';
 import streamToBuffer from './fs/stream-to-buffer';
 import shouldServe from './should-serve';
@@ -44,6 +46,8 @@ export {
   runNpmInstall,
   runShellScript,
   enginesMatch,
+  getNodeVersion,
+  getSpawnOptions,
   streamToBuffer,
   AnalyzeOptions,
   BuildOptions,

--- a/packages/now-build-utils/src/types.ts
+++ b/packages/now-build-utils/src/types.ts
@@ -162,3 +162,28 @@ export interface ShouldServeOptions {
    */
   config: Config;
 }
+
+export interface PackageJson {
+  name: string;
+  version: string;
+  engines?: {
+    [key: string]: string;
+    node: string;
+    npm: string;
+  };
+  scripts?: {
+    [key: string]: string;
+  };
+  dependencies?: {
+    [key: string]: string;
+  };
+  devDependencies?: {
+    [key: string]: string;
+  };
+}
+
+export interface NodeVersion {
+  major: number;
+  range: string;
+  runtime: string;
+}

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -6,6 +6,10 @@ const execa = require('execa');
 const assert = require('assert');
 const { glob, download } = require('../');
 const { createZip } = require('../dist/lambda');
+const {
+  getSupportedNodeVersion,
+  defaultSelection,
+} = require('../dist/fs/node-version');
 
 const {
   packAndDeploy,
@@ -62,6 +66,34 @@ it('should create zip files with symlinks properly', async () => {
   ]);
   assert(linkStat.isSymbolicLink());
   assert(aStat.isFile());
+});
+
+async function getNodeMajor(engines) {
+  const o = await getSupportedNodeVersion(engines);
+  return o.major;
+}
+
+it('should only match supported node versions or fallback to default', async () => {
+  expect(await getNodeMajor('10.x')).toBe(10);
+  expect(await getNodeMajor('9.x')).toBe(defaultSelection);
+  expect(await getNodeMajor('8.x')).toBe(8);
+  expect(await getNodeMajor('6.x')).toBe(defaultSelection);
+  expect(await getSupportedNodeVersion('')).toBe(defaultSelection);
+  expect(await getSupportedNodeVersion(null)).toBe(defaultSelection);
+  expect(await getSupportedNodeVersion(undefined)).toBe(defaultSelection);
+});
+
+it('should match all semver ranges', async () => {
+  // See https://docs.npmjs.com/files/package.json#engines
+  expect(await getNodeMajor('10.0.0')).toBe(10);
+  expect(await getNodeMajor('10.x')).toBe(10);
+  expect(await getNodeMajor('>=10')).toBe(10);
+  expect(await getNodeMajor('>=10.3.0')).toBe(10);
+  expect(await getNodeMajor('8.5.0 - 10.5.0')).toBe(10);
+  expect(await getNodeMajor('>=9.0.0')).toBe(10);
+  expect(await getNodeMajor('>=9.5.0 <=10.5.0')).toBe(10);
+  expect(await getNodeMajor('~10.5.0')).toBe(10);
+  expect(await getNodeMajor('^10.5.0')).toBe(10);
 });
 
 // own fixtures

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -75,9 +75,9 @@ async function getNodeMajor(engines) {
 
 it('should only match supported node versions or fallback to default', async () => {
   expect(await getNodeMajor('10.x')).toBe(10);
-  expect(await getNodeMajor('9.x')).toBe(defaultSelection);
   expect(await getNodeMajor('8.x')).toBe(8);
-  expect(await getNodeMajor('6.x')).toBe(defaultSelection);
+  expect(await getSupportedNodeVersion('6.x')).toBe(defaultSelection);
+  expect(await getSupportedNodeVersion('64.x')).toBe(defaultSelection);
   expect(await getSupportedNodeVersion('')).toBe(defaultSelection);
   expect(await getSupportedNodeVersion(null)).toBe(defaultSelection);
   expect(await getSupportedNodeVersion(undefined)).toBe(defaultSelection);


### PR DESCRIPTION
This PR moves some of the Node version selection logic into `@now/build-utils` so it can be reused in several of our Official Builders.

The public interface changes are the following:

## 1. Add `getNodeVersion()`

There are basically 3 things that can happen in `getNodeVersion`:

- missing `engines`, using default
- found `engines` but does not match, using default
- found `engines`, using matching version

The returned value can be used to find the runtime as well as spawn options.

## 2. Add `getSpawnOptions()`

This helps abstract away the PATH selection so builders dont need to worry about it.

## 3. Deprecate `enginesMatch()`

This is no longer needed and nothing will be using in my next PR to update Builders.

Related to #273