### PR TITLE
[now-node] Fix symlink regression

### DIFF
--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -178,9 +178,12 @@ async function compile(
           source = compileTypeScript(fsPath, source.toString());
         }
         const { mode } = lstatSync(fsPath);
-        if (isSymbolicLink(mode))
-          throw new Error('Internal error: Unexpected symlink.');
-        const entry = new FileBlob({ data: source, mode });
+        let entry: File;
+        if (isSymbolicLink(mode)) {
+          entry = new FileFsRef({ fsPath, mode });
+        } else {
+          entry = new FileBlob({ data: source, mode });
+        }
         fsCache.set(relPath, entry);
         sourceCache.set(relPath, source);
         return source.toString();


### PR DESCRIPTION
Fixes a regression from #765 that was causing 405 Method Not Allowed in some express apps.

The reason why our tests don't catch this is due to a different bug regarding symlink creation (or more likely, symlink upload).