### PR TITLE
[now-python] Add Python ASGI support

### DIFF
--- a/packages/now-python/now_init.py
+++ b/packages/now-python/now_init.py
@@ -2,10 +2,10 @@ from http.server import BaseHTTPRequestHandler
 
 import base64
 import json
+import inspect
 
 import __NOW_HANDLER_FILENAME
 __now_variables = dir(__NOW_HANDLER_FILENAME)
-
 
 if 'handler' in __now_variables or 'Handler' in __now_variables:
     base = __NOW_HANDLER_FILENAME.handler if ('handler' in __now_variables) else  __NOW_HANDLER_FILENAME.Handler
@@ -47,76 +47,201 @@ if 'handler' in __now_variables or 'Handler' in __now_variables:
             'body': res.text,
         }
 elif 'app' in __now_variables:
-    print('using Web Server Gateway Interface (WSGI)')
-    import sys
-    from urllib.parse import urlparse, unquote
-    from werkzeug._compat import BytesIO
-    from werkzeug._compat import string_types
-    from werkzeug._compat import to_bytes
-    from werkzeug._compat import wsgi_encoding_dance
-    from werkzeug.datastructures import Headers
-    from werkzeug.wrappers import Response
-    def now_handler(event, context):
-        payload = json.loads(event['body'])
+    if not inspect.iscoroutinefunction(__NOW_HANDLER_FILENAME.app.__call__):
+        print('using Web Server Gateway Interface (WSGI)')
+        import sys
+        from urllib.parse import urlparse, unquote
+        from werkzeug._compat import BytesIO
+        from werkzeug._compat import string_types
+        from werkzeug._compat import to_bytes
+        from werkzeug._compat import wsgi_encoding_dance
+        from werkzeug.datastructures import Headers
+        from werkzeug.wrappers import Response
+        def now_handler(event, context):
+            payload = json.loads(event['body'])
 
-        headers = Headers(payload.get('headers', {}))
+            headers = Headers(payload.get('headers', {}))
 
