### PR TITLE
Ignore yarn.lock changes on publish

### DIFF
--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -28,4 +28,7 @@ else
   echo "Publishing stable release"
 fi
 
+# Sometimes this is a false alarm and blocks publish
+git checkout yarn.lock
+
 yarn run lerna publish from-git $npm_tag --yes


### PR DESCRIPTION
This has caused too many problems.

Let's ignore any changes to yarn.lock so we can continue to publish.