### PR TITLE
[now-md] Add support for `config.js`

### DIFF
--- a/packages/now-md/index.js
+++ b/packages/now-md/index.js
@@ -17,6 +17,7 @@ exports.build = async ({ files, entrypoint, config }) => {
   const language = options.language || 'en';
   const meta = options.meta || null;
   const css = options.css || null;
+  const js = options.js || null;
 
   const processor = unified()
     .use(markdown)
@@ -26,6 +27,7 @@ exports.build = async ({ files, entrypoint, config }) => {
       language,
       meta,
       css,
+      js,
     })
     .use(format)
     .use(html);


### PR DESCRIPTION
Currently only CSS is supported, which is cool, but JS would be also useful.