-        body = payload.get('body', '')
-        if body != '':
+            body = payload.get('body', '')
+            if body != '':
+                if payload.get('encoding') == 'base64':
+                    body = base64.b64decode(body)
+            if isinstance(body, string_types):
+                body = to_bytes(body, charset='utf-8')
+
+            url = urlparse(unquote(payload['path']))
+            query = url.query
+            path = url.path
+
+            environ = {
+                'CONTENT_LENGTH': str(len(body)),
+                'CONTENT_TYPE': headers.get('content-type', ''),
+                'PATH_INFO': path,
+                'QUERY_STRING': query,
+                'REMOTE_ADDR': headers.get(
+                    'x-forwarded-for', headers.get(
+                        'x-real-ip', payload.get(
+                            'true-client-ip', ''))),
+                'REQUEST_METHOD': payload['method'],
+                'SERVER_NAME': headers.get('host', 'lambda'),
+                'SERVER_PORT': headers.get('x-forwarded-port', '80'),
+                'SERVER_PROTOCOL': 'HTTP/1.1',
+                'event': event,
+                'context': context,
+                'wsgi.errors': sys.stderr,
+                'wsgi.input': BytesIO(body),
+                'wsgi.multiprocess': False,
+                'wsgi.multithread': False,
+                'wsgi.run_once': False,
+                'wsgi.url_scheme': headers.get('x-forwarded-proto', 'http'),
+                'wsgi.version': (1, 0),
+            }
+
+            for key, value in environ.items():
+                if isinstance(value, string_types) and key != 'QUERY_STRING':
+                    environ[key] = wsgi_encoding_dance(value)
+
+            for key, value in headers.items():
+                key = 'HTTP_' + key.upper().replace('-', '_')
+                if key not in ('HTTP_CONTENT_TYPE', 'HTTP_CONTENT_LENGTH'):
+                    environ[key] = value
+
+            response = Response.from_app(__NOW_HANDLER_FILENAME.app, environ)
+
+            return_dict = {
+                'statusCode': response.status_code,
+                'headers': dict(response.headers)
+            }
+
+            if response.data:
+                return_dict['body'] = base64.b64encode(response.data).decode('utf-8')
+                return_dict['encoding'] = 'base64'
+
+            return return_dict
+    else:
+        print('using Asynchronous Server Gateway Interface (ASGI)')
+        import asyncio
+        import enum
+        from urllib.parse import urlparse, unquote, urlencode
+
+
+        class ASGICycleState(enum.Enum):
+            REQUEST = enum.auto()
+            RESPONSE = enum.auto()
+
+
+        class ASGICycle:
+            def __init__(self, scope):
+                self.scope = scope
+                self.body = b''
+                self.state = ASGICycleState.REQUEST
+                self.app_queue = None
+                self.response = {}
+
+            def __call__(self, app, body):
+                """
+                Receives the application and any body included in the request, then builds the
+                ASGI instance using the connection scope.
+                Runs until the response is completely read from the application.
+                """
+                loop = asyncio.new_event_loop()
+                self.app_queue = asyncio.Queue(loop=loop)
+                self.put_message({'type': 'http.request', 'body': body, 'more_body': False})
+
+                asgi_instance = app(self.scope, self.receive, self.send)
+
+                asgi_task = loop.create_task(asgi_instance)
+                loop.run_until_complete(asgi_task)
+                return self.response
+
+            def put_message(self, message):
+                self.app_queue.put_nowait(message)
+
+            async def receive(self):
+                """
+                Awaited by the application to receive messages in the queue.
+                """
+                message = await self.app_queue.get()
+                return message
+
+            async def send(self, message):
+                """
+                Awaited by the application to send messages to the current cycle instance.
+                """
+                message_type = message['type']
+
+                if self.state is ASGICycleState.REQUEST:
+                    if message_type != 'http.response.start':
+                        raise RuntimeError(
+                            f"Expected 'http.response.start', received: {message_type}"
+                        )
+
+                    status_code = message['status']
+                    headers = {k: v for k, v in message.get('headers', [])}
+
+                    self.on_request(headers, status_code)
+                    self.state = ASGICycleState.RESPONSE
+
+                elif self.state is ASGICycleState.RESPONSE:
+                    if message_type != 'http.response.body':
+                        raise RuntimeError(
+                            f"Expected 'http.response.body', received: {message_type}"
+                        )
+
+                    body = message.get('body', b'')
+                    more_body = message.get('more_body', False)
+
+                    # The body must be completely read before returning the response.
+                    self.body += body
+
+                    if not more_body:
+                        self.on_response()
+                        self.put_message({'type': 'http.disconnect'})
+
+            def on_request(self, headers, status_code):
+                self.response['statusCode'] = status_code
+                self.response['headers'] = {k.decode(): v.decode() for k, v in headers.items()}
+
+            def on_response(self):
+                if self.body:
+                    self.response['body'] = base64.b64encode(self.body).decode('utf-8')
+                    self.response['encoding'] = 'base64'
+
+        def now_handler(event, context):
+            payload = json.loads(event['body'])
+
+            headers = payload.get('headers', {})
+
+            body = payload.get('body', b'')
             if payload.get('encoding') == 'base64':
                 body = base64.b64decode(body)
-        if isinstance(body, string_types):
-            body = to_bytes(body, charset='utf-8')
+            elif not isinstance(body, bytes):
+                body = body.encode()
 
-        url = urlparse(unquote(payload['path']))
-        query = url.query
-        path = url.path
+            url = urlparse(unquote(payload['path']))
+            query = url.query.encode()
+            path = url.path
 
-        environ = {
-            'CONTENT_LENGTH': str(len(body)),
-            'CONTENT_TYPE': headers.get('content-type', ''),
-            'PATH_INFO': path,
-            'QUERY_STRING': query,
-            'REMOTE_ADDR': headers.get(
-                'x-forwarded-for', headers.get(
-                    'x-real-ip', payload.get(
-                        'true-client-ip', ''))),
-            'REQUEST_METHOD': payload['method'],
-            'SERVER_NAME': headers.get('host', 'lambda'),
-            'SERVER_PORT': headers.get('x-forwarded-port', '80'),
-            'SERVER_PROTOCOL': 'HTTP/1.1',
-            'event': event,
-            'context': context,
-            'wsgi.errors': sys.stderr,
-            'wsgi.input': BytesIO(body),
-            'wsgi.multiprocess': False,
-            'wsgi.multithread': False,
-            'wsgi.run_once': False,
-            'wsgi.url_scheme': headers.get('x-forwarded-proto', 'http'),
-            'wsgi.version': (1, 0),
-        }
+            scope = {
+                'server': (headers.get('host', 'lambda'), headers.get('x-forwarded-port', 80)),
+                'client': (headers.get(
+                    'x-forwarded-for', headers.get(
+                        'x-real-ip', payload.get(
+                            'true-client-ip', ''))), 0),
+                'scheme': headers.get('x-forwarded-proto', 'http'),
+                'root_path': '',
+                'query_string': query,
+                'headers': [[k.lower().encode(), v.encode()] for k, v in headers.items()],
+                'type': 'http',
+                'http_version': '1.1',
+                'method': payload['method'],
+                'path': path,
+            }
 
