### PR TITLE
[now-static-build] Remove default routes for now dev

### DIFF
--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -177,7 +177,7 @@ export async function build({
     if (meta.isDev && pkg.scripts && pkg.scripts[devScript]) {
       let devPort: number | undefined = nowDevScriptPorts.get(entrypoint);
 
-      if (framework && config.zeroConfig) {
+      if (framework && framework.defaultRoutes) {
         // We need to delete the routes for `now dev`
         // since in this case it will get proxied to
         // a custom server we don't have controll over

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -177,6 +177,13 @@ export async function build({
     if (meta.isDev && pkg.scripts && pkg.scripts[devScript]) {
       let devPort: number | undefined = nowDevScriptPorts.get(entrypoint);
 
+      if (framework && config.zeroConfig) {
+        // We need to delete the routes for `now dev`
+        // since in this case it will get proxied to
+        // a custom server we don't have controll over
+        delete framework.defaultRoutes;
+      }
+
       if (typeof devPort === 'number') {
         console.log(
           '`%s` server already running for %j',


### PR DESCRIPTION
We want to remove the `defaultRoutes` from the `framework` in `now dev` when a `dev` script was invoked, since the routes won't apply to the custom server of e.g. `gatsby develop`.