### PR TITLE
Add homepage to all packages

### DIFF
--- a/packages/now-bash/package.json
+++ b/packages/now-bash/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "author": "Nathan Rajlich <nate@zeit.co>",
   "license": "MIT",
+  "homepage": "https://zeit.co/docs/v2/deployments/official-builders/bash-now-bash",
   "repository": {
     "type": "git",
     "url": "https://github.com/zeit/now-builders.git",

--- a/packages/now-build-utils/package.json
+++ b/packages/now-build-utils/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.js",
+  "homepage": "https://zeit.co/docs/v2/deployments/builders/developer-guide",
   "repository": {
     "type": "git",
     "url": "https://github.com/zeit/now-builders.git",

--- a/packages/now-go/package.json
+++ b/packages/now-go/package.json
@@ -2,6 +2,7 @@
   "name": "@now/go",
   "version": "0.5.1-canary.6",
   "license": "MIT",
+  "homepage": "https://zeit.co/docs/v2/deployments/official-builders/go-now-go",
   "repository": {
     "type": "git",
     "url": "https://github.com/zeit/now-builders.git",

--- a/packages/now-html-minifier/package.json
+++ b/packages/now-html-minifier/package.json
@@ -2,6 +2,7 @@
   "name": "@now/html-minifier",
   "version": "1.1.3",
   "license": "MIT",
+  "homepage": "https://zeit.co/docs/v2/deployments/official-builders/html-minifier-now-html-minifier",
   "repository": {
     "type": "git",
     "url": "https://github.com/zeit/now-builders.git",

--- a/packages/now-md/package.json
+++ b/packages/now-md/package.json
@@ -2,6 +2,7 @@
   "name": "@now/md",
   "version": "0.5.4-canary.0",
   "license": "MIT",
+  "homepage": "https://zeit.co/docs/v2/deployments/official-builders/markdown-now-md",
   "repository": {
     "type": "git",
     "url": "https://github.com/zeit/now-builders.git",

--- a/packages/now-mdx-deck/package.json
+++ b/packages/now-mdx-deck/package.json
@@ -2,6 +2,7 @@
   "name": "@now/mdx-deck",
   "version": "0.5.4",
   "license": "MIT",
+  "homepage": "https://zeit.co/docs/v2/deployments/official-builders/mdx-deck-now-mdx-deck",
   "repository": {
     "type": "git",
     "url": "https://github.com/zeit/now-builders.git",

--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -3,6 +3,7 @@
   "version": "0.4.1-canary.17",
   "license": "MIT",
   "main": "./dist/index",
+  "homepage": "https://zeit.co/docs/v2/deployments/official-builders/next-js-now-next",
   "scripts": {
     "build": "./getBridgeTypes.sh && tsc",
     "test": "npm run build && jest",

--- a/packages/now-node-server/package.json
+++ b/packages/now-node-server/package.json
@@ -2,6 +2,7 @@
   "name": "@now/node-server",
   "version": "0.7.4-canary.5",
   "license": "MIT",
+  "homepage": "https://zeit.co/docs/v2/deployments/official-builders/node-js-server-now-node-server",
   "repository": {
     "type": "git",
     "url": "https://github.com/zeit/now-builders.git",

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.4-canary.22",
   "license": "MIT",
   "main": "./dist/index",
+  "homepage": "https://zeit.co/docs/v2/deployments/official-builders/node-js-now-node",
   "repository": {
     "type": "git",
     "url": "https://github.com/zeit/now-builders.git",

--- a/packages/now-optipng/package.json
+++ b/packages/now-optipng/package.json
@@ -3,6 +3,7 @@
   "version": "0.6.2-canary.1",
   "license": "MIT",
   "main": "./dist/index",
+  "homepage": "https://zeit.co/docs/v2/deployments/official-builders/optipng-now-optipng",
   "files": [
     "dist"
   ],

--- a/packages/now-php/package.json
+++ b/packages/now-php/package.json
@@ -2,6 +2,7 @@
   "name": "@now/php",
   "version": "0.5.5-canary.0",
   "license": "MIT",
+  "homepage": "https://zeit.co/docs/v2/deployments/official-builders/php-now-php",
   "repository": {
     "type": "git",
     "url": "https://github.com/zeit/now-builders.git",

--- a/packages/now-python/package.json
+++ b/packages/now-python/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.5-canary.7",
   "main": "./dist/index.js",
   "license": "MIT",
+  "homepage": "https://zeit.co/docs/v2/deployments/official-builders/python-now-python",
   "files": [
     "dist",
     "now_init.py"

--- a/packages/now-ruby/package.json
+++ b/packages/now-ruby/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0-canary.5",
   "license": "MIT",
   "main": "./dist/index",
+  "homepage": "https://zeit.co/docs/v2/deployments/official-builders/ruby-now-ruby",
   "files": [
     "dist",
     "now_init.rb"

--- a/packages/now-rust/package.json
+++ b/packages/now-rust/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.5-canary.4",
   "license": "MIT",
   "main": "./dist/index",
+  "homepage": "https://zeit.co/docs/v2/deployments/official-builders/now-rust",
   "repository": {
     "type": "git",
     "url": "https://github.com/zeit/now-builders.git",

--- a/packages/now-static-build/package.json
+++ b/packages/now-static-build/package.json
@@ -3,6 +3,7 @@
   "version": "0.5.8-canary.6",
   "license": "MIT",
   "main": "./dist/index",
+  "homepage": "https://zeit.co/docs/v2/deployments/official-builders/static-build-now-static-build",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
This PR adds a [homepage](https://docs.npmjs.com/files/package.json#homepage) field to each package.

This allows a user to visit npmjs.com and click "homepage" to go directly to the specified builder's documentation.

<img src="https://user-images.githubusercontent.com/229881/60463724-bae28180-9c1a-11e9-8db2-24dbee3cb99d.png" width=300 />

Note the "homepage" column  above ^

Closes #40