### PR TITLE
Fix branch inconsistencies

### DIFF
--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -15,7 +15,7 @@
     "directory": "packages/now-next"
   },
   "dependencies": {
-    "@now/node-bridge": "1.2.0-canary.3",
+    "@now/node-bridge": "1.2.2",
     "fs-extra": "^7.0.0",
     "get-port": "^5.0.0",
     "resolve-from": "^5.0.0",

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -10,7 +10,7 @@
     "directory": "packages/now-node"
   },
   "dependencies": {
-    "@now/node-bridge": "1.2.0-canary.3",
+    "@now/node-bridge": "1.2.2",
     "@types/node": "*",
     "@zeit/ncc": "0.20.3",
     "@zeit/ncc-watcher": "1.1.0"

--- a/packages/now-php/package.json
+++ b/packages/now-php/package.json
@@ -9,7 +9,7 @@
     "directory": "packages/now-php"
   },
   "dependencies": {
-    "@now/php-bridge": "^0.5.3-canary.0"
+    "@now/php-bridge": "^0.5.3"
   },
   "scripts": {
     "test": "jest"

--- a/packages/now-wordpress/package.json
+++ b/packages/now-wordpress/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/now-wordpress"
   },
   "dependencies": {
-    "@now/php-bridge": "^0.5.3-canary.0",
+    "@now/php-bridge": "^0.5.3",
     "node-fetch": "2.3.0",
     "yauzl": "2.10.0"
   },


### PR DESCRIPTION
When doing `git diff` between `master` and `canary`, only the `version` of the packages should differ, nothing else.