### PR TITLE
[now-build-utils] Add shell script args / opts

### DIFF
--- a/packages/now-build-utils/src/fs/run-user-scripts.ts
+++ b/packages/now-build-utils/src/fs/run-user-scripts.ts
@@ -82,16 +82,6 @@ export async function getNodeVersion(
     (packageJson && packageJson.engines && packageJson.engines.node) ||
     minNodeVersion;
   return getSupportedNodeVersion(range, typeof minNodeVersion !== 'undefined');
-
-  if (range) {
-    return getSupportedNodeVersion(range);
-  }
-
-  if (minNodeVersion) {
-    return getSupportedNodeVersion(minNodeVersion, true);
-  }
-
-  return getSupportedNodeVersion();
 }
 
 async function scanParentDirs(destPath: string, readPackageJson = false) {

--- a/packages/now-build-utils/src/fs/run-user-scripts.ts
+++ b/packages/now-build-utils/src/fs/run-user-scripts.ts
@@ -46,11 +46,15 @@ async function chmodPlusX(fsPath: string) {
   await fs.chmod(fsPath, base8);
 }
 
-export async function runShellScript(fsPath: string) {
+export async function runShellScript(
+  fsPath: string,
+  args: string[] = [],
+  spawnOpts?: SpawnOptions
+) {
   assert(path.isAbsolute(fsPath));
   const destPath = path.dirname(fsPath);
   await chmodPlusX(fsPath);
-  await spawnAsync(`./${path.basename(fsPath)}`, [], destPath);
+  await spawnAsync(`./${path.basename(fsPath)}`, args, destPath, spawnOpts);
   return true;
 }
 
@@ -69,9 +73,14 @@ export function getSpawnOptions(
   return opts;
 }
 
-export async function getNodeVersion(destPath: string, minNodeVersion?: string): Promise<NodeVersion> {
+export async function getNodeVersion(
+  destPath: string,
+  minNodeVersion?: string
+): Promise<NodeVersion> {
   const { packageJson } = await scanParentDirs(destPath, true);
-  const range = (packageJson && packageJson.engines && packageJson.engines.node) || minNodeVersion;
+  const range =
+    (packageJson && packageJson.engines && packageJson.engines.node) ||
+    minNodeVersion;
   return getSupportedNodeVersion(range, typeof minNodeVersion !== 'undefined');
 
   if (range) {
@@ -140,7 +149,13 @@ export async function runNpmInstall(
   } else {
     await spawnAsync(
       'yarn',
-      commandArgs.concat(['--ignore-engines', '--mutex', 'network', '--cwd', destPath]),
+      commandArgs.concat([
+        '--ignore-engines',
+        '--mutex',
+        'network',
+        '--cwd',
+        destPath,
+      ]),
       destPath,
       opts
     );


### PR DESCRIPTION
Some users may wish to use Node 10 from a build script like `build.sh`.

I will do a follow up PR to pass the spawn options from `@now/static-build`.

Related to [this spectrum issue](https://spectrum.chat/zeit/now/is-it-possible-to-specify-the-npm-version~ce099974-91f9-4af6-aec0-72a276fc740d)

Update: I also removed dead code