### PR TITLE
[now-build-utils] Set version to 0.7.4

### DIFF
--- a/packages/now-build-utils/package.json
+++ b/packages/now-build-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@now/build-utils",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.js",

--- a/packages/now-build-utils/test/fixtures/15-yarn-ignore-engines/now.json
+++ b/packages/now-build-utils/test/fixtures/15-yarn-ignore-engines/now.json
@@ -4,7 +4,7 @@
     {
       "src": "index.js",
       "use": "@now/node",
-      "config": { "maxLambdaSize": "15mb" }
+      "config": { "maxLambdaSize": "18mb" }
     }
   ],
   "probes": [{ "path": "/", "mustContain": "found:RANDOMNESS_PLACEHOLDER" }]


### PR DESCRIPTION
Increase the version for `now-build-utils` since we made a manual release.