### PR TITLE
[now-build-utils] Display link for missing `build` script warning

### DIFF
--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -29,7 +29,7 @@ const MISSING_BUILD_SCRIPT_WARNING: Warning = {
   code: 'missing_build_script',
   message:
     'Your `package.json` file is missing a `build` property inside the `script` property. ' +
-    'More details: <link>',
+    'More details: https://zeit.co/docs/v2/advanced/platform/frequently-asked-questions#missing-build-script',
 };
 
 function hasPublicDirectory(files: string[]) {

--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -28,7 +28,8 @@ const API_BUILDERS: Builder[] = [
 const MISSING_BUILD_SCRIPT_WARNING: Warning = {
   code: 'missing_build_script',
   message:
-    'Your `package.json` file is missing a `build` property inside the `script` property',
+    'Your `package.json` file is missing a `build` property inside the `script` property. ' +
+    'More details: <link>',
 };
 
 function hasPublicDirectory(files: string[]) {


### PR DESCRIPTION
Display a link with the `build` script warning to explain the warning in more detail.