### PR TITLE
[now-static-build] Add missing random to test

### DIFF
--- a/packages/now-static-build/test/fixtures/07-nonzero-sh/build.sh
+++ b/packages/now-static-build/test/fixtures/07-nonzero-sh/build.sh
@@ -1,2 +1,2 @@
-echo 'non-zero exit code should fail the build'
+echo 'non-zero exit code should fail the build RANDOMNESS_PLACEHOLDER'
 exit 1


### PR DESCRIPTION
I forgot to add this to the test in PR #672

Without the random placeholder, the test might appear to pass when it should fail because of de-duping.