### PR TITLE
[now-node] Add warning in `now dev` when node version mismatches the requested range

### DIFF
--- a/packages/now-build-utils/package.json
+++ b/packages/now-build-utils/package.json
@@ -26,7 +26,7 @@
     "minimatch": "3.0.4",
     "multistream": "2.1.1",
     "node-fetch": "2.2.0",
-    "semver": "6.1.1",
+    "semver": "6.2.0",
     "yazl": "2.4.3"
   },
   "devDependencies": {
@@ -36,7 +36,7 @@
     "@types/fs-extra": "^5.0.5",
     "@types/glob": "^7.1.1",
     "@types/node-fetch": "^2.1.6",
-    "@types/semver": "6.0.0",
+    "@types/semver": "6.0.1",
     "@types/yazl": "^2.4.1",
     "execa": "^1.0.0",
     "typescript": "3.5.2"

--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -19,7 +19,7 @@
     "fs-extra": "^7.0.0",
     "get-port": "^5.0.0",
     "resolve-from": "^5.0.0",
-    "semver": "^5.6.0"
+    "semver": "6.2.0"
   },
   "files": [
     "dist"
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@types/next-server": "^8.0.0",
     "@types/resolve-from": "^5.0.1",
-    "@types/semver": "^6.0.0",
+    "@types/semver": "6.0.1",
     "jest": "^24.7.1",
     "typescript": "3.5.2"
   }

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -174,18 +174,18 @@ export const build = async ({
   const pkg = await readPackageJson(entryPath);
   const nextVersion = getNextVersion(pkg);
 
-  if (!meta.isDev) {
-    await createServerlessConfig(workPath);
-  }
-
-  const nodeVersion = await getNodeVersion(entryPath);
-  const spawnOpts = getSpawnOptions(meta, nodeVersion);
-
   if (!nextVersion) {
     throw new Error(
       'No Next.js version could be detected in "package.json". Make sure `"next"` is installed in "dependencies" or "devDependencies"'
     );
   }
+
+  if (!meta.isDev) {
+    await createServerlessConfig(workPath);
+  }
+
+  const nodeVersion = await getNodeVersion(entryPath, undefined, meta.isDev);
+  const spawnOpts = getSpawnOptions(meta, nodeVersion);
 
   if (meta.isDev) {
     let childProcess: ChildProcess | undefined;

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -15,7 +15,6 @@
     "@now/node-bridge": "1.2.2",
     "@types/node": "*",
     "@zeit/node-file-trace": "0.1.6",
-    "semver": "6.2.0",
     "typescript": "3.5.2"
   },
   "scripts": {
@@ -30,7 +29,6 @@
     "@types/content-type": "1.1.3",
     "@types/cookie": "0.3.3",
     "@types/etag": "1.8.0",
-    "@types/semver": "6.0.1",
     "@types/test-listen": "1.1.0",
     "@zeit/ncc": "0.20.4",
     "content-type": "1.0.4",

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -30,7 +30,6 @@
     "@types/content-type": "1.1.3",
     "@types/cookie": "0.3.3",
     "@types/etag": "1.8.0",
-    "@types/node": "*",
     "@types/semver": "6.0.1",
     "@types/test-listen": "1.1.0",
     "@zeit/ncc": "0.20.4",

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -15,6 +15,7 @@
     "@now/node-bridge": "1.2.2",
     "@types/node": "*",
     "@zeit/node-file-trace": "0.1.6",
+    "semver": "6.2.0",
     "typescript": "3.5.2"
   },
   "scripts": {
@@ -29,6 +30,8 @@
     "@types/content-type": "1.1.3",
     "@types/cookie": "0.3.3",
     "@types/etag": "1.8.0",
+    "@types/node": "*",
+    "@types/semver": "6.0.1",
     "@types/test-listen": "1.1.0",
     "@zeit/ncc": "0.20.4",
     "content-type": "1.0.4",

--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -1,4 +1,5 @@
 import { basename, dirname, join, relative, resolve, sep } from 'path';
+import { satisfies } from 'semver';
 import nodeFileTrace from '@zeit/node-file-trace';
 import {
   glob,
@@ -61,6 +62,15 @@ async function downloadInstallAndBundle({
   console.log("installing dependencies for user's code...");
   const entrypointFsDirname = join(workPath, dirname(entrypoint));
   const nodeVersion = await getNodeVersion(entrypointFsDirname);
+
+  if (meta.isDev && !satisfies(process.version, nodeVersion.range)) {
+    console.log(
+      `WARN: Your current version of \`node\` (${
+        process.version
+      }) does not match the requested range (${nodeVersion.range})`
+    );
+  }
+
   const spawnOpts = getSpawnOptions(meta, nodeVersion);
   await runNpmInstall(entrypointFsDirname, ['--prefer-offline'], spawnOpts);
 

--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -1,5 +1,4 @@
 import { basename, dirname, join, relative, resolve, sep } from 'path';
-import { satisfies } from 'semver';
 import nodeFileTrace from '@zeit/node-file-trace';
 import {
   glob,
@@ -61,15 +60,11 @@ async function downloadInstallAndBundle({
 
   console.log("installing dependencies for user's code...");
   const entrypointFsDirname = join(workPath, dirname(entrypoint));
-  const nodeVersion = await getNodeVersion(entrypointFsDirname);
-
-  if (meta.isDev && !satisfies(process.version, nodeVersion.range)) {
-    console.log(
-      `WARN: Your current version of \`node\` (${
-        process.version
-      }) does not match the requested range (${nodeVersion.range})`
-    );
-  }
+  const nodeVersion = await getNodeVersion(
+    entrypointFsDirname,
+    undefined,
+    meta.isDev
+  );
 
   const spawnOpts = getSpawnOptions(meta, nodeVersion);
   await runNpmInstall(entrypointFsDirname, ['--prefer-offline'], spawnOpts);

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -169,7 +169,11 @@ export async function build({
       }
     }
 
-    const nodeVersion = await getNodeVersion(entrypointDir, minNodeRange);
+    const nodeVersion = await getNodeVersion(
+      entrypointDir,
+      minNodeRange,
+      meta.isDev
+    );
     const spawnOpts = getSpawnOptions(meta, nodeVersion);
 
     await runNpmInstall(entrypointDir, ['--prefer-offline'], spawnOpts);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1235,10 +1235,10 @@
   dependencies:
     resolve-from "*"
 
-"@types/semver@6.0.0", "@types/semver@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.0.0.tgz#86ba89f02a414e39c68d02b351872e4ed31bd773"
-  integrity sha512-OO0srjOGH99a4LUN2its3+r6CBYcplhJ466yLqs+zvAWgphCpS8hYZEZ797tRDP/QKcqTdb/YCN6ifASoAWkrQ==
+"@types/semver@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.0.1.tgz#a984b405c702fa5a7ec6abc56b37f2ba35ef5af6"
+  integrity sha512-ffCdcrEE5h8DqVxinQjo+2d1q+FV5z7iNtPofw3JsrltSoSVlOGaW0rY8XxtO9XukdTn8TaCGWmk2VFGhI70mg==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -7892,10 +7892,10 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
-semver@6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.1.1.tgz#53f53da9b30b2103cd4f15eab3a18ecbcb210c9b"
-  integrity sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==
+semver@6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.2.0.tgz#4d813d9590aaf8a9192693d6c85b9344de5901db"
+  integrity sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==
 
 semver@~5.3.0:
   version "5.3.0"


### PR DESCRIPTION
Also updates `semver` module in `@now/build-utils` and `@now/next`.