### PR TITLE
[now-build-utils] Remove `enginesMatch` export

### DIFF
--- a/packages/now-build-utils/src/fs/run-user-scripts.ts
+++ b/packages/now-build-utils/src/fs/run-user-scripts.ts
@@ -4,7 +4,6 @@ import path from 'path';
 import spawn from 'cross-spawn';
 import { SpawnOptions } from 'child_process';
 import { deprecate } from 'util';
-import { intersects } from 'semver';
 import { Meta, PackageJson, NodeVersion } from '../types';
 import { getSupportedNodeVersion } from './node-version';
 

--- a/packages/now-build-utils/src/fs/run-user-scripts.ts
+++ b/packages/now-build-utils/src/fs/run-user-scripts.ts
@@ -76,21 +76,6 @@ export async function getNodeVersion(destPath: string): Promise<NodeVersion> {
   return getSupportedNodeVersion(range);
 }
 
-/**
- * @deprecate enginesMatch() is deprecated.
- * Please use getNodeMajorVersion() instead.
- */
-export async function enginesMatch(
-  destPath: string,
-  nodeVersion: string
-): Promise<boolean> {
-  const { packageJson } = await scanParentDirs(destPath, true);
-
-  const engineVersion =
-    packageJson && packageJson.engines && packageJson.engines.node;
-  return intersects(nodeVersion, engineVersion || '0.0.0');
-}
-
 async function scanParentDirs(destPath: string, readPackageJson = false) {
   assert(path.isAbsolute(destPath));
 

--- a/packages/now-build-utils/src/index.ts
+++ b/packages/now-build-utils/src/index.ts
@@ -20,7 +20,6 @@ import {
   runPackageJsonScript,
   runNpmInstall,
   runShellScript,
-  enginesMatch,
   getNodeVersion,
   getSpawnOptions,
 } from './fs/run-user-scripts';
@@ -45,7 +44,6 @@ export {
   runPackageJsonScript,
   runNpmInstall,
   runShellScript,
-  enginesMatch,
   getNodeVersion,
   getSpawnOptions,
   streamToBuffer,


### PR DESCRIPTION
This was added in canary and no stable builders actually use it yet.

I deprecated `enginesMatch` in #648 and then stopped using this method completely in #649 so it should be safe to remove.

The only time it would fail is if someone pinned to this specific canary version: `@now/node@0.5.6-canary.7` (but that is unlikely).

Related to #273 