### PR TITLE
[now-node] Make `types.d.ts` the main types export

### DIFF
--- a/packages/now-node/build.sh
+++ b/packages/now-node/build.sh
@@ -13,12 +13,17 @@ cp -v "$bridge_defs" src
 # build ts files
 tsc
 
+# todo: improve
+# copy type file for ts test
+cp dist/types.d.ts test/fixtures/15-helpers/ts/types.d.ts
+
+# use types.d.ts as the main types export
+mv dist/types.d.ts dist/types
+rm dist/*.d.ts
+mv dist/types dist/index.d.ts
+
 # bundle helpers.ts with ncc
 rm dist/helpers.js
 ncc build src/helpers.ts -o dist/helpers
 mv dist/helpers/index.js dist/helpers.js
 rm -rf dist/helpers
-
-# todo: improve
-# copy type file for ts test
-cp dist/types.d.ts test/fixtures/15-helpers/ts/types.d.ts


### PR DESCRIPTION
Fix https://github.com/zeit/now-builders/issues/703.