### PR TITLE
[now-build-utils] Ignore more default routes and builds

### DIFF
--- a/packages/now-build-utils/src/detect-builder.ts
+++ b/packages/now-build-utils/src/detect-builder.ts
@@ -9,7 +9,7 @@ const BUILDERS = new Map<string, Builder>([
   ['next', { src, use: '@now/next', config }],
 ]);
 
-const API_BUILDERS: Builder[] = [
+export const API_BUILDERS: Builder[] = [
   { src: 'api/**/*.js', use: '@now/node@canary', config },
   { src: 'api/**/*.ts', use: '@now/node@canary', config },
   { src: 'api/**/*.rs', use: '@now/rust', config },
@@ -73,6 +73,12 @@ export function ignoreApiFilter(file: string) {
   }
 
   if (file.includes('/_')) {
+    return false;
+  }
+
+  // If the file does not match any builder we also
+  // don't want to create a reoute e.g. `package.json`
+  if (API_BUILDERS.some(({ src }) => minimatch(file, src)) === false) {
     return false;
   }
 

--- a/packages/now-build-utils/src/detect-builder.ts
+++ b/packages/now-build-utils/src/detect-builder.ts
@@ -9,7 +9,7 @@ const BUILDERS = new Map<string, Builder>([
   ['next', { src, use: '@now/next', config }],
 ]);
 
-export const API_BUILDERS: Builder[] = [
+const API_BUILDERS: Builder[] = [
   { src: 'api/**/*.js', use: '@now/node@canary', config },
   { src: 'api/**/*.ts', use: '@now/node@canary', config },
   { src: 'api/**/*.rs', use: '@now/rust', config },

--- a/packages/now-build-utils/src/detect-builder.ts
+++ b/packages/now-build-utils/src/detect-builder.ts
@@ -77,7 +77,7 @@ export function ignoreApiFilter(file: string) {
   }
 
   // If the file does not match any builder we also
-  // don't want to create a reoute e.g. `package.json`
+  // don't want to create a route e.g. `package.json`
   if (API_BUILDERS.some(({ src }) => minimatch(file, src)) === false) {
     return false;
   }

--- a/packages/now-build-utils/src/detect-builder.ts
+++ b/packages/now-build-utils/src/detect-builder.ts
@@ -78,7 +78,7 @@ export function ignoreApiFilter(file: string) {
 
   // If the file does not match any builder we also
   // don't want to create a route e.g. `package.json`
-  if (API_BUILDERS.some(({ src }) => minimatch(file, src)) === false) {
+  if (API_BUILDERS.every(({ src }) => !minimatch(file, src))) {
     return false;
   }
 

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -224,7 +224,7 @@ it('Test `detectApiBuilders`', async () => {
 
 it('Test `detectApiRoutes`', async () => {
   {
-    const files = ['api/user.go', 'api/team.js'];
+    const files = ['api/user.go', 'api/team.js', 'api/package.json'];
 
     const { defaultRoutes } = await detectApiRoutes(files);
     expect(defaultRoutes.length).toBe(2);


### PR DESCRIPTION
Ignore more default routes and builds if they do not that match any builder.