### PR TITLE
[now-build-utils] Fail if `engines` is invalid

### DIFF
--- a/packages/now-build-utils/src/fs/node-version.ts
+++ b/packages/now-build-utils/src/fs/node-version.ts
@@ -19,8 +19,8 @@ export async function getSupportedNodeVersion(
 
   if (!engineRange) {
     console.log(
-      'missing `engines` in `package.json`, using default runtime ' +
-        selection.runtime
+      'missing `engines` in `package.json`, using default range: ' +
+        selection.range
     );
   } else {
     const found = supportedOptions.some(o => {
@@ -31,8 +31,7 @@ export async function getSupportedNodeVersion(
     });
     if (found) {
       console.log(
-        'found `engines` in `package.json`, selecting runtime' +
-          selection.runtime
+        'found `engines` in `package.json`, selecting range: ' + selection.range
       );
     } else {
       throw new Error(

--- a/packages/now-build-utils/src/fs/node-version.ts
+++ b/packages/now-build-utils/src/fs/node-version.ts
@@ -3,11 +3,12 @@ import { NodeVersion } from '../types';
 
 const supportedOptions: NodeVersion[] = [
   { major: 10, range: '10.x', runtime: 'nodejs10.x' },
-  { major: 8, range: '8.x', runtime: 'nodejs8.10' },
+  { major: 8, range: '8.10.x', runtime: 'nodejs8.10' },
 ];
 
 // This version should match Fargate's default in the PATH
-export const defaultSelection = supportedOptions[supportedOptions.length - 1];
+// Today that is Node 8
+export const defaultSelection = supportedOptions.filter(o => o.major === 8)[0];
 
 export async function getSupportedNodeVersion(
   engineRange?: string
@@ -16,24 +17,28 @@ export async function getSupportedNodeVersion(
 
   if (!engineRange) {
     console.log(
-      'missing `engines` in `package.json`, using default node v' +
-        selection.major
+      'missing `engines` in `package.json`, using default runtime' +
+        selection.runtime
     );
   } else {
-    for (let o of supportedOptions) {
-      if (intersects(o.range, engineRange)) {
-        selection = o;
-        console.log(
-          'found `engines` in `package.json`, selecting node v' +
-            selection.major
-        );
-        return selection; // the array is ordered so break early to use the first (largest) match
-      }
+    const found = supportedOptions.some(o => {
+      // the array is already in order so return the first
+      // match which will be the newest verison of node
+      selection = o;
+      return intersects(o.range, engineRange);
+    });
+    if (found) {
+      console.log(
+        'found `engines` in `package.json`, selecting runtime' +
+          selection.runtime
+      );
+    } else {
+      throw new Error(
+        'found `engines` in `package.json` with an unsupported node range: ' +
+          engineRange +
+          '\nplease use `10.x` or `8.10.x` instead'
+      );
     }
-    console.log(
-      'WARNING: version of `engines` in `package.json` is not supported, using default node v' +
-        selection.major
-    );
   }
   return selection;
 }

--- a/packages/now-build-utils/src/fs/node-version.ts
+++ b/packages/now-build-utils/src/fs/node-version.ts
@@ -8,7 +8,9 @@ const supportedOptions: NodeVersion[] = [
 
 // This version should match Fargate's default in the PATH
 // Today that is Node 8
-export const defaultSelection = supportedOptions.find(o => o.major === 8);
+export const defaultSelection = supportedOptions.find(
+  o => o.major === 8
+) as NodeVersion;
 
 export async function getSupportedNodeVersion(
   engineRange?: string

--- a/packages/now-build-utils/src/fs/node-version.ts
+++ b/packages/now-build-utils/src/fs/node-version.ts
@@ -8,7 +8,7 @@ const supportedOptions: NodeVersion[] = [
 
 // This version should match Fargate's default in the PATH
 // Today that is Node 8
-export const defaultSelection = supportedOptions.filter(o => o.major === 8)[0];
+export const defaultSelection = supportedOptions.find(o => o.major === 8);
 
 export async function getSupportedNodeVersion(
   engineRange?: string
@@ -17,13 +17,13 @@ export async function getSupportedNodeVersion(
 
   if (!engineRange) {
     console.log(
-      'missing `engines` in `package.json`, using default runtime' +
+      'missing `engines` in `package.json`, using default runtime ' +
         selection.runtime
     );
   } else {
     const found = supportedOptions.some(o => {
       // the array is already in order so return the first
-      // match which will be the newest verison of node
+      // match which will be the newest version of node
       selection = o;
       return intersects(o.range, engineRange);
     });

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -74,6 +74,7 @@ it('should only match supported node versions', () => {
   expect(getSupportedNodeVersion('8.11.x')).rejects.toThrow();
   expect(getSupportedNodeVersion('6.x')).rejects.toThrow();
   expect(getSupportedNodeVersion('999.x')).rejects.toThrow();
+  expect(getSupportedNodeVersion('foo')).rejects.toThrow();
   expect(getSupportedNodeVersion('')).resolves.toBe(defaultSelection);
   expect(getSupportedNodeVersion(null)).resolves.toBe(defaultSelection);
   expect(getSupportedNodeVersion(undefined)).resolves.toBe(defaultSelection);

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -68,32 +68,49 @@ it('should create zip files with symlinks properly', async () => {
   assert(aStat.isFile());
 });
 
-async function getNodeMajor(engines) {
-  const o = await getSupportedNodeVersion(engines);
-  return o.major;
-}
-
-it('should only match supported node versions or fallback to default', async () => {
-  expect(await getNodeMajor('10.x')).toBe(10);
-  expect(await getNodeMajor('8.x')).toBe(8);
-  expect(await getSupportedNodeVersion('6.x')).toBe(defaultSelection);
-  expect(await getSupportedNodeVersion('64.x')).toBe(defaultSelection);
-  expect(await getSupportedNodeVersion('')).toBe(defaultSelection);
-  expect(await getSupportedNodeVersion(null)).toBe(defaultSelection);
-  expect(await getSupportedNodeVersion(undefined)).toBe(defaultSelection);
+it('should only match supported node versions', () => {
+  expect(getSupportedNodeVersion('10.x')).resolves.toHaveProperty('major', 10);
+  expect(getSupportedNodeVersion('8.10.x')).resolves.toHaveProperty('major', 8);
+  expect(getSupportedNodeVersion('8.11.x')).rejects.toThrow();
+  expect(getSupportedNodeVersion('6.x')).rejects.toThrow();
+  expect(getSupportedNodeVersion('999.x')).rejects.toThrow();
+  expect(getSupportedNodeVersion('')).resolves.toBe(defaultSelection);
+  expect(getSupportedNodeVersion(null)).resolves.toBe(defaultSelection);
+  expect(getSupportedNodeVersion(undefined)).resolves.toBe(defaultSelection);
 });
 
-it('should match all semver ranges', async () => {
+it('should match all semver ranges', () => {
   // See https://docs.npmjs.com/files/package.json#engines
-  expect(await getNodeMajor('10.0.0')).toBe(10);
-  expect(await getNodeMajor('10.x')).toBe(10);
-  expect(await getNodeMajor('>=10')).toBe(10);
-  expect(await getNodeMajor('>=10.3.0')).toBe(10);
-  expect(await getNodeMajor('8.5.0 - 10.5.0')).toBe(10);
-  expect(await getNodeMajor('>=9.0.0')).toBe(10);
-  expect(await getNodeMajor('>=9.5.0 <=10.5.0')).toBe(10);
-  expect(await getNodeMajor('~10.5.0')).toBe(10);
-  expect(await getNodeMajor('^10.5.0')).toBe(10);
+  expect(getSupportedNodeVersion('10.0.0')).resolves.toHaveProperty(
+    'major',
+    10,
+  );
+  expect(getSupportedNodeVersion('10.x')).resolves.toHaveProperty('major', 10);
+  expect(getSupportedNodeVersion('>=10')).resolves.toHaveProperty('major', 10);
+  expect(getSupportedNodeVersion('>=10.3.0')).resolves.toHaveProperty(
+    'major',
+    10,
+  );
+  expect(getSupportedNodeVersion('8.5.0 - 10.5.0')).resolves.toHaveProperty(
+    'major',
+    10,
+  );
+  expect(getSupportedNodeVersion('>=9.0.0')).resolves.toHaveProperty(
+    'major',
+    10,
+  );
+  expect(getSupportedNodeVersion('>=9.5.0 <=10.5.0')).resolves.toHaveProperty(
+    'major',
+    10,
+  );
+  expect(getSupportedNodeVersion('~10.5.0')).resolves.toHaveProperty(
+    'major',
+    10,
+  );
+  expect(getSupportedNodeVersion('^10.5.0')).resolves.toHaveProperty(
+    'major',
+    10,
+  );
 });
 
 // own fixtures


### PR DESCRIPTION
As a follow up to @Timer's [comment](https://github.com/zeit/now-builders/pull/648#pullrequestreview-253025302), this PR will ensure we fail fast (build error) when `engines` does not match any supported version or the semver range is completely invalid.

If `engines` is not defined, the default `8.10.x` is used and a log message is printed.

I also changed the tests to be more jest-like.