-        for key, value in environ.items():
-            if isinstance(value, string_types) and key != 'QUERY_STRING':
-                environ[key] = wsgi_encoding_dance(value)
+            asgi_cycle = ASGICycle(scope)
+            response = asgi_cycle(__NOW_HANDLER_FILENAME.app, body)
+            return response
 
-        for key, value in headers.items():
-            key = 'HTTP_' + key.upper().replace('-', '_')
-            if key not in ('HTTP_CONTENT_TYPE', 'HTTP_CONTENT_LENGTH'):
-                environ[key] = value
-
-        response = Response.from_app(__NOW_HANDLER_FILENAME.app, environ)
-
-        return_dict = {
-            'statusCode': response.status_code,
-            'headers': dict(response.headers)
-        }
-
-        if response.data:
-            return_dict['body'] = base64.b64encode(response.data).decode('utf-8')
-            return_dict['encoding'] = 'base64'
-
-        return return_dict
 else:
     print('Missing variable `handler` or `app` in file __NOW_HANDLER_FILENAME.py')
     print('See the docs https://zeit.co/docs/v2/deployments/official-builders/python-now-python')

--- a/packages/now-python/now_init.py
+++ b/packages/now-python/now_init.py
@@ -236,6 +236,7 @@ elif 'app' in __now_variables:
                 'http_version': '1.1',
                 'method': payload['method'],
                 'path': path,
+                'raw_path': path.encode(),
             }
 
             asgi_cycle = ASGICycle(scope)

--- a/packages/now-python/test/fixtures/11-asgi/Pipfile
+++ b/packages/now-python/test/fixtures/11-asgi/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+sanic = "*"
+
+[requires]
+python_version = "3.6"

