### PR TITLE
Revert "Only run github action on 'release' event (#662)"

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,5 +1,5 @@
 workflow "Canary publish" {
-  on = "release"
+  on = "push"
   resolves = ["3. Canary yarn run publish"]
 }
 
@@ -38,7 +38,7 @@ action "3. Canary yarn run publish" {
 
 
 workflow "Master publish" {
-  on = "release"
+  on = "push"
   resolves = ["3. Master yarn run publish"]
 }
 


### PR DESCRIPTION
This reverts commit 5ff2c37147eb203f5199ffe4d4aa9480e3ebaa85.

`release` event is not triggered because we don't create releases when publishing (They appear [here](https://github.com/zeit/now-builders/releases) but this page just displays tags as placeholders for releases).