### PR TITLE
Normalize slash for nested paths

### DIFF
--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -228,7 +228,7 @@ function getRoutes(
 
     const relativeToPages = path.relative('pages', relativePath);
     const extension = path.extname(relativeToPages);
-    const pageName = relativeToPages.replace(extension, '');
+    const pageName = relativeToPages.replace(extension, '').replace(/\\/g, '/');
 
     if (pageName.startsWith('_')) {
       continue;

--- a/packages/now-next/test/unit/build.test.js
+++ b/packages/now-next/test/unit/build.test.js
@@ -22,6 +22,18 @@ describe('build meta dev', () => {
       export default () => 'Index page'
     `,
     }),
+    'pages/nested/page.tsx': new FileBlob({
+      mode: 0o777,
+      data: `
+      export default () => 'Nested page'
+    `,
+    }),
+    'pages/api/test.js': new FileBlob({
+      mode: 0o777,
+      data: `
+      export default (req, res) => res.status(200).end('API Route')
+    `,
+    }),
     // This file should be omitted because `pages/index.js` will use the same route
     'public/index': new FileBlob({
       mode: 0o777,
@@ -80,11 +92,15 @@ describe('build meta dev', () => {
       { src: '/static/(.*)', dest: 'http://localhost:5000/static/$1' },
       { src: '/index', dest: 'http://localhost:5000/index' },
       { src: '/', dest: 'http://localhost:5000/' },
+      { src: '/nested/page', dest: 'http://localhost:5000/nested/page' },
+      { src: '/api/test', dest: 'http://localhost:5000/api/test' },
       { src: '/data.txt', dest: 'http://localhost:5000/data.txt' },
     ]);
     expect(watch).toEqual([
       'next.config.js',
       'pages/index.js',
+      'pages/nested/page.tsx',
+      'pages/api/test.js',
       'public/index',
       'public/data.txt',
       'package.json',

--- a/packages/now-next/test/unit/build.test.js
+++ b/packages/now-next/test/unit/build.test.js
@@ -22,6 +22,12 @@ describe('build meta dev', () => {
       export default () => 'Index page'
     `,
     }),
+    'pages/nested/[param].js': new FileBlob({
+      mode: 0o777,
+      data: `
+      export default () => 'Dynamic page'
+    `,
+    }),
     'pages/nested/page.tsx': new FileBlob({
       mode: 0o777,
       data: `
@@ -51,9 +57,14 @@ describe('build meta dev', () => {
           "now-build": "next build"
         },
         "dependencies": {
-          "next": "8",
+          "next": "9",
           "react": "16",
           "react-dom": "16"
+        },
+        "devDependencies": {
+          "@types/node": "12",
+          "@types/react": "16",
+          "typescript": "3"
         }
       }
     `,
@@ -94,11 +105,16 @@ describe('build meta dev', () => {
       { src: '/', dest: 'http://localhost:5000/' },
       { src: '/nested/page', dest: 'http://localhost:5000/nested/page' },
       { src: '/api/test', dest: 'http://localhost:5000/api/test' },
+      {
+        src: '^/(nested\\/([^\\/]+?)(?:\\/)?)$',
+        dest: 'http://localhost:5000/$1',
+      },
       { src: '/data.txt', dest: 'http://localhost:5000/data.txt' },
     ]);
     expect(watch).toEqual([
       'next.config.js',
       'pages/index.js',
+      'pages/nested/[param].js',
       'pages/nested/page.tsx',
       'pages/api/test.js',
       'public/index',


### PR DESCRIPTION
Fixes [now-cli#2385](https://github.com/zeit/now-cli/issues/2385), [next.js#8017](https://github.com/zeit/next.js/issues/8017) and #722 