--- a/packages/now-python/test/fixtures/11-asgi/Pipfile.lock
+++ b/packages/now-python/test/fixtures/11-asgi/Pipfile.lock
@@ -1,0 +1,207 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "93dcd591e5690d3a71cb02979cbe317e83e3c03ec020867bf1554a480ef5cd8a"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.6"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "aiofiles": {
+            "hashes": [
+                "sha256:021ea0ba314a86027c166ecc4b4c07f2d40fc0f4b3a950d1868a0f2571c2bbee",
+                "sha256:1e644c2573f953664368de28d2aa4c89dfd64550429d0c27c4680ccd3aa4985d"
+            ],
+            "version": "==0.4.0"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
+                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
+            ],
+            "version": "==2019.6.16"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "h11": {
+            "hashes": [
+                "sha256:acca6a44cb52a32ab442b1779adf0875c443c689e9e028f8d831a3769f9c5208",
+                "sha256:f2b1ca39bfed357d1f19ac732913d5f9faa54a5062eca7d2ec3a916cfb7ae4c7"
+            ],
+            "version": "==0.8.1"
+        },
+        "h2": {
+            "hashes": [
+                "sha256:c8f387e0e4878904d4978cd688a3195f6b169d49b1ffa572a3d347d7adc5e09f",
+                "sha256:fd07e865a3272ac6ef195d8904de92dc7b38dc28297ec39cfa22716b6d62e6eb"
+            ],
+            "version": "==3.1.0"
+        },
+        "hpack": {
+            "hashes": [
+                "sha256:0edd79eda27a53ba5be2dfabf3b15780928a0dff6eb0c60a3d6767720e970c89",
+                "sha256:8eec9c1f4bfae3408a3f30500261f7e6a65912dc138526ea054f9ad98892e9d2"
+            ],
+            "version": "==3.0.0"
+        },
+        "httpcore": {
+            "hashes": [
+                "sha256:96f910b528d47b683242ec207050c7bbaa99cd1b9a07f78ea80cf61e55556b58"
+            ],
+            "version": "==0.3.0"
+        },
+        "httptools": {
+            "hashes": [
+                "sha256:e00cbd7ba01ff748e494248183abc6e153f49181169d8a3d41bb49132ca01dfc"
+            ],
+            "version": "==0.0.13"
+        },
+        "hyperframe": {
+            "hashes": [
+                "sha256:5187962cb16dcc078f23cb5a4b110098d546c3f41ff2d4038a9896893bbd0b40",
+                "sha256:a9f5c17f2cc3c719b917c4f33ed1c61bd1f8dfac4b1bd23b7c80b3400971b41f"
+            ],
+            "version": "==5.2.0"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
+        },
+        "multidict": {
+            "hashes": [
+                "sha256:024b8129695a952ebd93373e45b5d341dbb87c17ce49637b34000093f243dd4f",
+                "sha256:041e9442b11409be5e4fc8b6a97e4bcead758ab1e11768d1e69160bdde18acc3",
+                "sha256:045b4dd0e5f6121e6f314d81759abd2c257db4634260abcfe0d3f7083c4908ef",
+                "sha256:047c0a04e382ef8bd74b0de01407e8d8632d7d1b4db6f2561106af812a68741b",
+                "sha256:068167c2d7bbeebd359665ac4fff756be5ffac9cda02375b5c5a7c4777038e73",
+                "sha256:148ff60e0fffa2f5fad2eb25aae7bef23d8f3b8bdaf947a65cdbe84a978092bc",
+                "sha256:1d1c77013a259971a72ddaa83b9f42c80a93ff12df6a4723be99d858fa30bee3",
+                "sha256:1d48bc124a6b7a55006d97917f695effa9725d05abe8ee78fd60d6588b8344cd",
+                "sha256:31dfa2fc323097f8ad7acd41aa38d7c614dd1960ac6681745b6da124093dc351",
+                "sha256:34f82db7f80c49f38b032c5abb605c458bac997a6c3142e0d6c130be6fb2b941",
+                "sha256:3d5dd8e5998fb4ace04789d1d008e2bb532de501218519d70bb672c4c5a2fc5d",
+                "sha256:4a6ae52bd3ee41ee0f3acf4c60ceb3f44e0e3bc52ab7da1c2b2aa6703363a3d1",
+                "sha256:4b02a3b2a2f01d0490dd39321c74273fed0568568ea0e7ea23e02bd1fb10a10b",
+                "sha256:4b843f8e1dd6a3195679d9838eb4670222e8b8d01bc36c9894d6c3538316fa0a",
+                "sha256:5de53a28f40ef3c4fd57aeab6b590c2c663de87a5af76136ced519923d3efbb3",
+                "sha256:61b2b33ede821b94fa99ce0b09c9ece049c7067a33b279f343adfe35108a4ea7",
+                "sha256:6a3a9b0f45fd75dc05d8e93dc21b18fc1670135ec9544d1ad4acbcf6b86781d0",
+                "sha256:76ad8e4c69dadbb31bad17c16baee61c0d1a4a73bed2590b741b2e1a46d3edd0",
+                "sha256:7ba19b777dc00194d1b473180d4ca89a054dd18de27d0ee2e42a103ec9b7d014",
+                "sha256:7c1b7eab7a49aa96f3db1f716f0113a8a2e93c7375dd3d5d21c4941f1405c9c5",
+                "sha256:7fc0eee3046041387cbace9314926aa48b681202f8897f8bff3809967a049036",
+                "sha256:8ccd1c5fff1aa1427100ce188557fc31f1e0a383ad8ec42c559aabd4ff08802d",
+                "sha256:8e08dd76de80539d613654915a2f5196dbccc67448df291e69a88712ea21e24a",
+                "sha256:c18498c50c59263841862ea0501da9f2b3659c00db54abfbf823a80787fde8ce",
+                "sha256:c49db89d602c24928e68c0d510f4fcf8989d77defd01c973d6cbe27e684833b1",
+                "sha256:ce20044d0317649ddbb4e54dab3c1bcc7483c78c27d3f58ab3d0c7e6bc60d26a",
+                "sha256:d1071414dd06ca2eafa90c85a079169bfeb0e5f57fd0b45d44c092546fcd6fd9",
+                "sha256:d3be11ac43ab1a3e979dac80843b42226d5d3cccd3986f2e03152720a4297cd7",
+                "sha256:db603a1c235d110c860d5f39988ebc8218ee028f07a7cbc056ba6424372ca31b"
+            ],
+            "version": "==4.5.2"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+            ],
+            "version": "==2.22.0"
+        },
+        "requests-async": {
+            "hashes": [
+                "sha256:8731420451383196ecf2fd96082bfc8ae5103ada90aba185888499d7784dde6f"
+            ],
+            "version": "==0.5.0"
+        },
+        "rfc3986": {
+            "hashes": [
+                "sha256:0344d0bd428126ce554e7ca2b61787b6a28d2bbd19fc70ed2dd85efe31176405",
+                "sha256:df4eba676077cefb86450c8f60121b9ae04b94f65f85b69f3f731af0516b7b18"
+            ],
+            "version": "==1.3.2"
+        },
+        "sanic": {
+            "hashes": [
+                "sha256:cc64978266025afb0e7c0f8be928e2b81670c5d58ddac290d04c9d0da6ec2112",
+                "sha256:ebd806298782400db811ea9d63e8096e835e67f0b5dc5e66e507532984a82bb3"
+            ],
+            "index": "pypi",
+            "version": "==19.6.0"
+        },
+        "ujson": {
+            "hashes": [
+                "sha256:f66073e5506e91d204ab0c614a148d5aa938bdbf104751be66f8ad7a222f5f86"
+            ],
+            "markers": "sys_platform != 'win32' and implementation_name == 'cpython'",
+            "version": "==1.35"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
+                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
+            ],
+            "version": "==1.25.3"
+        },
+        "uvloop": {
+            "hashes": [
+                "sha256:0fcd894f6fc3226a962ee7ad895c4f52e3f5c3c55098e21efb17c071849a0573",
+                "sha256:2f31de1742c059c96cb76b91c5275b22b22b965c886ee1fced093fa27dde9e64",
+                "sha256:459e4649fcd5ff719523de33964aa284898e55df62761e7773d088823ccbd3e0",
+                "sha256:67867aafd6e0bc2c30a079603a85d83b94f23c5593b3cc08ec7e58ac18bf48e5",
+                "sha256:8c200457e6847f28d8bb91c5e5039d301716f5f2fce25646f5fb3fd65eda4a26",
+                "sha256:958906b9ca39eb158414fbb7d6b8ef1b7aee4db5c8e8e5d00fcbb69a1ce9dca7",
+                "sha256:ac1dca3d8f3ef52806059e81042ee397ac939e5a86c8a3cea55d6b087db66115",
+                "sha256:b284c22d8938866318e3b9d178142b8be316c52d16fcfe1560685a686718a021",
+                "sha256:c48692bf4587ce281d641087658eca275a5ad3b63c78297bbded96570ae9ce8f",
+                "sha256:fefc3b2b947c99737c348887db2c32e539160dcbeb7af9aa6b53db7a283538fe"
+            ],
+            "markers": "sys_platform != 'win32' and implementation_name == 'cpython'",
+            "version": "==0.12.2"
+        },
+        "websockets": {
+            "hashes": [
+                "sha256:0e2f7d6567838369af074f0ef4d0b802d19fa1fee135d864acc656ceefa33136",
+                "sha256:2a16dac282b2fdae75178d0ed3d5b9bc3258dabfae50196cbb30578d84b6f6a6",
+                "sha256:5a1fa6072405648cb5b3688e9ed3b94be683ce4a4e5723e6f5d34859dee495c1",
+                "sha256:5c1f55a1274df9d6a37553fef8cff2958515438c58920897675c9bc70f5a0538",
+                "sha256:669d1e46f165e0ad152ed8197f7edead22854a6c90419f544e0f234cc9dac6c4",
+                "sha256:695e34c4dbea18d09ab2c258994a8bf6a09564e762655408241f6a14592d2908",
+                "sha256:6b2e03d69afa8d20253455e67b64de1a82ff8612db105113cccec35d3f8429f0",
+                "sha256:79ca7cdda7ad4e3663ea3c43bfa8637fc5d5604c7737f19a8964781abbd1148d",
+                "sha256:7fd2dd9a856f72e6ed06f82facfce01d119b88457cd4b47b7ae501e8e11eba9c",
+                "sha256:82c0354ac39379d836719a77ee360ef865377aa6fdead87909d50248d0f05f4d",
+                "sha256:8f3b956d11c5b301206382726210dc1d3bee1a9ccf7aadf895aaf31f71c3716c",
+                "sha256:91ec98640220ae05b34b79ee88abf27f97ef7c61cf525eec57ea8fcea9f7dddb",
+                "sha256:952be9540d83dba815569d5cb5f31708801e0bbfc3a8c5aef1890b57ed7e58bf",
+                "sha256:99ac266af38ba1b1fe13975aea01ac0e14bb5f3a3200d2c69f05385768b8568e",
+                "sha256:9fa122e7adb24232247f8a89f2d9070bf64b7869daf93ac5e19546b409e47e96",
+                "sha256:a0873eadc4b8ca93e2e848d490809e0123eea154aa44ecd0109c4d0171869584",
+                "sha256:cb998bd4d93af46b8b49ecf5a72c0a98e5cc6d57fdca6527ba78ad89d6606484",
+                "sha256:e02e57346f6a68523e3c43bbdf35dde5c440318d1f827208ae455f6a2ace446d",
+                "sha256:e79a5a896bcee7fff24a788d72e5c69f13e61369d055f28113e71945a7eb1559",
+                "sha256:ee55eb6bcf23ecc975e6b47c127c201b913598f38b6a300075f84eeef2d3baff",
+                "sha256:f1414e6cbcea8d22843e7eafdfdfae3dd1aba41d1945f6ca66e4806c07c4f454"
+            ],
+            "version": "==6.0"
+        }
+    },
+    "develop": {}
+}

