### PR TITLE
[now-build-utils] Use ncc before publishing to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@types/node": "*",
+    "@zeit/ncc": "0.20.4",
     "async-retry": "1.2.3",
     "buffer-replace": "1.0.0",
     "codecov": "3.2.0",

--- a/packages/now-build-utils/build.sh
+++ b/packages/now-build-utils/build.sh
@@ -1,0 +1,6 @@
+tsc
+
+rm dist/index.js
+ncc build src/index.ts -o dist/main
+mv dist/main/index.js dist/index.js
+rm -rf dist/main

--- a/packages/now-build-utils/package.json
+++ b/packages/now-build-utils/package.json
@@ -11,24 +11,11 @@
     "directory": "packages/now-build-utils"
   },
   "scripts": {
-    "build": "tsc",
-    "test": "tsc && jest",
-    "prepublishOnly": "tsc"
+    "build": "./build.sh",
+    "test": "./build.sh && jest",
+    "prepublishOnly": "./build.sh"
   },
-  "dependencies": {
-    "async-retry": "1.2.3",
-    "async-sema": "2.1.4",
-    "cross-spawn": "6.0.5",
-    "end-of-stream": "1.4.1",
-    "fs-extra": "7.0.0",
-    "glob": "7.1.3",
-    "into-stream": "5.0.0",
-    "minimatch": "3.0.4",
-    "multistream": "2.1.1",
-    "node-fetch": "2.2.0",
-    "semver": "6.1.1",
-    "yazl": "2.4.3"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/async-retry": "^1.2.1",
     "@types/cross-spawn": "6.0.0",
@@ -39,7 +26,19 @@
     "@types/node-fetch": "^2.1.6",
     "@types/semver": "6.0.0",
     "@types/yazl": "^2.4.1",
+    "async-retry": "1.2.3",
+    "async-sema": "2.1.4",
+    "cross-spawn": "6.0.5",
+    "end-of-stream": "1.4.1",
     "execa": "^1.0.0",
-    "typescript": "3.5.2"
+    "fs-extra": "7.0.0",
+    "glob": "7.1.3",
+    "into-stream": "5.0.0",
+    "minimatch": "3.0.4",
+    "multistream": "2.1.1",
+    "node-fetch": "2.2.0",
+    "semver": "6.1.1",
+    "typescript": "3.5.2",
+    "yazl": "2.4.3"
   }
 }

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -146,15 +146,18 @@ for (const builder of buildersToTestWith) {
 
   // eslint-disable-next-line no-restricted-syntax
   for (const fixture of fs.readdirSync(fixturesPath2)) {
-    // eslint-disable-next-line no-loop-func
-    it(`should build ${builder}/${fixture}`, async () => {
-      await expect(
-        testDeployment(
-          { builderUrl, buildUtilsUrl },
-          path.join(fixturesPath2, fixture),
-        ),
-      ).resolves.toBeDefined();
-    });
+    // don't run all foreign fixtures, just some
+    if (['01-cowsay', '01-cache-headers', '03-env-vars'].includes(fixture)) {
+      // eslint-disable-next-line no-loop-func
+      it(`should build ${builder}/${fixture}`, async () => {
+        await expect(
+          testDeployment(
+            { builderUrl, buildUtilsUrl },
+            path.join(fixturesPath2, fixture),
+          ),
+        ).resolves.toBeDefined();
+      });
+    }
   }
 }
 

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -135,7 +135,7 @@ for (const fixture of fs.readdirSync(fixturesPath)) {
 
 // few foreign tests
 
-const buildersToTestWith = ['now-node', 'now-static-build'];
+const buildersToTestWith = ['now-next', 'now-node', 'now-static-build'];
 
 // eslint-disable-next-line no-restricted-syntax
 for (const builder of buildersToTestWith) {
@@ -146,18 +146,15 @@ for (const builder of buildersToTestWith) {
 
   // eslint-disable-next-line no-restricted-syntax
   for (const fixture of fs.readdirSync(fixturesPath2)) {
-    // don't run all foreign fixtures, just some
-    if (['01-cowsay', '03-env-vars'].includes(fixture)) {
-      // eslint-disable-next-line no-loop-func
-      it(`should build ${builder}/${fixture}`, async () => {
-        await expect(
-          testDeployment(
-            { builderUrl, buildUtilsUrl },
-            path.join(fixturesPath2, fixture),
-          ),
-        ).resolves.toBeDefined();
-      });
-    }
+    // eslint-disable-next-line no-loop-func
+    it(`should build ${builder}/${fixture}`, async () => {
+      await expect(
+        testDeployment(
+          { builderUrl, buildUtilsUrl },
+          path.join(fixturesPath2, fixture),
+        ),
+      ).resolves.toBeDefined();
+    });
   }
 }
 


### PR DESCRIPTION
Related to #471

This runs ncc on `@now/build-utils` before publishing to npm which reduces install time for production builds.

I also changed the build-utils test suite to run tests fixtures for `@now/next`, `@now/node`, and `@now/static-build`.