### PR TITLE
[RFC] feat: use package.json and now-dev script in @now/node

### DIFF
--- a/packages/now-build-utils/src/types.ts
+++ b/packages/now-build-utils/src/types.ts
@@ -43,6 +43,7 @@ export interface Config {
   rust?: string;
   debug?: boolean;
   zeroConfig?: boolean;
+  basePath?: string;
   import?: { [key: string]: string };
 }
 

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@now/node",
+  "name": "@morgs32/node",
   "version": "0.7.4-canary.54",
   "license": "MIT",
   "main": "./dist/index",

--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -300,6 +300,8 @@ export async function build({
 }: BuildOptions) {
   const shouldAddHelpers = config.helpers !== false;
 
+  console.log('arguments[0]', arguments[0]);
+
   const {
     entrypointPath,
     entrypointFsDirname,

--- a/packages/now-node/src/types.ts
+++ b/packages/now-node/src/types.ts
@@ -1,4 +1,5 @@
 import { ServerResponse, IncomingMessage } from 'http';
+import { build } from '.';
 
 export type NowRequestCookies = { [key: string]: string };
 export type NowRequestQuery = { [key: string]: string | string[] };
@@ -15,3 +16,5 @@ export type NowResponse = ServerResponse & {
   json: (jsonBody: any) => NowResponse;
   status: (statusCode: number) => NowResponse;
 };
+
+export { build };

--- a/packages/now-static-build/build.sh
+++ b/packages/now-static-build/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euo pipefail
 
-ncc build src/index.ts -o dist
+ncc build src/index.ts -o dist --external=@now/node

--- a/packages/now-static-build/package.json
+++ b/packages/now-static-build/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@now/static-build",
-  "version": "0.5.8-canary.26",
+  "name": "@morgs32/universal-now-builder",
+  "version": "0.5.8-canary.34",
   "license": "MIT",
   "main": "./dist/index",
   "homepage": "https://zeit.co/docs/v2/deployments/official-builders/static-build-now-static-build",

--- a/packages/now-static-build/package.json
+++ b/packages/now-static-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morgs32/universal-now-builder",
-  "version": "0.5.8-canary.34",
+  "version": "0.5.8-canary.43",
   "license": "MIT",
   "main": "./dist/index",
   "homepage": "https://zeit.co/docs/v2/deployments/official-builders/static-build-now-static-build",

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -194,7 +194,7 @@ export async function build({
       if (framework && framework.defaultRoutes) {
         // We need to delete the routes for `now dev`
         // since in this case it will get proxied to
-        // a custom server we don't have controll over
+        // a custom server we don't have control over
         delete framework.defaultRoutes;
       }
 
@@ -257,7 +257,9 @@ export async function build({
         console.log('Detected dev server for %j', entrypoint);
       }
 
-      let srcBase = mountpoint.replace(/^\.\/?/, '');
+      let srcBase = config.basePath
+        ? config.basePath.replace(/^\//, '')
+        : mountpoint.replace(/^\.\/?/, '');
 
       if (srcBase.length > 0) {
         srcBase = `/${srcBase}`;
@@ -324,16 +326,21 @@ export async function build({
       }
     }
 
-    const watch = [path.join(mountpoint.replace(/^\.\/?/, ''), '**/*')];
+    const watch: Array<string> = [];
+    // const watch = [path.join(mountpoint.replace(/^\.\/?/, ''), '**/*')];
     const result = { routes, watch, output };
 
-    if (pkg.main && (!meta.isDev || !pkg.scripts[devScript])) {
+    const hasMain = pkg.main || config.main;
+    const useMain = !meta.isDev || !pkg.scripts[devScript];
+    if (hasMain && useMain) {
+      const mainPath = config.main || path.join(workPath, pkg.main);
       const nodeConfig = {
         ...arguments[0], // All the args passed to this build.
-        entrypoint: pkg.main,
+        entrypoint: mainPath,
       };
       const nodeResult = await nodeBuilder(nodeConfig);
-      result.watch.push(...nodeResult.watch);
+      console.log('nodeResult.watch', nodeResult.watch);
+      // result.watch.push(...nodeResult.watch);
       Object.assign(result.output, nodeResult.output);
     }
     return result;


### PR DESCRIPTION
The idea being simply to allow a `now-dev` script for a `@now/node` deployment.

The reasons to do this are:
- I desperately need to manage my own react app with SSR
- And in dev, my own webpack/hotmiddleware/devmiddleware/devserver

This would allow an entrypoint in `@now/node` of a `package.json` file. That pkg file could use a `now-dev` script just like `@now/static-build` does now.

And on deploy, `@now/node` can use the pkg.main file for a ref to the server file.

Thoughts?

```
// now.json
{
  "version": 2,
  "builds": [
    {
      "src": "app/package.json",
      "use": "@now/node"
    }
  ],
  "routes": [
    {
      "src": "/(.*)",
      "dest": "app/$1"
    }
  ]
}
```

```
// package.json
{
  "name": "app-server",
  "main": "build/server.js",
  ...
}
```

