### PR TITLE
[now-bash] Add import config prop

### DIFF
--- a/packages/now-bash/index.js
+++ b/packages/now-bash/index.js
@@ -13,6 +13,15 @@ exports.config = {
   maxLambdaSize: '10mb',
 };
 
+// From this list: https://import.pw/importpw/import/docs/config.md
+const allowedConfigImports = new Set([
+  'CACHE',
+  'CURL_OPTS',
+  'DEBUG',
+  'RELOAD',
+  'SERVER',
+]);
+
 exports.analyze = ({ files, entrypoint }) => files[entrypoint].digest;
 
 exports.build = async ({
@@ -24,9 +33,22 @@ exports.build = async ({
   await download(files, srcDir);
 
   const configEnv = Object.keys(config).reduce((o, v) => {
-    o[`IMPORT_${snakeCase(v).toUpperCase()}`] = config[v]; // eslint-disable-line no-param-reassign
+    const name = snakeCase(v).toUpperCase();
+
+    if (allowedConfigImports.has(name)) {
+      o[`IMPORT_${name}`] = config[v]; // eslint-disable-line no-param-reassign
+    }
+
     return o;
   }, {});
+
+  if (config && config.imports) {
+    Object.keys(config).forEach((key) => {
+      const name = snakeCase(key).toUpperCase();
+      // eslint-disable-next-line no-param-reassign
+      configEnv[`IMPORT_${name}`] = config.imports[key];
+    });
+  }
 
   const IMPORT_CACHE = `${workPath}/.import-cache`;
   const env = Object.assign({}, process.env, configEnv, {

--- a/packages/now-bash/index.js
+++ b/packages/now-bash/index.js
@@ -42,11 +42,11 @@ exports.build = async ({
     return o;
   }, {});
 
-  if (config && config.imports) {
-    Object.keys(config.imports).forEach((key) => {
+  if (config && config.import) {
+    Object.keys(config.import).forEach((key) => {
       const name = snakeCase(key).toUpperCase();
       // eslint-disable-next-line no-param-reassign
-      configEnv[`IMPORT_${name}`] = config.imports[key];
+      configEnv[`IMPORT_${name}`] = config.import[key];
     });
   }
 

--- a/packages/now-bash/index.js
+++ b/packages/now-bash/index.js
@@ -43,7 +43,7 @@ exports.build = async ({
   }, {});
 
   if (config && config.imports) {
-    Object.keys(config).forEach((key) => {
+    Object.keys(config.imports).forEach((key) => {
       const name = snakeCase(key).toUpperCase();
       // eslint-disable-next-line no-param-reassign
       configEnv[`IMPORT_${name}`] = config.imports[key];

--- a/packages/now-build-utils/src/types.ts
+++ b/packages/now-build-utils/src/types.ts
@@ -31,7 +31,7 @@ export interface Config {
   rust?: string;
   debug?: boolean;
   zeroConfig?: boolean;
-  imports?: { [key: string]: string };
+  import?: { [key: string]: string };
 }
 
 export interface Meta {

--- a/packages/now-build-utils/src/types.ts
+++ b/packages/now-build-utils/src/types.ts
@@ -25,6 +25,7 @@ export interface Config {
   rust?: string;
   debug?: boolean;
   zeroConfig?: boolean;
+  imports?: { [key: string]: string };
 }
 
 export interface Meta {

--- a/packages/now-build-utils/src/types.ts
+++ b/packages/now-build-utils/src/types.ts
@@ -16,7 +16,13 @@ export interface Files {
 }
 
 export interface Config {
-  [key: string]: string | string[] | boolean | number | undefined;
+  [key: string]:
+    | string
+    | string[]
+    | boolean
+    | number
+    | { [key: string]: string }
+    | undefined;
   maxLambdaSize?: string;
   includeFiles?: string | string[];
   bundle?: boolean;


### PR DESCRIPTION
Add `import` config prop to `now-bash` but still allows the default imports directly within the `config`.

This also adds the type to `Config` in `now-build-utils`.