### PR TITLE
[now-ruby] Use BUNDLE_JOBS=4 for parallel Ruby gem downloads

### DIFF
--- a/packages/now-ruby/index.ts
+++ b/packages/now-ruby/index.ts
@@ -64,6 +64,7 @@ async function bundleInstall(
         env: {
           BUNDLE_SILENCE_ROOT_WARNING: '1',
           BUNDLE_APP_CONFIG: bundleAppConfig,
+          BUNDLE_JOBS: '4',
         },
       }
     );


### PR DESCRIPTION
Specifies the number of gems Bundler can install in parallel.

https://bundler.io/v2.0/man/bundle-config.1.html
https://bundler.io/v2.0/man/bundle-install.1.html