### PR TITLE
[now-next] Update @now/next for new dynamic syntax

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -40,6 +40,7 @@ import {
   validateEntrypoint,
   normalizePage,
   getDynamicRoutes,
+  isDynamicRoute,
 } from './utils';
 
 interface BuildParamsMeta {
@@ -414,7 +415,7 @@ export const build = async ({
 
       const pathname = page.replace(/\.html$/, '');
 
-      if (pathname.startsWith('$') || pathname.includes('/$')) {
+      if (isDynamicRoute(pathname)) {
         dynamicPages.push(pathname);
       }
 
@@ -461,7 +462,7 @@ export const build = async ({
 
         const pathname = page.replace(/\.js$/, '');
 
-        if (pathname.startsWith('$') || pathname.includes('/$')) {
+        if (isDynamicRoute(pathname)) {
           dynamicPages.push(normalizePage(pathname));
         }
 

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -9,6 +9,14 @@ export interface EnvConfig {
   [name: string]: string | undefined;
 }
 
+// Identify /[param]/ in route string
+const TEST_DYNAMIC_ROUTE = /\/\[[^\/]+?\](?=\/|$)/;
+
+function isDynamicRoute(route: string): boolean {
+  route = route.startsWith('/') ? route : `/${route}`;
+  return TEST_DYNAMIC_ROUTE.test(route);
+}
+
 /**
  * Validate if the entrypoint is allowed to be used
  */
@@ -226,7 +234,7 @@ function getRoutes(
       continue;
     }
 
-    if (pageName.startsWith('$') || pageName.includes('/$')) {
+    if (isDynamicRoute(pageName)) {
       dynamicPages.push(normalizePage(pageName));
     }
 
@@ -351,4 +359,5 @@ export {
   stringMap,
   syncEnvVars,
   normalizePage,
+  isDynamicRoute,
 };


### PR DESCRIPTION
This adds handling for the new `[id]` dynamic syntax and removes the old `$id` syntax.

Tested with https://dynamic.jj4.now.sh and `@ijjk/now-next@0.0.1-dev.12` 