### PR TITLE
[now-ruby] Move typescript to devDependency

### DIFF
--- a/packages/now-ruby/package.json
+++ b/packages/now-ruby/package.json
@@ -2,6 +2,7 @@
   "name": "@now/ruby",
   "author": "Nathan Cahill <nathan@nathancahill.com>",
   "version": "0.1.0-canary.4",
+  "license": "MIT",
   "main": "./dist/index",
   "files": [
     "dist",
@@ -12,7 +13,6 @@
     "url": "https://github.com/zeit/now-builders.git",
     "directory": "packages/now-ruby"
   },
-  "license": "MIT",
   "scripts": {
     "build": "tsc",
     "test": "tsc && jest",
@@ -20,7 +20,9 @@
   },
   "dependencies": {
     "execa": "^1.0.0",
-    "fs-extra": "^7.0.1",
+    "fs-extra": "^7.0.1"
+  },
+  "devDependencies": {
     "typescript": "3.5.2"
   }
 }


### PR DESCRIPTION
Since typescript is only used during development of this builder, it should be `devDependency`.

You can see how large [@now/ruby](https://packagephobia.now.sh/result?p=@now/ruby@0.1.0-canary.4) builder is on Package Phobia (42 MB).

After this change, it will be significantly smaller (under 1 MB).