### PR TITLE
[now-bash][now-go][now-python] Support zero config

### DIFF
--- a/packages/now-bash/index.js
+++ b/packages/now-bash/index.js
@@ -10,7 +10,7 @@ const {
 } = require('@now/build-utils'); // eslint-disable-line import/no-extraneous-dependencies
 
 exports.config = {
-  maxLambdaSize: '10mb',
+  maxLambdaSize: '30mb',
 };
 
 // From this list: https://import.pw/importpw/import/docs/config.md

--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -120,7 +120,14 @@ Learn more: https://zeit.co/docs/v2/deployments/official-builders/go-now-go/#ent
   const parsedAnalyzed = JSON.parse(analyzed) as Analyzed;
 
   if (meta.isDev) {
-    const base = dirname(downloadedFiles['now.json'].fsPath);
+    let base = null;
+
+    if (config && config.zeroConfig) {
+      base = workPath;
+    } else {
+      base = dirname(downloadedFiles['now.json'].fsPath);
+    }
+
     const destNow = join(
       base,
       '.now',

--- a/packages/now-python/src/index.ts
+++ b/packages/now-python/src/index.ts
@@ -92,7 +92,7 @@ export const build = async ({
   files: originalFiles,
   entrypoint,
   meta = {},
-  config = {},
+  config,
 }: BuildOptions) => {
   console.log('downloading files...');
   let downloadedFiles = await download(originalFiles, workPath, meta);

--- a/packages/now-python/src/index.ts
+++ b/packages/now-python/src/index.ts
@@ -92,12 +92,20 @@ export const build = async ({
   files: originalFiles,
   entrypoint,
   meta = {},
+  config = {},
 }: BuildOptions) => {
   console.log('downloading files...');
   let downloadedFiles = await download(originalFiles, workPath, meta);
 
   if (meta.isDev) {
-    const base = dirname(downloadedFiles['now.json'].fsPath);
+    let base = null;
+
+    if (config && config.zeroConfig) {
+      base = workPath;
+    } else {
+      base = dirname(downloadedFiles['now.json'].fsPath);
+    }
+
     const destNow = join(base, '.now', 'cache', basename(entrypoint, '.py'));
     await download(downloadedFiles, destNow);
     downloadedFiles = await glob('**', destNow);


### PR DESCRIPTION
Support `zeroConfig` property and increase `maxLambdaSize` for `@now/bash` since the default wasn't enough while testing