### PR TITLE
[docs] Add codeowners for ruby

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,4 @@
 /packages/now-go        @styfle @sophearak
 /packages/now-python    @styfle @sophearak
 /packages/now-rust      @styfle @mike-engel @anmonteiro
+/packages/now-ruby      @styfle @coetry @nathancahill


### PR DESCRIPTION
This adds @nathancahill and @coetry, the resident Ruby experts, to codeowners so that we can get more eyes on code reviews. 