### PR TITLE
[now-static-build] Improve msg when missing script

### DIFF
--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -71,6 +71,7 @@ export async function build({
   const entrypointName = path.basename(entrypoint);
 
   if (entrypointName.endsWith('.sh')) {
+    console.log(`Running build script "${entrypoint}"`);
     await runShellScript(path.join(workPath, entrypoint));
     validateDistDir(distPath, meta.isDev);
     return glob('**', distPath, mountpoint);
@@ -147,7 +148,7 @@ export async function build({
           'See the local development docs: https://zeit.co/docs/v2/deployments/official-builders/static-build-now-static-build/#local-development'
         );
       }
-      console.log('Running user "now-build" script from `package.json`...');
+      console.log(`Running "now-build" script in "${entrypoint}"`);
       const found = await runPackageJsonScript(
         entrypointFsDirname,
         'now-build',
@@ -166,6 +167,6 @@ export async function build({
   }
 
   throw new Error(
-    `Build src is "${entrypoint}" but expected "package.json" or "script.sh"`
+    `Build "src" is "${entrypoint}" but expected "package.json" or "build.sh"`
   );
 }

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -55,7 +55,7 @@ export async function build({
   config,
   meta = {},
 }: BuildOptions) {
-  console.log('downloading user files...');
+  console.log('Downloading user files...');
   await download(files, workPath, meta);
 
   const mountpoint = path.dirname(entrypoint);
@@ -147,7 +147,7 @@ export async function build({
           'See the local development docs: https://zeit.co/docs/v2/deployments/official-builders/static-build-now-static-build/#local-development'
         );
       }
-      console.log('running user "now-build" script from `package.json`...');
+      console.log('Running user "now-build" script from `package.json`...');
       const found = await runPackageJsonScript(
         entrypointFsDirname,
         'now-build',
@@ -155,7 +155,7 @@ export async function build({
       );
       if (!found) {
         throw new Error(
-          `missing required "now-build" script in "${entrypoint}"`
+          `Missing required "now-build" script in "${entrypoint}"`
         );
       }
       validateDistDir(distPath, meta.isDev);
@@ -166,6 +166,6 @@ export async function build({
   }
 
   throw new Error(
-    `build src is "${entrypoint}" but expected "package.json" or "script.sh"`
+    `Build src is "${entrypoint}" but expected "package.json" or "script.sh"`
   );
 }

--- a/packages/now-static-build/test/fixtures/07-nonzero-sh/build.sh
+++ b/packages/now-static-build/test/fixtures/07-nonzero-sh/build.sh
@@ -1,0 +1,2 @@
+echo 'non-zero exit code should fail the build'
+exit 1

--- a/packages/now-static-build/test/fixtures/07-nonzero-sh/now.json
+++ b/packages/now-static-build/test/fixtures/07-nonzero-sh/now.json
@@ -1,0 +1,4 @@
+{
+  "version": 2,
+  "builds": [{ "src": "build.sh", "use": "@now/static-build" }]
+}

--- a/packages/now-static-build/test/test.js
+++ b/packages/now-static-build/test/test.js
@@ -22,6 +22,7 @@ const testsThatFailToBuild = new Set([
   '04-wrong-dist-dir',
   '05-empty-dist-dir',
   '06-missing-script',
+  '07-nonzero-sh',
 ]);
 
 // eslint-disable-next-line no-restricted-syntax


### PR DESCRIPTION
This improves two error messages:

1. When `now-build` script is missing from `package.json`
2. When neither `.sh` file or `package.json` file is provided as the entrypoint `src`

Fixes #131
