### PR TITLE
Remove --mutex from yarn command

### DIFF
--- a/packages/now-build-utils/src/fs/run-user-scripts.ts
+++ b/packages/now-build-utils/src/fs/run-user-scripts.ts
@@ -141,8 +141,6 @@ export async function runNpmInstall(
       'yarn',
       commandArgs.concat([
         '--ignore-engines',
-        '--mutex',
-        'network',
         '--cwd',
         destPath,
       ]),


### PR DESCRIPTION
Remove mutex because it is not reentrant and hangs on sub-invocation