### PR TITLE
[now-node] Fix `18-nested-tsconfig` tests

### DIFF
--- a/packages/now-node/test/fixtures/18-nested-tsconfig/functions/double-redirect.ts
+++ b/packages/now-node/test/fixtures/18-nested-tsconfig/functions/double-redirect.ts
@@ -3,13 +3,15 @@ import { parse } from 'url';
 
 const func = (req: IncomingMessage, res: ServerResponse) => {
   if (req.url) {
-    const url = parse(req.url);
+    const { pathname, search } = parse(req.url);
+    const location = pathname
+      ? pathname.replace(/\/+/g, '/') + (search ? search : '')
+      : '/';
+    /*
     res.writeHead(302, {
-      Location: url.pathname
-        ? url.pathname.replace(/\/+/g, '/') + (url.search ? url.search : '')
-        : '/',
-    });
-    res.end();
+      Location: location
+    });*/
+    res.end(`double-redirect:RANDOMNESS_PLACEHOLDER:${location}`);
   }
 };
 

--- a/packages/now-node/test/fixtures/18-nested-tsconfig/now.json
+++ b/packages/now-node/test/fixtures/18-nested-tsconfig/now.json
@@ -30,6 +30,10 @@
     },
     {
       "path": "//",
+      "mustContain": "double-redirect:RANDOMNESS_PLACEHOLDER"
+    },
+    {
+      "path": "/pricing/",
       "mustContain": "trailing-redirect:RANDOMNESS_PLACEHOLDER"
     }
   ]

--- a/packages/now-node/test/fixtures/18-nested-tsconfig/now.json
+++ b/packages/now-node/test/fixtures/18-nested-tsconfig/now.json
@@ -29,10 +29,6 @@
       "mustContain": "root:RANDOMNESS_PLACEHOLDER"
     },
     {
-      "path": "//",
-      "mustContain": "double-redirect:RANDOMNESS_PLACEHOLDER"
-    },
-    {
       "path": "/pricing/",
       "mustContain": "trailing-redirect:RANDOMNESS_PLACEHOLDER"
     }


### PR DESCRIPTION
Since `now-proxy` changed, these tests started failing with

```
Error: Fetched page https://test-lauxkjuiu.now.sh// does not contain trailing-redirect:3ed9f90b3ed9f90b3ed9f9. Instead it contains root:3ed9f90b3ed9f90b3ed9f9
```

<img src="https://user-images.githubusercontent.com/229881/61913999-f36d3680-af0c-11e9-92b8-96299575f1d2.png" width="400" />

This fixes the tests so we are checking the correct thing.
