### PR TITLE
Nested tsconfig.json lookup support

### DIFF
--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -132,12 +132,14 @@ async function compile(
     try {
       var { code, map } = tsCompile(source, path);
     } catch (e) {
-      // If TypeScript compile fails, attempt a direct non-typecheck compile
-      try {
-        var { code, map } = tsCompile(source, path, true);
-      } catch (e) {
-        return source;
+      if (config.debug) {
+        console.error(e);
+        console.log(
+          'TypeScript compilation failed, falling back to basic transformModule'
+        );
       }
+      // If TypeScript compile fails, attempt a direct non-typecheck compile
+      var { code, map } = tsCompile(source, path, true);
     }
     tsCompiled.add(relPath);
     preparedFiles[relPath.slice(0, -3) + '.js.map'] = new FileBlob({

--- a/packages/now-node/src/typescript.ts
+++ b/packages/now-node/src/typescript.ts
@@ -195,7 +195,6 @@ export function init(opts: Options = {}): Compile {
     let build = builds.get(configFileName);
     if (build) return build;
 
-    const outputCache = new Map<string, { code: string; map: any }>();
     const config = readConfig(configFileName);
 
     /**
@@ -325,7 +324,6 @@ export function init(opts: Options = {}): Compile {
       (build = {
         getOutput,
         getOutputTypeCheck,
-        outputCache,
       })
     );
     return build;
@@ -363,7 +361,7 @@ export function init(opts: Options = {}): Compile {
           options: {},
         };
         const configDiagnosticList = filterDiagnostics(
-          config.errors,
+          errorResult.errors,
           ignoreDiagnostics
         );
         // Render the configuration errors.
@@ -401,7 +399,7 @@ export function init(opts: Options = {}): Compile {
 
     if (configFileName) {
       const configDiagnosticList = filterDiagnostics(
-        config.errors,
+        configResult.errors,
         ignoreDiagnostics
       );
       // Render the configuration errors.
@@ -426,7 +424,6 @@ export function init(opts: Options = {}): Compile {
       }),
     };
     delete output.map.sourceRoot;
-    build.outputCache.set(fileName, output);
     return output;
   }
 
@@ -436,7 +433,6 @@ export function init(opts: Options = {}): Compile {
 interface Build {
   getOutput(code: string, fileName: string): [string, string];
   getOutputTypeCheck(code: string, fileName: string): [string, string];
-  outputCache: Map<string, { code: string; map: any }>;
 }
 
 /**

--- a/packages/now-node/src/typescript.ts
+++ b/packages/now-node/src/typescript.ts
@@ -57,7 +57,6 @@ interface Options {
   compiler?: string;
   ignore?: string[];
   project?: string;
-  skipProject?: boolean | null;
   compilerOptions?: object;
   ignoreDiagnostics?: Array<number | string>;
   readFile?: (path: string) => string | undefined;
@@ -87,7 +86,6 @@ const DEFAULTS: Options = {
   compilerOptions: undefined,
   ignore: undefined,
   project: undefined,
-  skipProject: null,
   ignoreDiagnostics: undefined,
   logError: null,
 };
@@ -163,24 +161,17 @@ export function init(opts: Options = {}): Compile {
   const transformers = options.transformers || undefined;
   const readFile = options.readFile || ts.sys.readFile;
   const fileExists = options.fileExists || ts.sys.fileExists;
-  const config = readConfig(cwd, ts, fileExists, readFile, options);
-  const configDiagnosticList = filterDiagnostics(
-    config.errors,
-    ignoreDiagnostics
-  );
-  const extensions = ['.ts'];
-  const outputCache = new Map<string, { code: string; map: any }>();
+
+  const formatDiagnostics =
+    process.stdout.isTTY || options.pretty
+      ? ts.formatDiagnosticsWithColorAndContext
+      : ts.formatDiagnostics;
 
   const diagnosticHost: _ts.FormatDiagnosticsHost = {
     getNewLine: () => ts.sys.newLine,
     getCurrentDirectory: () => cwd,
     getCanonicalFileName: path => path,
   };
-
-  const formatDiagnostics =
-    process.stdout.isTTY || options.pretty
-      ? ts.formatDiagnosticsWithColorAndContext
-      : ts.formatDiagnostics;
 
   function createTSError(diagnostics: ReadonlyArray<_ts.Diagnostic>) {
     const diagnosticText = formatDiagnostics(diagnostics, diagnosticHost);
@@ -198,136 +189,235 @@ export function init(opts: Options = {}): Compile {
     }
   }
 
-  // Render the configuration errors.
-  if (configDiagnosticList.length) reportTSError(configDiagnosticList);
+  // we create a custom build per tsconfig.json instance
+  const builds = new Map<string, Build>();
+  function getBuild(configFileName: string = ''): Build {
+    let build = builds.get(configFileName);
+    if (build) return build;
 
-  // Enable additional extensions when JSX or `allowJs` is enabled.
-  if (config.options.jsx) extensions.push('.tsx');
-  if (config.options.allowJs) extensions.push('.js');
-  if (config.options.jsx && config.options.allowJs) extensions.push('.jsx');
+    const outputCache = new Map<string, { code: string; map: any }>();
+    const config = readConfig(configFileName);
 
-  /**
-   * Create the basic required function using transpile mode.
-   */
-  let getOutput = function(code: string, fileName: string): [string, string] {
-    const result = ts.transpileModule(code, {
-      fileName,
-      transformers,
-      compilerOptions: config.options,
-      reportDiagnostics: true,
-    });
+    /**
+     * Create the basic required function using transpile mode.
+     */
+    let getOutput = function(code: string, fileName: string): [string, string] {
+      const result = ts.transpileModule(code, {
+        fileName,
+        transformers,
+        compilerOptions: config.options,
+        reportDiagnostics: true,
+      });
 
-    const diagnosticList = result.diagnostics
-      ? filterDiagnostics(result.diagnostics, ignoreDiagnostics)
-      : [];
-
-    if (diagnosticList.length) reportTSError(configDiagnosticList);
-
-    return [result.outputText, result.sourceMapText as string];
-  };
-
-  // Use full language services when the fast option is disabled.
-  let getOutputTypeCheck: (code: string, fileName: string) => [string, string];
-  {
-    const memoryCache = new MemoryCache(config.fileNames);
-    const cachedReadFile = cachedLookup(debugFn('readFile', readFile));
-
-    // Create the compiler host for type checking.
-    const serviceHost: _ts.LanguageServiceHost = {
-      getScriptFileNames: () => Array.from(memoryCache.fileVersions.keys()),
-      getScriptVersion: (fileName: string) => {
-        const version = memoryCache.fileVersions.get(fileName);
-        return version === undefined ? '' : version.toString();
-      },
-      getScriptSnapshot(fileName: string) {
-        let contents = memoryCache.fileContents.get(fileName);
-
-        // Read contents into TypeScript memory cache.
-        if (contents === undefined) {
-          contents = cachedReadFile(fileName);
-          if (contents === undefined) return;
-
-          memoryCache.fileVersions.set(fileName, 1);
-          memoryCache.fileContents.set(fileName, contents);
-        }
-
-        return ts.ScriptSnapshot.fromString(contents);
-      },
-      readFile: cachedReadFile,
-      readDirectory: cachedLookup(
-        debugFn('readDirectory', ts.sys.readDirectory)
-      ),
-      getDirectories: cachedLookup(
-        debugFn('getDirectories', ts.sys.getDirectories)
-      ),
-      fileExists: cachedLookup(debugFn('fileExists', fileExists)),
-      directoryExists: cachedLookup(
-        debugFn('directoryExists', ts.sys.directoryExists)
-      ),
-      getNewLine: () => ts.sys.newLine,
-      useCaseSensitiveFileNames: () => ts.sys.useCaseSensitiveFileNames,
-      getCurrentDirectory: () => cwd,
-      getCompilationSettings: () => config.options,
-      getDefaultLibFileName: () => ts.getDefaultLibFilePath(config.options),
-      getCustomTransformers: () => transformers,
-    };
-
-    const registry = ts.createDocumentRegistry(
-      ts.sys.useCaseSensitiveFileNames,
-      cwd
-    );
-    const service = ts.createLanguageService(serviceHost, registry);
-
-    // Set the file contents into cache manually.
-    const updateMemoryCache = function(contents: string, fileName: string) {
-      const fileVersion = memoryCache.fileVersions.get(fileName) || 0;
-
-      // Avoid incrementing cache when nothing has changed.
-      if (memoryCache.fileContents.get(fileName) === contents) return;
-
-      memoryCache.fileVersions.set(fileName, fileVersion + 1);
-      memoryCache.fileContents.set(fileName, contents);
-    };
-
-    getOutputTypeCheck = function(code: string, fileName: string) {
-      updateMemoryCache(code, fileName);
-
-      const output = service.getEmitOutput(fileName);
-
-      // Get the relevant diagnostics - this is 3x faster than `getPreEmitDiagnostics`.
-      const diagnostics = service
-        .getSemanticDiagnostics(fileName)
-        .concat(service.getSyntacticDiagnostics(fileName));
-
-      const diagnosticList = filterDiagnostics(diagnostics, ignoreDiagnostics);
+      const diagnosticList = result.diagnostics
+        ? filterDiagnostics(result.diagnostics, ignoreDiagnostics)
+        : [];
 
       if (diagnosticList.length) reportTSError(diagnosticList);
 
-      if (output.emitSkipped) {
-        throw new TypeError(`${relative(cwd, fileName)}: Emit skipped`);
-      }
-
-      // Throw an error when requiring `.d.ts` files.
-      if (output.outputFiles.length === 0) {
-        throw new TypeError(
-          'Unable to require `.d.ts` file.\n' +
-            'This is usually the result of a faulty configuration or import. ' +
-            'Make sure there is a `.js`, `.json` or another executable extension and ' +
-            'loader (attached before `ts-node`) available alongside ' +
-            `\`${basename(fileName)}\`.`
-        );
-      }
-
-      return [output.outputFiles[1].text, output.outputFiles[0].text];
+      return [result.outputText, result.sourceMapText as string];
     };
+
+    // Use full language services when the fast option is disabled.
+    let getOutputTypeCheck: (
+      code: string,
+      fileName: string
+    ) => [string, string];
+    {
+      const memoryCache = new MemoryCache(config.fileNames);
+      const cachedReadFile = cachedLookup(debugFn('readFile', readFile));
+
+      // Create the compiler host for type checking.
+      const serviceHost: _ts.LanguageServiceHost = {
+        getScriptFileNames: () => Array.from(memoryCache.fileVersions.keys()),
+        getScriptVersion: (fileName: string) => {
+          const version = memoryCache.fileVersions.get(fileName);
+          return version === undefined ? '' : version.toString();
+        },
+        getScriptSnapshot(fileName: string) {
+          let contents = memoryCache.fileContents.get(fileName);
+
+          // Read contents into TypeScript memory cache.
+          if (contents === undefined) {
+            contents = cachedReadFile(fileName);
+            if (contents === undefined) return;
+
+            memoryCache.fileVersions.set(fileName, 1);
+            memoryCache.fileContents.set(fileName, contents);
+          }
+
+          return ts.ScriptSnapshot.fromString(contents);
+        },
+        readFile: cachedReadFile,
+        readDirectory: cachedLookup(
+          debugFn('readDirectory', ts.sys.readDirectory)
+        ),
+        getDirectories: cachedLookup(
+          debugFn('getDirectories', ts.sys.getDirectories)
+        ),
+        fileExists: cachedLookup(debugFn('fileExists', fileExists)),
+        directoryExists: cachedLookup(
+          debugFn('directoryExists', ts.sys.directoryExists)
+        ),
+        getNewLine: () => ts.sys.newLine,
+        useCaseSensitiveFileNames: () => ts.sys.useCaseSensitiveFileNames,
+        getCurrentDirectory: () => cwd,
+        getCompilationSettings: () => config.options,
+        getDefaultLibFileName: () => ts.getDefaultLibFilePath(config.options),
+        getCustomTransformers: () => transformers,
+      };
+
+      const registry = ts.createDocumentRegistry(
+        ts.sys.useCaseSensitiveFileNames,
+        cwd
+      );
+      const service = ts.createLanguageService(serviceHost, registry);
+
+      // Set the file contents into cache manually.
+      const updateMemoryCache = function(contents: string, fileName: string) {
+        const fileVersion = memoryCache.fileVersions.get(fileName) || 0;
+
+        // Avoid incrementing cache when nothing has changed.
+        if (memoryCache.fileContents.get(fileName) === contents) return;
+
+        memoryCache.fileVersions.set(fileName, fileVersion + 1);
+        memoryCache.fileContents.set(fileName, contents);
+      };
+
+      getOutputTypeCheck = function(code: string, fileName: string) {
+        updateMemoryCache(code, fileName);
+
+        const output = service.getEmitOutput(fileName);
+
+        // Get the relevant diagnostics - this is 3x faster than `getPreEmitDiagnostics`.
+        const diagnostics = service
+          .getSemanticDiagnostics(fileName)
+          .concat(service.getSyntacticDiagnostics(fileName));
+
+        const diagnosticList = filterDiagnostics(
+          diagnostics,
+          ignoreDiagnostics
+        );
+
+        if (diagnosticList.length) reportTSError(diagnosticList);
+
+        if (output.emitSkipped) {
+          throw new TypeError(`${relative(cwd, fileName)}: Emit skipped`);
+        }
+
+        // Throw an error when requiring `.d.ts` files.
+        if (output.outputFiles.length === 0) {
+          throw new TypeError(
+            'Unable to require `.d.ts` file.\n' +
+              'This is usually the result of a faulty configuration or import. ' +
+              'Make sure there is a `.js`, `.json` or another executable extension and ' +
+              'loader (attached before `ts-node`) available alongside ' +
+              `\`${basename(fileName)}\`.`
+          );
+        }
+
+        return [output.outputFiles[1].text, output.outputFiles[0].text];
+      };
+    }
+
+    builds.set(
+      configFileName,
+      (build = {
+        getOutput,
+        getOutputTypeCheck,
+        outputCache,
+      })
+    );
+    return build;
+  }
+
+  // determine the tsconfig.json path for a given folder
+  function detectConfig(basePath: string): string | undefined {
+    basePath = normalizeSlashes(basePath);
+    let configFileName: string | undefined = undefined;
+
+    // Read project configuration when available.
+    configFileName = options.project
+      ? normalizeSlashes(resolve(cwd, options.project))
+      : ts.findConfigFile(normalizeSlashes(cwd), fileExists);
+
+    if (configFileName) return normalizeSlashes(configFileName);
+  }
+
+  /**
+   * Load TypeScript configuration.
+   */
+  function readConfig(configFileName: string): _ts.ParsedCommandLine {
+    let config: any = { compilerOptions: {} };
+    let basePath = normalizeSlashes(dirname(configFileName));
+
+    // Read project configuration when available.
+    if (configFileName) {
+      const result = ts.readConfigFile(configFileName, readFile);
+
+      // Return diagnostics.
+      if (result.error) {
+        const errorResult = {
+          errors: [result.error],
+          fileNames: [],
+          options: {},
+        };
+        const configDiagnosticList = filterDiagnostics(
+          config.errors,
+          ignoreDiagnostics
+        );
+        // Render the configuration errors.
+        if (configDiagnosticList.length) reportTSError(configDiagnosticList);
+        return errorResult;
+      }
+
+      config = result.config;
+    }
+
+    // Remove resolution of "files".
+    if (!options.files) {
+      config.files = [];
+      config.include = [];
+    }
+
+    // Override default configuration options `ts-node` requires.
+    config.compilerOptions = Object.assign(
+      {},
+      config.compilerOptions,
+      options.compilerOptions,
+      TS_NODE_COMPILER_OPTIONS
+    );
+
+    const configResult = fixConfig(
+      ts,
+      ts.parseJsonConfigFileContent(
+        config,
+        ts.sys,
+        basePath,
+        undefined,
+        configFileName
+      )
+    );
+
+    if (configFileName) {
+      const configDiagnosticList = filterDiagnostics(
+        config.errors,
+        ignoreDiagnostics
+      );
+      // Render the configuration errors.
+      if (configDiagnosticList.length) reportTSError(configDiagnosticList);
+    }
+
+    return configResult;
   }
 
   // Create a simple TypeScript compiler proxy.
   function compile(code: string, fileName: string, skipTypeCheck?: boolean) {
-    const [value, sourceMap] = (skipTypeCheck ? getOutput : getOutputTypeCheck)(
-      code,
-      fileName
-    );
+    const configFileName = detectConfig(fileName);
+    const build = getBuild(configFileName);
+    const [value, sourceMap] = (skipTypeCheck
+      ? build.getOutput
+      : build.getOutputTypeCheck)(code, fileName);
     const output = {
       code: value,
       map: Object.assign(JSON.parse(sourceMap), {
@@ -336,11 +426,17 @@ export function init(opts: Options = {}): Compile {
       }),
     };
     delete output.map.sourceRoot;
-    outputCache.set(fileName, output);
+    build.outputCache.set(fileName, output);
     return output;
   }
 
   return compile;
+}
+
+interface Build {
+  getOutput(code: string, fileName: string): [string, string];
+  getOutputTypeCheck(code: string, fileName: string): [string, string];
+  outputCache: Map<string, { code: string; map: any }>;
 }
 
 /**
@@ -362,71 +458,10 @@ function fixConfig(ts: TSCommon, config: _ts.ParsedCommandLine) {
     config.options.target = ts.ScriptTarget.ES5;
   }
 
-  // Target CommonJS modules by default (instead of magically switching to ES6 when the target is ES6).
-  if (config.options.module === undefined) {
-    config.options.module = ts.ModuleKind.CommonJS;
-  }
+  // Target CommonJS, always!
+  config.options.module = ts.ModuleKind.CommonJS;
 
   return config;
-}
-
-/**
- * Load TypeScript configuration.
- */
-function readConfig(
-  cwd: string,
-  ts: TSCommon,
-  fileExists: (path: string) => boolean,
-  readFile: (path: string) => string | undefined,
-  options: Options
-): _ts.ParsedCommandLine {
-  let config: any = { compilerOptions: {} };
-  let basePath = normalizeSlashes(cwd);
-  let configFileName: string | undefined = undefined;
-
-  // Read project configuration when available.
-  if (!options.skipProject) {
-    configFileName = options.project
-      ? normalizeSlashes(resolve(cwd, options.project))
-      : ts.findConfigFile(normalizeSlashes(cwd), fileExists);
-
-    if (configFileName) {
-      const result = ts.readConfigFile(configFileName, readFile);
-
-      // Return diagnostics.
-      if (result.error) {
-        return { errors: [result.error], fileNames: [], options: {} };
-      }
-
-      config = result.config;
-      basePath = normalizeSlashes(dirname(configFileName));
-    }
-  }
-
-  // Remove resolution of "files".
-  if (!options.files) {
-    config.files = [];
-    config.include = [];
-  }
-
-  // Override default configuration options `ts-node` requires.
-  config.compilerOptions = Object.assign(
-    {},
-    config.compilerOptions,
-    options.compilerOptions,
-    TS_NODE_COMPILER_OPTIONS
-  );
-
-  return fixConfig(
-    ts,
-    ts.parseJsonConfigFileContent(
-      config,
-      ts.sys,
-      basePath,
-      undefined,
-      configFileName
-    )
-  );
 }
 
 /**

--- a/packages/now-node/test/fixtures/18-nested-tsconfig/functions/double-redirect.ts
+++ b/packages/now-node/test/fixtures/18-nested-tsconfig/functions/double-redirect.ts
@@ -1,0 +1,16 @@
+import { IncomingMessage, ServerResponse } from 'http';
+import { parse } from 'url';
+
+const func = (req: IncomingMessage, res: ServerResponse) => {
+  if (req.url) {
+    const url = parse(req.url);
+    res.writeHead(302, {
+      Location: url.pathname
+        ? url.pathname.replace(/\/+/g, '/') + (url.search ? url.search : '')
+        : '/',
+    });
+    res.end();
+  }
+};
+
+export default func;

--- a/packages/now-node/test/fixtures/18-nested-tsconfig/functions/package.json
+++ b/packages/now-node/test/fixtures/18-nested-tsconfig/functions/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "functions",
+  "version": "1.0.0",
+  "main": "index.js",
+  "devDependencies": {
+    "@types/node": "12.6.1"
+  }
+}

--- a/packages/now-node/test/fixtures/18-nested-tsconfig/functions/referer-redirect.ts
+++ b/packages/now-node/test/fixtures/18-nested-tsconfig/functions/referer-redirect.ts
@@ -1,0 +1,18 @@
+import { IncomingMessage, ServerResponse } from 'http';
+import { parse } from 'url';
+
+const func = (req: IncomingMessage, res: ServerResponse) => {
+  const { referer } = req.headers;
+  if (!referer) {
+    res.writeHead(302, { Location: `/404` });
+    return;
+  }
+  const {
+    host,
+    query: { section },
+  } = parse(referer, true);
+  res.writeHead(302, { Location: `/deployments/${host}/${section}` });
+  res.end();
+};
+
+export default func;

--- a/packages/now-node/test/fixtures/18-nested-tsconfig/functions/trailing-redirect.ts
+++ b/packages/now-node/test/fixtures/18-nested-tsconfig/functions/trailing-redirect.ts
@@ -1,0 +1,20 @@
+import { IncomingMessage, ServerResponse } from 'http';
+import { parse } from 'url';
+
+const func = (req: IncomingMessage, res: ServerResponse) => {
+  if (req.url) {
+    const url = parse(req.url);
+    let pathname = url.pathname;
+    if (pathname && pathname.slice(-1) === '/') {
+      // remove all leading `/`s, keep one
+      pathname = pathname.replace(/^\/+/g, '/');
+      const location = pathname.slice(0, -1) + (url.search ? url.search : '');
+      /*res.writeHead(302, {
+        Location: location
+      })*/
+      res.end(`trailing-redirect:RANDOMNESS_PLACEHOLDER:${location}`);
+    }
+  }
+};
+
+export default func;

--- a/packages/now-node/test/fixtures/18-nested-tsconfig/functions/tsconfig.json
+++ b/packages/now-node/test/fixtures/18-nested-tsconfig/functions/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    "lib": [
+      "es2015"
+    ] /* Specify library files to be included in the compilation. */,
+
+    /* Strict Type-Checking Options */
+    "strict": true /* Enable all strict type-checking options. */,
+    "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
+    "strictNullChecks": true /* Enable strict null checks. */,
+    "strictFunctionTypes": true /* Enable strict checking of function types. */,
+    "strictBindCallApply": true /* Enable strict 'bind', 'call', and 'apply' methods on functions. */,
+    "strictPropertyInitialization": true /* Enable strict checking of property initialization in classes. */,
+    "noImplicitThis": true /* Raise error on 'this' expressions with an implied 'any' type. */,
+    "alwaysStrict": true /* Parse in strict mode and emit "use strict" for each source file. */,
+
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+  },
+  "exclude": ["./screenshot-api/**"]
+}

--- a/packages/now-node/test/fixtures/18-nested-tsconfig/index.ts
+++ b/packages/now-node/test/fixtures/18-nested-tsconfig/index.ts
@@ -1,0 +1,9 @@
+import { NowRequest, NowResponse } from '@now/node';
+
+export default function(req: NowRequest, res: NowResponse) {
+  if (req) {
+    res.end('root:RANDOMNESS_PLACEHOLDER');
+  } else {
+    res.end('no req found');
+  }
+}

--- a/packages/now-node/test/fixtures/18-nested-tsconfig/now.json
+++ b/packages/now-node/test/fixtures/18-nested-tsconfig/now.json
@@ -1,0 +1,36 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "functions/referer-redirect.ts", "use": "@now/node" },
+    { "src": "functions/double-redirect.ts", "use": "@now/node" },
+    { "src": "functions/trailing-redirect.ts", "use": "@now/node" },
+    { "src": "index.ts", "use": "@now/node" }
+  ],
+  "routes": [
+    {
+      "src": "/",
+      "dest": "index.ts"
+    },
+    {
+      "src": "(/.*)/$",
+      "dest": "/functions/trailing-redirect.ts"
+    },
+    {
+      "src": "^.*?//.*$",
+      "dest": "/functions/double-redirect.ts"
+    },
+    {
+      "handle": "filesystem"
+    }
+  ],
+  "probes": [
+    {
+      "path": "/",
+      "mustContain": "root:RANDOMNESS_PLACEHOLDER"
+    },
+    {
+      "path": "//",
+      "mustContain": "trailing-redirect:RANDOMNESS_PLACEHOLDER"
+    }
+  ]
+}

--- a/packages/now-node/test/fixtures/18-nested-tsconfig/package.json
+++ b/packages/now-node/test/fixtures/18-nested-tsconfig/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "nested-tsconfig",
+  "version": "1.0.0",
+  "main": "index.js",
+  "devDependencies": {
+    "typescript": "3.5.3"
+  }
+}

--- a/packages/now-node/test/fixtures/18-nested-tsconfig/tsconfig.json
+++ b/packages/now-node/test/fixtures/18-nested-tsconfig/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "allowJs": true,
+    "jsx": "preserve",
+    "target": "esnext",
+    "module": "esnext",
+    "lib": ["dom", "es2017"],
+    "noEmit": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "exclude": ["./functions/**"],
+  "include": ["**/*.ts", "**/*.tsx"]
+}


### PR DESCRIPTION
This implements nested tsconfig.json lookup loading by checking for the `tsconfig.json` for each compiled `.ts` file.

We then store a map of builds for each `tsconfig.json` path effectively turning the loader into a builder of builders, while retaining caching within each build itself.

Fixes #724.