### PR TITLE
Use the local version of `node` when running via `now dev`

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -308,7 +308,7 @@ export const build = async ({
   const dynamicPages: string[] = [];
 
   // Use the system-installed version of `node` when running via `now dev`
-  const runtime = meta.isDev ? 'nodejs' : 'nodejs8.10';
+  const runtime = meta.isDev ? 'nodejs' : nodeVersion.runtime;
 
   if (isLegacy) {
     const filesAfterBuild = await glob('**', entryPath);

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -307,9 +307,6 @@ export const build = async ({
   const staticPages: { [key: string]: FileFsRef } = {};
   const dynamicPages: string[] = [];
 
-  // Use the system-installed version of `node` when running via `now dev`
-  const runtime = meta.isDev ? 'nodejs' : nodeVersion.runtime;
-
   if (isLegacy) {
     const filesAfterBuild = await glob('**', entryPath);
 
@@ -389,7 +386,7 @@ export const build = async ({
             'now__launcher.js': new FileBlob({ data: launcher }),
           },
           handler: 'now__launcher.launcher',
-          runtime,
+          runtime: nodeVersion.runtime,
         });
         console.log(`Created lambda for page: "${page}"`);
       })
@@ -474,7 +471,7 @@ export const build = async ({
             'page.js': pages[page],
           },
           handler: 'now__launcher.launcher',
-          runtime,
+          runtime: nodeVersion.runtime,
         });
         console.log(`Created lambda for page: "${page}"`);
       })

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -307,6 +307,9 @@ export const build = async ({
   const staticPages: { [key: string]: FileFsRef } = {};
   const dynamicPages: string[] = [];
 
+  // Use the system-installed version of `node` when running via `now dev`
+  const runtime = meta.isDev ? 'nodejs' : 'nodejs8.10';
+
   if (isLegacy) {
     const filesAfterBuild = await glob('**', entryPath);
 
@@ -386,7 +389,7 @@ export const build = async ({
             'now__launcher.js': new FileBlob({ data: launcher }),
           },
           handler: 'now__launcher.launcher',
-          runtime: 'nodejs8.10',
+          runtime,
         });
         console.log(`Created lambda for page: "${page}"`);
       })
@@ -471,7 +474,7 @@ export const build = async ({
             'page.js': pages[page],
           },
           handler: 'now__launcher.launcher',
-          runtime: 'nodejs8.10',
+          runtime,
         });
         console.log(`Created lambda for page: "${page}"`);
       })

--- a/packages/now-node-server/index.js
+++ b/packages/now-node-server/index.js
@@ -157,10 +157,13 @@ exports.build = async ({
     'bridge.js': new FileFsRef({ fsPath: require('@now/node-bridge') }),
   };
 
+  // Use the system-installed version of `node` when running via `now dev`
+  const runtime = meta.isDev ? 'nodejs' : nodeVersion.runtime;
+
   const lambda = await createLambda({
     files: { ...preparedFiles, ...launcherFiles },
     handler: 'launcher.launcher',
-    runtime: nodeVersion.runtime,
+    runtime,
   });
 
   return { [entrypoint]: lambda };

--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -217,13 +217,16 @@ export async function build({
     });
   }
 
+  // Use the system-installed version of `node` when running via `now dev`
+  const runtime = meta.isDev ? 'nodejs' : nodeVersion.runtime;
+
   const lambda = await createLambda({
     files: {
       ...preparedFiles,
       ...launcherFiles,
     },
     handler: 'launcher.launcher',
-    runtime: nodeVersion.runtime,
+    runtime,
   });
 
   const output = { [entrypoint]: lambda };


### PR DESCRIPTION
This is a companion to https://github.com/zeit/now-cli/pull/2480.