### PR TITLE
[now-build-utils] Fix file order

### DIFF
--- a/packages/now-build-utils/src/detect-builder.ts
+++ b/packages/now-build-utils/src/detect-builder.ts
@@ -88,15 +88,7 @@ export function ignoreApiFilter(file: string) {
 // We need to sort the file paths by alphabet to make
 // sure the routes stay in the same order e.g. for deduping
 export function sortFiles(fileA: string, fileB: string) {
-  if (fileA > fileB) {
-    return 1;
-  }
-
-  if (fileA < fileB) {
-    return -1;
-  }
-
-  return 0;
+  return fileA.localeCompare(fileB);
 }
 
 export async function detectApiBuilders(

--- a/packages/now-build-utils/src/detect-builder.ts
+++ b/packages/now-build-utils/src/detect-builder.ts
@@ -85,16 +85,33 @@ export function ignoreApiFilter(file: string) {
   return true;
 }
 
+// We need to sort the file paths by alphabet to make
+// sure the routes stay in the same order e.g. for deduping
+export function sortFiles(fileA: string, fileB: string) {
+  if (fileA > fileB) {
+    return 1;
+  }
+
+  if (fileA < fileB) {
+    return -1;
+  }
+
+  return 0;
+}
+
 export async function detectApiBuilders(
   files: string[]
 ): Promise<Builder[] | null> {
-  const builds = files.filter(ignoreApiFilter).map(file => {
-    const result = API_BUILDERS.find(
-      ({ src }): boolean => minimatch(file, src)
-    );
+  const builds = files
+    .sort(sortFiles)
+    .filter(ignoreApiFilter)
+    .map(file => {
+      const result = API_BUILDERS.find(
+        ({ src }): boolean => minimatch(file, src)
+      );
 
-    return result ? { ...result, src: file } : null;
-  });
+      return result ? { ...result, src: file } : null;
+    });
 
   const finishedBuilds = builds.filter(Boolean);
   return finishedBuilds.length > 0 ? (finishedBuilds as Builder[]) : null;

--- a/packages/now-build-utils/src/detect-routes.ts
+++ b/packages/now-build-utils/src/detect-routes.ts
@@ -1,6 +1,6 @@
 import { Route } from './types';
 import { parse as parsePath } from 'path';
-import { ignoreApiFilter } from './detect-builder';
+import { ignoreApiFilter, sortFiles } from './detect-builder';
 
 function joinPath(...segments: string[]) {
   const joinedPath = segments.join('/');
@@ -55,7 +55,7 @@ function createRouteFromPath(filePath: string): Route {
   );
 
   const src = `^/${srcParts.join('/')}$`;
-  const dest = `/${filePath}?${query.join('&')}`;
+  const dest = `/${filePath}${query.length ? '?' : ''}${query.join('&')}`;
 
   return { src, dest };
 }
@@ -181,6 +181,7 @@ export async function detectApiRoutes(
   // the first ones to get handled
   const sortedFiles = files
     .filter(ignoreApiFilter)
+    .sort(sortFiles)
     .sort(sortFilesBySegmentCount);
 
   const defaultRoutes: Route[] = [];

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -228,6 +228,8 @@ it('Test `detectApiRoutes`', async () => {
 
     const { defaultRoutes } = await detectApiRoutes(files);
     expect(defaultRoutes.length).toBe(2);
+    expect(defaultRoutes[0].dest).toBe('/api/team.js');
+    expect(defaultRoutes[1].dest).toBe('/api/user.go');
   }
 
   {


### PR DESCRIPTION
Fix file order to make sure the routes and builds are always in the same order.