### PR TITLE
[now-node] Add redirect helper function

### DIFF
--- a/packages/now-node/src/helpers.ts
+++ b/packages/now-node/src/helpers.ts
@@ -198,6 +198,26 @@ function json(req: NowRequest, res: NowResponse, jsonBody: any): NowResponse {
   return send(req, res, body);
 }
 
+function redirect(
+  res: NowResponse,
+  statusCode: number,
+  path: string
+): NowResponse {
+  if (typeof statusCode === 'string') {
+    path = statusCode;
+    statusCode = 302;
+    res.statusCode = statusCode;
+    res.setHeader('Location', path);
+    res.end();
+    return res;
+  } else if (typeof statusCode === 'number') {
+    res.statusCode = statusCode;
+    res.setHeader('Location', path);
+    res.end();
+    return res;
+  }
+}
+
 export class ApiError extends Error {
   readonly statusCode: number;
 
@@ -262,6 +282,7 @@ export function createServerWithHelpers(
       res.status = statusCode => status(res, statusCode);
       res.send = body => send(req, res, body);
       res.json = jsonBody => json(req, res, jsonBody);
+      res.redirect = (statusCode, path) => redirect(res, statusCode, path);
 
       await listener(req, res);
     } catch (err) {

--- a/packages/now-node/src/helpers.ts
+++ b/packages/now-node/src/helpers.ts
@@ -210,12 +210,11 @@ function redirect(
     res.setHeader('Location', path);
     res.end();
     return res;
-  } else if (typeof statusCode === 'number') {
-    res.statusCode = statusCode;
-    res.setHeader('Location', path);
-    res.end();
-    return res;
   }
+  res.statusCode = statusCode;
+  res.setHeader('Location', path);
+  res.end();
+  return res;
 }
 
 export class ApiError extends Error {

--- a/packages/now-node/src/types.ts
+++ b/packages/now-node/src/types.ts
@@ -14,4 +14,5 @@ export type NowResponse = ServerResponse & {
   send: (body: any) => NowResponse;
   json: (jsonBody: any) => NowResponse;
   status: (statusCode: number) => NowResponse;
+  redirect: (statusCode: number, path: string) => NowResponse;
 };


### PR DESCRIPTION
This PR focuses on adding a `redirect()` function. The function matches the express API, so there is no confusion at the time the user consumes it 👌 : )

**can be consumed as follows:**

`res.redirect(path);`
or
`res.redirect(statusCode, path);`
