### PR TITLE
[now-node] Add support for `server.listen()`

### DIFF
--- a/packages/now-node/src/launcher.ts
+++ b/packages/now-node/src/launcher.ts
@@ -25,9 +25,7 @@ try {
   let listener = require("./${entrypoint}");
   if (listener.default) listener = listener.default;
 
-  if (isServerListening) {
-    console.log('Server is listening');
-  } else if (typeof listener.listen === 'function') {
+  if (typeof listener.listen === 'function') {
     Server.prototype.listen = saveListen;
     const server = listener;
     bridge = new Bridge(server);
@@ -48,8 +46,17 @@ try {
     }
     bridge.listen();
   } else {
-    console.error('Export is invalid. Did you forget to export a function or a server?');
-    process.exit(1);
+    console.log('WARN: No serverless export detected, falling back to server listening...');
+    if (!isServerListening) {
+      setTimeout(() => {
+        if (!isServerListening) {
+          console.error('Export is invalid.');
+          console.error('Did you forget to export a function or a server?');
+          process.exit(1);
+        }
+      }, 1000);
+    }
+
   }
 } catch (err) {
   if (err.code === 'MODULE_NOT_FOUND') {

--- a/packages/now-node/src/launcher.ts
+++ b/packages/now-node/src/launcher.ts
@@ -44,17 +44,15 @@ try {
     bridge.setServer(server);
     bridge.listen();
   } else if (typeof listener === 'object' && Object.keys(listener).length === 0) {
-    if (!isServerListening) {
-      setTimeout(() => {
-        if (!isServerListening) {
-          console.error('No export detected.');
-          console.error('Did you forget to export a function or a server?');
-          process.exit(1);
-        }
-      }, 1000);
-    }
+    setTimeout(() => {
+      if (!isServerListening) {
+        console.error('No exports found in module "${entrypoint}".');
+        console.error('Did you forget to export a function or a server?');
+        process.exit(1);
+      }
+    }, 5000);
   } else {
-    console.error('Export is invalid.');
+    console.error('Invalid export found in module "${entrypoint}".');
     console.error('The default export must be a function or server.');
   }
 } catch (err) {

--- a/packages/now-node/test/fixtures/02-node-server/hapi-async/index.js
+++ b/packages/now-node/test/fixtures/02-node-server/hapi-async/index.js
@@ -1,0 +1,25 @@
+const Hapi = require('@hapi/hapi');
+
+const init = async () => {
+  const server = Hapi.server({
+    port: 3000,
+    host: 'localhost',
+  });
+
+  server.route({
+    method: 'GET',
+    path: '/{p*}',
+    handler: () => 'hapi-async:RANDOMNESS_PLACEHOLDER',
+  });
+
+  await server.start();
+  console.log('Hapi server running on %s', server.info.uri);
+};
+
+process.on('unhandledRejection', (err) => {
+  console.log('Hapi failed in an unexpected way');
+  console.log(err);
+  process.exit(1);
+});
+
+init();

--- a/packages/now-node/test/fixtures/02-node-server/hapi-async/package.json
+++ b/packages/now-node/test/fixtures/02-node-server/hapi-async/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@hapi/hapi": "18.3.1"
+  }
+}

--- a/packages/now-node/test/fixtures/02-node-server/index.js
+++ b/packages/now-node/test/fixtures/02-node-server/index.js
@@ -1,0 +1,7 @@
+const http = require('http');
+
+const server = http.createServer((req, resp) => {
+  resp.end('root:RANDOMNESS_PLACEHOLDER');
+});
+
+server.listen();

--- a/packages/now-node/test/fixtures/02-node-server/now.json
+++ b/packages/now-node/test/fixtures/02-node-server/now.json
@@ -1,0 +1,11 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "index.js", "use": "@now/node" },
+    { "src": "subdirectory/index.js", "use": "@now/node" }
+  ],
+  "probes": [
+    { "path": "/", "mustContain": "root:RANDOMNESS_PLACEHOLDER" },
+    { "path": "/subdirectory/", "mustContain": "subdir:RANDOMNESS_PLACEHOLDER" }
+  ]
+}

--- a/packages/now-node/test/fixtures/02-node-server/now.json
+++ b/packages/now-node/test/fixtures/02-node-server/now.json
@@ -1,11 +1,15 @@
 {
   "version": 2,
-  "builds": [
-    { "src": "index.js", "use": "@now/node" },
-    { "src": "subdirectory/index.js", "use": "@now/node" }
-  ],
+  "builds": [{ "src": "**/*.js", "use": "@now/node" }],
   "probes": [
     { "path": "/", "mustContain": "root:RANDOMNESS_PLACEHOLDER" },
-    { "path": "/subdirectory/", "mustContain": "subdir:RANDOMNESS_PLACEHOLDER" }
+    {
+      "path": "/subdirectory/",
+      "mustContain": "subdir:RANDOMNESS_PLACEHOLDER"
+    },
+    {
+      "path": "/hapi-async/",
+      "mustContain": "hapi-async:RANDOMNESS_PLACEHOLDER"
+    }
   ]
 }

--- a/packages/now-node/test/fixtures/02-node-server/subdirectory/index.js
+++ b/packages/now-node/test/fixtures/02-node-server/subdirectory/index.js
@@ -1,0 +1,7 @@
+const http = require('http');
+
+const server = http.createServer((req, resp) => {
+  resp.end('subdir:RANDOMNESS_PLACEHOLDER');
+});
+
+server.listen();


### PR DESCRIPTION
Add support for `server.listen()` to `@now/node`.

This will allow us to deprecate `@now/node-server`.