### PR TITLE
Add lucleray to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,11 @@
 # Documentation
 # https://help.github.com/en/articles/about-code-owners
 
-*                       @styfle
-/packages/now-node      @styfle @tootallnate
-/packages/now-next      @timer  @dav-is
-/packages/now-go        @styfle @sophearak
-/packages/now-python    @styfle @sophearak
-/packages/now-rust      @styfle @mike-engel @anmonteiro
-/packages/now-ruby      @styfle @coetry @nathancahill
+*                         @styfle
+/packages/now-node        @styfle @tootallnate @lucleray
+/packages/now-node-bridge @styfle @tootallnate @lucleray
+/packages/now-next        @timer  @dav-is
+/packages/now-go          @styfle @sophearak
+/packages/now-python      @styfle @sophearak
+/packages/now-rust        @styfle @mike-engel @anmonteiro
+/packages/now-ruby        @styfle @coetry @nathancahill


### PR DESCRIPTION
@lucleray spent a lot of time refactoring the `@now/node` and `@now/node-bridge` packages its good to get eyes when new PRs come in 👀 

Previously there were no owners for `@now/node-bridge` so I added the same owners.

https://github.com/zeit/now-builders/pull/695/files?w=1