### PR TITLE
[now-build-utils] Ignore dot and underscore prefix for api directory

### DIFF
--- a/packages/now-build-utils/src/detect-builder.ts
+++ b/packages/now-build-utils/src/detect-builder.ts
@@ -34,10 +34,23 @@ export async function detectBuilder(pkg: PackageJson): Promise<Builder> {
   return { src, use: '@now/static-build', config };
 }
 
+// Files that match a specific pattern will get ignored
+export function ignoreApiFilter(file: string) {
+  if (file.includes('/.')) {
+    return false;
+  }
+
+  if (file.includes('/_')) {
+    return false;
+  }
+
+  return true;
+}
+
 export async function detectApiBuilders(
   files: string[]
 ): Promise<Builder[] | null> {
-  const builds = files.map(file => {
+  const builds = files.filter(ignoreApiFilter).map(file => {
     return API_BUILDERS.find(({ src }): boolean => minimatch(file, src));
   });
 

--- a/packages/now-build-utils/src/detect-builder.ts
+++ b/packages/now-build-utils/src/detect-builder.ts
@@ -50,27 +50,14 @@ export function ignoreApiFilter(file: string) {
 export async function detectApiBuilders(
   files: string[]
 ): Promise<Builder[] | null> {
-  const hasIgnores = files.some(file => !ignoreApiFilter(file));
-
-  const builds = files.map(file => {
-    if (!ignoreApiFilter(file)) {
-      return null;
-    }
-
+  const builds = files.filter(ignoreApiFilter).map(file => {
     const result = API_BUILDERS.find(
       ({ src }): boolean => minimatch(file, src)
     );
 
-    if (hasIgnores) {
-      // We must overwrite the `src` property and create an own
-      // match for each file.
-      return { ...result, src: file };
-    }
-
-    return result;
+    return result ? { ...result, src: file } : null;
   });
 
-  // We can use `new Set` here since `builds` contains references to `API_BUILDERS`
-  const finishedBuilds = Array.from(new Set(builds.filter(Boolean)));
+  const finishedBuilds = builds.filter(Boolean);
   return finishedBuilds.length > 0 ? (finishedBuilds as Builder[]) : null;
 }

--- a/packages/now-build-utils/src/detect-builder.ts
+++ b/packages/now-build-utils/src/detect-builder.ts
@@ -50,8 +50,24 @@ export function ignoreApiFilter(file: string) {
 export async function detectApiBuilders(
   files: string[]
 ): Promise<Builder[] | null> {
-  const builds = files.filter(ignoreApiFilter).map(file => {
-    return API_BUILDERS.find(({ src }): boolean => minimatch(file, src));
+  const hasIgnores = files.some(file => !ignoreApiFilter(file));
+
+  const builds = files.map(file => {
+    if (!ignoreApiFilter(file)) {
+      return null;
+    }
+
+    const result = API_BUILDERS.find(
+      ({ src }): boolean => minimatch(file, src)
+    );
+
+    if (hasIgnores) {
+      // We must overwrite the `src` property and create an own
+      // match for each file.
+      return { ...result, src: file };
+    }
+
+    return result;
   });
 
   // We can use `new Set` here since `builds` contains references to `API_BUILDERS`

--- a/packages/now-build-utils/src/detect-routes.ts
+++ b/packages/now-build-utils/src/detect-routes.ts
@@ -196,8 +196,6 @@ export async function detectApiRoutes(
 
     const conflictingSegment = getConflictingSegment(file);
 
-    console.log({ file, conflictingSegment });
-
     if (conflictingSegment) {
       return {
         defaultRoutes: null,

--- a/packages/now-build-utils/src/detect-routes.ts
+++ b/packages/now-build-utils/src/detect-routes.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import { Route } from './types';
+import { ignoreApiFilter } from './detect-builder';
 
 function concatArrayOfText(texts: string[]): string {
   const last = texts.pop();
@@ -183,7 +184,9 @@ export async function detectApiRoutes(
 
   // The deepest routes need to be
   // the first ones to get handled
-  const sortedFiles = files.sort(sortFilesBySegmentCount);
+  const sortedFiles = files
+    .filter(ignoreApiFilter)
+    .sort(sortFilesBySegmentCount);
 
   const defaultRoutes: Route[] = [];
 

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -207,6 +207,18 @@ it('Test `detectApiBuilders`', async () => {
     const builders = await detectApiBuilders(files);
     expect(builders).toBe(null);
   }
+
+  {
+    const files = [
+      'api/users/[id].js',
+      'api/_utils/handler.js',
+      'api/users/.helper.js',
+      'api/teams/_helper.js',
+    ];
+
+    const builders = await detectApiBuilders(files);
+    expect(builders.length).toBe(1);
+  }
 });
 
 it('Test `detectApiRoutes`', async () => {
@@ -243,5 +255,16 @@ it('Test `detectApiRoutes`', async () => {
 
     const { defaultRoutes } = await detectApiRoutes(files);
     expect(defaultRoutes.length).toBe(2);
+  }
+
+  {
+    const files = [
+      'api/_utils/handler.js',
+      'api/[endpoint]/.helper.js',
+      'api/[endpoint]/[id].js',
+    ];
+
+    const builders = await detectApiBuilders(files);
+    expect(builders.length).toBe(1);
   }
 });


### PR DESCRIPTION
Ignore files and folders with a dot or underscore prefix for api.