### PR TITLE
Complete cleanup

### DIFF
--- a/packages/now-node-server/package.json
+++ b/packages/now-node-server/package.json
@@ -11,8 +11,6 @@
   "dependencies": {
     "@now/node-bridge": "1.2.2",
     "@zeit/ncc": "0.18.5",
-    "@now/node-bridge": "1.2.0-canary.3",
-    "@zeit/ncc": "0.18.5",
     "fs-extra": "7.0.1"
   },
   "scripts": {


### PR DESCRIPTION
This completes my cleanup and makes `git diff` only show the version as the difference between canary and master.