### PR TITLE
[now-node-bridge] Fix main field in package.json

### DIFF
--- a/packages/now-node-bridge/package.json
+++ b/packages/now-node-bridge/package.json
@@ -2,7 +2,7 @@
   "name": "@now/node-bridge",
   "version": "1.2.0-canary.3",
   "license": "MIT",
-  "main": "./index.js",
+  "main": "./bridge.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/zeit/now-builders.git",

--- a/packages/now-node-bridge/test/bridge.test.js
+++ b/packages/now-node-bridge/test/bridge.test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const { Server } = require('http');
-const { Bridge } = require('../bridge');
+const { Bridge } = require('../'); // test the "main" from package.json
 
 test('port binding', async () => {
   const server = new Server();


### PR DESCRIPTION
This will ensure the `bridge.d.ts` types associate to the main file `bridge.js` so we no longer need to copy `.d.ts` anymore.

I also made sure the tests are running against the "main" in package.json instead of against a specific file.