### PR TITLE
[now-next] Reorder process overrides

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -285,10 +285,9 @@ export const build = async ({
 
   console.log('running user script...');
   const memoryToConsume = Math.floor(os.totalmem() / 1024 ** 2) - 128;
-  const buildSpawnOptions = { ...spawnOpts };
-  const env = { ...buildSpawnOptions.env } as any;
+  const env = { ...spawnOpts.env } as any;
   env.NODE_OPTIONS = `--max_old_space_size=${memoryToConsume}`;
-  await runPackageJsonScript(entryPath, 'now-build', buildSpawnOptions);
+  await runPackageJsonScript(entryPath, 'now-build', { ...spawnOpts, env });
 
   if (isLegacy) {
     console.log('running npm install --production...');

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -165,6 +165,8 @@ export const build = async ({
   watch?: string[];
   childProcesses: ChildProcess[];
 }> => {
+  process.env.__NEXT_BUILDER_EXPERIMENTAL_TARGET = 'serverless';
+
   validateEntrypoint(entrypoint);
 
   const entryDirectory = path.dirname(entrypoint);
@@ -186,11 +188,7 @@ export const build = async ({
     );
   }
 
-  process.env.__NEXT_BUILDER_EXPERIMENTAL_TARGET = 'serverless';
-
   if (meta.isDev) {
-    // eslint-disable-next-line no-underscore-dangle
-    process.env.__NEXT_BUILDER_EXPERIMENTAL_DEBUG = 'true';
     let childProcess: ChildProcess | undefined;
 
     // If this is the initial build, we want to start the server

--- a/packages/now-next/test/integration/index.test.js
+++ b/packages/now-next/test/integration/index.test.js
@@ -10,7 +10,8 @@ it(
     const {
       buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'standard'));
-    expect(output.index).toBeDefined();
+    expect(output['index.html']).toBeDefined();
+    expect(output.goodbye).toBeDefined();
     const filePaths = Object.keys(output);
     const serverlessError = filePaths.some(filePath => filePath.match(/_error/));
     const hasUnderScoreAppStaticFile = filePaths.some(filePath => filePath.match(/static.*\/pages\/_app\.js$/));

--- a/packages/now-next/test/integration/standard/next.config.js
+++ b/packages/now-next/test/integration/standard/next.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  target: 'serverless',
-};

--- a/packages/now-next/test/integration/standard/now.json
+++ b/packages/now-next/test/integration/standard/now.json
@@ -1,4 +1,4 @@
 {
   "version": 2,
-  "builds": [{ "src": "next.config.js", "use": "@now/next" }]
+  "builds": [{ "src": "package.json", "use": "@now/next" }]
 }

--- a/packages/now-next/test/integration/standard/pages/goodbye.js
+++ b/packages/now-next/test/integration/standard/pages/goodbye.js
@@ -1,0 +1,3 @@
+const F = () => 'Goodbye World!';
+F.getInitialProps = () => ({});
+export default F;


### PR DESCRIPTION
PR #649 broke the Next.js' serverless target feature, causing poor UX/DX for users.

The crux of this problem is that the PR started snapshotting `process.env`, which differs from default behavior. Normally, all `process.env` values are passed down to a child process at creation time.

There was logic in this builder that relied on that non-snapshotting behavior.

---

This PR also removes `__NEXT_BUILDER_EXPERIMENTAL_DEBUG` which is unnecessary since we now leverage Next.js' dev server instead of production builder.