### PR TITLE
[now-build-utils] Do not use `canary` for zero config

### DIFF
--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -16,8 +16,8 @@ const BUILDERS = new Map<string, Builder>([
 ]);
 
 const API_BUILDERS: Builder[] = [
-  { src: 'api/**/*.js', use: '@now/node@canary', config },
-  { src: 'api/**/*.ts', use: '@now/node@canary', config },
+  { src: 'api/**/*.js', use: '@now/node', config },
+  { src: 'api/**/*.ts', use: '@now/node', config },
   { src: 'api/**/*.rs', use: '@now/rust', config },
   { src: 'api/**/*.go', use: '@now/go', config },
   { src: 'api/**/*.php', use: '@now/php', config },

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -224,7 +224,7 @@ it('Test `detectBuilders`', async () => {
     // no package.json + no build + raw static + api
     const files = ['api/users.js', 'index.html'];
     const { builders, errors } = await detectBuilders(files);
-    expect(builders[0].use).toBe('@now/node@canary');
+    expect(builders[0].use).toBe('@now/node');
     expect(builders[0].src).toBe('api/users.js');
     expect(builders[1].use).toBe('@now/static');
     expect(builders[1].src).toBe('index.html');
@@ -236,7 +236,7 @@ it('Test `detectBuilders`', async () => {
     // package.json + no build + root + api
     const files = ['index.html', 'api/[endpoint].js', 'static/image.png'];
     const { builders, errors } = await detectBuilders(files);
-    expect(builders[0].use).toBe('@now/node@canary');
+    expect(builders[0].use).toBe('@now/node');
     expect(builders[0].src).toBe('api/[endpoint].js');
     expect(builders[1].use).toBe('@now/static');
     expect(builders[1].src).toBe('index.html');
@@ -255,7 +255,7 @@ it('Test `detectBuilders`', async () => {
     ];
 
     const { builders } = await detectBuilders(files);
-    expect(builders[0].use).toBe('@now/node@canary');
+    expect(builders[0].use).toBe('@now/node');
     expect(builders[0].src).toBe('api/[endpoint]/[id].js');
     expect(builders.length).toBe(1);
   }
@@ -269,7 +269,7 @@ it('Test `detectBuilders`', async () => {
     const files = ['package.json', 'api/endpoint.js', 'public/index.html'];
 
     const { builders } = await detectBuilders(files, pkg);
-    expect(builders[0].use).toBe('@now/node@canary');
+    expect(builders[0].use).toBe('@now/node');
     expect(builders[0].src).toBe('api/endpoint.js');
     expect(builders[1].use).toBe('@now/next');
     expect(builders[1].src).toBe('package.json');
@@ -285,7 +285,7 @@ it('Test `detectBuilders`', async () => {
     const files = ['package.json', 'api/endpoint.js', 'index.html'];
 
     const { builders } = await detectBuilders(files, pkg);
-    expect(builders[0].use).toBe('@now/node@canary');
+    expect(builders[0].use).toBe('@now/node');
     expect(builders[0].src).toBe('api/endpoint.js');
     expect(builders[1].use).toBe('@now/next');
     expect(builders[1].src).toBe('package.json');
@@ -297,7 +297,7 @@ it('Test `detectBuilders`', async () => {
     const files = ['api/endpoint.js', 'index.html', 'favicon.ico'];
 
     const { builders } = await detectBuilders(files);
-    expect(builders[0].use).toBe('@now/node@canary');
+    expect(builders[0].use).toBe('@now/node');
     expect(builders[0].src).toBe('api/endpoint.js');
     expect(builders[1].use).toBe('@now/static');
     expect(builders[1].src).toBe('favicon.ico');
@@ -316,7 +316,7 @@ it('Test `detectBuilders`', async () => {
     ];
 
     const { builders } = await detectBuilders(files);
-    expect(builders[0].use).toBe('@now/node@canary');
+    expect(builders[0].use).toBe('@now/node');
     expect(builders[0].src).toBe('api/endpoint.js');
     expect(builders[1].use).toBe('@now/static');
     expect(builders[1].src).toBe('public/**/*');
@@ -366,7 +366,7 @@ it('Test `detectBuilders`', async () => {
     const files = ['package.json', 'api/[endpoint].js'];
 
     const { builders } = await detectBuilders(files, pkg);
-    expect(builders[0].use).toBe('@now/node@canary');
+    expect(builders[0].use).toBe('@now/node');
     expect(builders[0].src).toBe('api/[endpoint].js');
     expect(builders.length).toBe(1);
   }


### PR DESCRIPTION
We don't want to use canary builders for zero config.

Fixes #816