--- a/packages/now-python/test/fixtures/11-asgi/index.py
+++ b/packages/now-python/test/fixtures/11-asgi/index.py
@@ -1,0 +1,8 @@
+from sanic import Sanic
+from sanic import response
+app = Sanic()
+
+
+@app.route("/")
+async def index(request):
+    return response.text("wsgi:RANDOMNESS_PLACEHOLDER")

--- a/packages/now-python/test/fixtures/11-asgi/index.py
+++ b/packages/now-python/test/fixtures/11-asgi/index.py
@@ -5,4 +5,4 @@ app = Sanic()
 
 @app.route("/")
 async def index(request):
-    return response.text("wsgi:RANDOMNESS_PLACEHOLDER")
+    return response.text("asgi:RANDOMNESS_PLACEHOLDER")

--- a/packages/now-python/test/fixtures/11-asgi/now.json
+++ b/packages/now-python/test/fixtures/11-asgi/now.json
@@ -7,5 +7,5 @@
       "config": { "maxLambdaSize": "10mb" }
     }
   ],
-  "probes": [{ "path": "/", "mustContain": "wsgi:RANDOMNESS_PLACEHOLDER" }]
+  "probes": [{ "path": "/", "mustContain": "asgi:RANDOMNESS_PLACEHOLDER" }]
 }

