### PR TITLE
[now-ruby] Use ruby 2.5.5

### DIFF
--- a/packages/now-ruby/install-ruby.ts
+++ b/packages/now-ruby/install-ruby.ts
@@ -2,7 +2,7 @@ import { join } from 'path';
 import execa from 'execa';
 import { getWriteableDirectory } from '@now/build-utils';
 
-const RUBY_VERSION = '2.5.3';
+const RUBY_VERSION = '2.5.5';
 
 async function installRuby(version: string = RUBY_VERSION) {
   const baseDir = await getWriteableDirectory();


### PR DESCRIPTION
Release notes for 2.5.5 and 2.5.4:

https://www.ruby-lang.org/en/news/2019/03/15/ruby-2-5-5-released/
https://www.ruby-lang.org/en/news/2019/03/13/ruby-2-5-4-released/
