### PR TITLE
[tests] Improve git diff in jest config and refactor

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ const { execSync } = require('child_process');
 const { relative } = require('path');
 
 const branch = execSync('git branch | grep "*" | cut -d " " -f2').toString();
-console.log(`Running tests on branch "${branch}"`);
+console.log(`Running tests on branch "${branch.trim()}"`);
 const gitPath = branch === 'master' ? 'HEAD~1' : 'origin/canary...HEAD';
 const diff = execSync(`git diff ${gitPath} --name-only`).toString();
 
@@ -21,7 +21,9 @@ if (matches.length === 0) {
   console.log(matches.join('\n'));
 }
 
-const testMatch = matches.map(item => `**/${item}/**/?(*.)+(spec|test).[jt]s?(x)`);
+const testMatch = matches.map(
+  item => `**/${item}/**/?(*.)+(spec|test).[jt]s?(x)`
+);
 
 module.exports = {
   testEnvironment: 'node',

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,25 +11,17 @@ const changed = diff
   .filter(item => Boolean(item) && item.includes('packages/'))
   .map(item => relative('packages', item).split('/')[0]);
 
-const matches = [];
+const matches = Array.from(new Set(changed));
 
-if (changed.length > 0) {
-  console.log('The following packages have changed:');
-
-  changed.map((item) => {
-    matches.push(item);
-    console.log(item);
-
-    return null;
-  });
-} else {
+if (matches.length === 0) {
   matches.push('now-node');
   console.log(`No packages changed, defaulting to ${matches[0]}`);
+} else {
+  console.log('The following packages have changed:');
+  console.log(matches.join('\n'));
 }
 
-const testMatch = Array.from(new Set(matches)).map(
-  item => `**/${item}/**/?(*.)+(spec|test).[jt]s?(x)`,
-);
+const testMatch = matches.map(item => `**/${item}/**/?(*.)+(spec|test).[jt]s?(x)`);
 
 module.exports = {
   testEnvironment: 'node',

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,8 +3,8 @@ const { relative } = require('path');
 
 const branch = execSync('git branch | grep "*" | cut -d " " -f2').toString();
 console.log(`Running tests on branch "${branch}"`);
-const base = branch === 'master' ? 'HEAD~1' : 'origin/canary';
-const diff = execSync(`git diff ${base} --name-only`).toString();
+const gitPath = branch === 'master' ? 'HEAD~1' : 'origin/canary...';
+const diff = execSync(`git diff ${gitPath} --name-only`).toString();
 
 const changed = diff
   .split('\n')

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,8 @@ const changed = diff
 const matches = Array.from(new Set(changed));
 
 if (matches.length === 0) {
-  console.log(`No packages changed, not running tests.`);
+  matches.push('now-node');
+  console.log(`No packages changed, defaulting to ${matches[0]}`);
 } else {
   console.log('The following packages have changed:');
   console.log(matches.join('\n'));

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,8 +14,7 @@ const changed = diff
 const matches = Array.from(new Set(changed));
 
 if (matches.length === 0) {
-  matches.push('now-node');
-  console.log(`No packages changed, defaulting to ${matches[0]}`);
+  console.log(`No packages changed, not running tests.`);
 } else {
   console.log('The following packages have changed:');
   console.log(matches.join('\n'));

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ const { relative } = require('path');
 
 const branch = execSync('git branch | grep "*" | cut -d " " -f2').toString();
 console.log(`Running tests on branch "${branch}"`);
-const gitPath = branch === 'master' ? 'HEAD~1' : 'origin/canary...';
+const gitPath = branch === 'master' ? 'HEAD~1' : 'origin/canary...HEAD';
 const diff = execSync(`git diff ${gitPath} --name-only`).toString();
 
 const changed = diff

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,10 @@
 const { execSync } = require('child_process');
 const { relative } = require('path');
 
-const branch = execSync('git branch | grep "*" | cut -d " " -f2').toString();
-console.log(`Running tests on branch "${branch.trim()}"`);
+const branch = execSync('git branch | grep "*" | cut -d " " -f2')
+  .toString()
+  .trim();
+console.log(`Running tests on branch "${branch}"`);
 const gitPath = branch === 'master' ? 'HEAD~1' : 'origin/canary...HEAD';
 const diff = execSync(`git diff ${gitPath} --name-only`).toString();
 
@@ -22,7 +24,7 @@ if (matches.length === 0) {
 }
 
 const testMatch = matches.map(
-  item => `**/${item}/**/?(*.)+(spec|test).[jt]s?(x)`
+  item => `**/${item}/**/?(*.)+(spec|test).[jt]s?(x)`,
 );
 
 module.exports = {


### PR DESCRIPTION
This PR improves the `git diff` in `jest.config.js`. We can use _Symmetric Difference Notation_ to only look for changes on the PR branch side and not on the `canary` branch side.

See docs for this here : https://git-scm.com/docs/gitrevisions#_dotted_range_notations