--- a/packages/now-python/test/fixtures/11-asgi/now.json
+++ b/packages/now-python/test/fixtures/11-asgi/now.json
@@ -3,7 +3,7 @@
   "builds": [
     {
       "src": "index.py",
-      "use": "https://github.com/nathancahill/now-builder-python.git",
+      "use": "@now/python",
       "config": { "maxLambdaSize": "10mb" }
     }
   ],

--- a/packages/now-python/test/fixtures/11-asgi/now.json
+++ b/packages/now-python/test/fixtures/11-asgi/now.json
@@ -1,0 +1,11 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "index.py",
+      "use": "https://github.com/nathancahill/now-builder-python.git",
+      "config": { "maxLambdaSize": "10mb" }
+    }
+  ],
+  "probes": [{ "path": "/", "mustContain": "wsgi:RANDOMNESS_PLACEHOLDER" }]
+}


### PR DESCRIPTION
ASGI (Asynchronous Server Gateway Interface): https://asgi.readthedocs.io/en/latest/

> ASGI, the emerging Python standard for asynchronous web servers and applications
> -- Django Project

ASGI is supported by Django, [Starlette](https://www.starlette.io/), [Uvicorn](https://www.uvicorn.org/), [Sanic](), [Quart](https://gitlab.com/pgjones/quart/) and more. Many more frameworks (like Werkzeug and Flask) are in the process of adding support too. It would be great to include support for it in the `@now/python` builder.