### PR TITLE
[now-node] Add support for AWS Lambda API usage

### DIFF
--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -306,12 +306,14 @@ export async function build({
 
   // Use the system-installed version of `node` when running via `now dev`
   const runtime = meta.isDev ? 'nodejs' : nodeVersion.runtime;
+
+  // Enable the raw AWS API and use this handler
   const awsLambdaHandler = config.awsLambdaHandler as string;
 
   const lambda = await createLambda({
     files: {
       ...preparedFiles,
-      ...(awsLambdaHandler ? files : launcherFiles),
+      ...(awsLambdaHandler ? {} : launcherFiles),
     },
     handler: awsLambdaHandler || `${LAUNCHER_FILENAME}.launcher`,
     runtime,

--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -306,13 +306,14 @@ export async function build({
 
   // Use the system-installed version of `node` when running via `now dev`
   const runtime = meta.isDev ? 'nodejs' : nodeVersion.runtime;
+  const awsLambdaHandler = config.awsLambdaHandler as string;
 
   const lambda = await createLambda({
     files: {
       ...preparedFiles,
-      ...launcherFiles,
+      ...(awsLambdaHandler ? files : launcherFiles),
     },
-    handler: `${LAUNCHER_FILENAME}.launcher`,
+    handler: awsLambdaHandler || `${LAUNCHER_FILENAME}.launcher`,
     runtime,
   });
 

--- a/packages/now-node/test/fixtures/25-aws-api/callback/index.js
+++ b/packages/now-node/test/fixtures/25-aws-api/callback/index.js
@@ -1,0 +1,10 @@
+const { say } = require('cowsay');
+
+exports.handler = function (event, context, callback) {
+  const data = {
+    statusCode: 200,
+    headers: {},
+    body: say({ text: 'aws-api-callback:RANDOMNESS_PLACEHOLDER' }),
+  };
+  callback(null, data);
+};

--- a/packages/now-node/test/fixtures/25-aws-api/index.js
+++ b/packages/now-node/test/fixtures/25-aws-api/index.js
@@ -1,0 +1,9 @@
+
+
+exports.handler = async function () {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: 'aws-api:RANDOMNESS_PLACEHOLDER',
+  };
+};

--- a/packages/now-node/test/fixtures/25-aws-api/index.js
+++ b/packages/now-node/test/fixtures/25-aws-api/index.js
@@ -1,9 +1,9 @@
-
+const { say } = require('cowsay');
 
 exports.handler = async function () {
   return {
     statusCode: 200,
     headers: {},
-    body: 'aws-api:RANDOMNESS_PLACEHOLDER',
+    body: say({ text: 'aws-api-root:RANDOMNESS_PLACEHOLDER' }),
   };
 };

--- a/packages/now-node/test/fixtures/25-aws-api/now.json
+++ b/packages/now-node/test/fixtures/25-aws-api/now.json
@@ -1,0 +1,11 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "index.js",
+      "use": "@now/node",
+      "config": { "awsLambdaHandler": "index.handler" }
+    }
+  ],
+  "probes": [{ "path": "/", "mustContain": "aws-api:RANDOMNESS_PLACEHOLDER" }]
+}

--- a/packages/now-node/test/fixtures/25-aws-api/now.json
+++ b/packages/now-node/test/fixtures/25-aws-api/now.json
@@ -5,7 +5,18 @@
       "src": "index.js",
       "use": "@now/node",
       "config": { "awsLambdaHandler": "index.handler" }
+    },
+    {
+      "src": "callback/index.js",
+      "use": "@now/node",
+      "config": { "awsLambdaHandler": "callback/index.handler" }
     }
   ],
-  "probes": [{ "path": "/", "mustContain": "aws-api:RANDOMNESS_PLACEHOLDER" }]
+  "probes": [
+    { "path": "/", "mustContain": "aws-api-root:RANDOMNESS_PLACEHOLDER" },
+    {
+      "path": "/callback",
+      "mustContain": "aws-api-callback:RANDOMNESS_PLACEHOLDER"
+    }
+  ]
 }

--- a/packages/now-node/test/fixtures/25-aws-api/package.json
+++ b/packages/now-node/test/fixtures/25-aws-api/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "cowsay": "1.4.0"
+  }
+}


### PR DESCRIPTION
The idea here is that users should be able to deploy existing AWS Lambda functions to ZEIT Now without modifications besides adding `now.json`.

```json
{
  "version": 2,
  "builds": [
    {
      "src": "index.js",
      "use": "@now/node",
      "config": { "awsLambdaHandler": "index.handler" }
    }
  ]
}
```

This will work with any filename and any function name since the handler is defined in the `config.awsLambdaHandler`.

However multiple entry points will need to use define multiple `builds` instead of using `src` glob syntax.