### PR TITLE
Fixed dependency

### DIFF
--- a/packages/now-node-server/package.json
+++ b/packages/now-node-server/package.json
@@ -10,8 +10,6 @@
   },
   "dependencies": {
     "@now/node-bridge": "1.2.2",
-    "@zeit/ncc": "0.18.5",
-    "@now/node-bridge": "1.2.0-canary.3",
     "@zeit/ncc": "0.20.3",
     "fs-extra": "7.0.1"
   },


### PR DESCRIPTION
This in `git diff canary` is wrong:

![image](https://user-images.githubusercontent.com/6170607/60769372-24590900-a0cf-11e9-978f-0a0ede97354d.png)
