### PR TITLE
[now-node] Set typescript package main without extension

### DIFF
--- a/packages/now-node/test/fixtures/42-yarn-workspaces-typescript-dep/now.json
+++ b/packages/now-node/test/fixtures/42-yarn-workspaces-typescript-dep/now.json
@@ -1,5 +1,11 @@
 {
   "version": 2,
-  "builds": [{ "src": "api/**/index.js", "use": "@now/node" }],
+  "builds": [
+    {
+      "src": "api/**/index.js",
+      "use": "@now/node",
+      "config": { "debug": true }
+    }
+  ],
   "probes": [{ "path": "/api/", "mustContain": "api:RANDOMNESS_PLACEHOLDER" }]
 }

--- a/packages/now-node/test/fixtures/42-yarn-workspaces-typescript-dep/packages/lib/package.json
+++ b/packages/now-node/test/fixtures/42-yarn-workspaces-typescript-dep/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builders-typescript-test/lib",
-  "main": "index.ts",
+  "main": "index",
   "version": "1.0.0",
   "devDependencies": {
     "typescript": "^3.4.5"


### PR DESCRIPTION
As a follow-up to https://github.com/zeit/now-builders/pull/765, this provides the failing test for the package.json without the main. Fix incoming.