### PR TITLE
[now-next] Use ncc before publishing to npm

### DIFF
--- a/packages/now-next/.gitignore
+++ b/packages/now-next/.gitignore
@@ -1,2 +1,2 @@
 /dist
-/src/now__bridge.d.ts
+/src/now__bridge.ts

--- a/packages/now-next/build.sh
+++ b/packages/now-next/build.sh
@@ -4,3 +4,5 @@ set -euo pipefail
 bridge_defs="$(dirname $(pwd))/now-node-bridge/src/bridge.ts"
 
 cp -v "$bridge_defs" src/now__bridge.ts
+
+tsc

--- a/packages/now-next/build.sh
+++ b/packages/now-next/build.sh
@@ -6,3 +6,7 @@ bridge_defs="$(dirname $(pwd))/now-node-bridge/src/bridge.ts"
 cp -v "$bridge_defs" src/now__bridge.ts
 
 tsc
+
+ncc build src/index.ts -o dist/main
+mv dist/main/index.js dist/index.js
+rm -rf dist/main

--- a/packages/now-next/getBridgeTypes.sh
+++ b/packages/now-next/getBridgeTypes.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-bridge_entrypoint="$(node -p 'require.resolve("@now/node-bridge")')"
-bridge_defs="$(dirname "$bridge_entrypoint")/bridge.d.ts"
+bridge_defs="$(dirname $(pwd))/now-node-bridge/src/bridge.ts"
 
-if [ ! -e "$bridge_defs" ]; then
-  yarn install --cwd "$bridge_entrypoint"
-fi
-
-cp -v "$bridge_defs" src/now__bridge.d.ts
+cp -v "$bridge_defs" src/now__bridge.ts

--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -15,7 +15,6 @@
     "directory": "packages/now-next"
   },
   "dependencies": {
-    "@now/node-bridge": "1.2.2",
     "fs-extra": "^7.0.0",
     "get-port": "^5.0.0",
     "resolve-from": "^5.0.0",

--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -5,9 +5,9 @@
   "main": "./dist/index",
   "homepage": "https://zeit.co/docs/v2/deployments/official-builders/next-js-now-next",
   "scripts": {
-    "build": "./getBridgeTypes.sh && tsc",
-    "test": "npm run build && jest",
-    "prepublish": "yarn run build"
+    "build": "./build.sh",
+    "test": "./build.sh && jest",
+    "prepublishOnly": "./build.sh"
   },
   "repository": {
     "type": "git",

--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -14,19 +14,18 @@
     "url": "https://github.com/zeit/now-builders.git",
     "directory": "packages/now-next"
   },
-  "dependencies": {
-    "fs-extra": "^7.0.0",
-    "get-port": "^5.0.0",
-    "resolve-from": "^5.0.0",
-    "semver": "^5.6.0"
-  },
+  "dependencies": {},
   "files": [
     "dist"
   ],
   "devDependencies": {
-    "@types/next-server": "^8.0.0",
-    "@types/resolve-from": "^5.0.1",
-    "@types/semver": "^6.0.0",
+    "@types/next-server": "8.0.0",
+    "@types/resolve-from": "5.0.1",
+    "@types/semver": "6.0.0",
+    "fs-extra": "7.0.0",
+    "get-port": "5.0.0",
+    "resolve-from": "5.0.0",
+    "semver": "6.1.1",
     "typescript": "3.5.2"
   }
 }

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -331,7 +331,7 @@ export const build = async ({
     );
     const launcherFiles = {
       'now__bridge.js': new FileFsRef({
-        fsPath: require('@now/node-bridge'),
+        fsPath: path.join(__dirname, 'now__bridge.js'),
       }),
     };
     const nextFiles: { [key: string]: FileFsRef } = {
@@ -395,7 +395,7 @@ export const build = async ({
     console.log('preparing lambda files...');
     const launcherFiles = {
       'now__bridge.js': new FileFsRef({
-        fsPath: require('@now/node-bridge'),
+        fsPath: path.join(__dirname, 'now__bridge.js'),
       }),
       'now__launcher.js': new FileFsRef({
         fsPath: path.join(__dirname, 'launcher.js'),

--- a/packages/now-next/src/launcher.ts
+++ b/packages/now-next/src/launcher.ts
@@ -3,8 +3,8 @@ if (!process.env.NODE_ENV) {
     process.env.NOW_REGION === 'dev1' ? 'development' : 'production';
 }
 
-const { Server } = require('http');
-const { Bridge } = require('./now__bridge');
+import { Server } from 'http';
+import { Bridge } from './now__bridge';
 const page = require('./page');
 
 // page.render is for React rendering

--- a/packages/now-next/test/unit/utils.test.js
+++ b/packages/now-next/test/unit/utils.test.js
@@ -6,7 +6,7 @@ const {
   normalizePackageJson,
   getNextConfig,
 } = require('@now/next/dist/utils');
-const FileRef = require('@now/build-utils/file-ref'); // eslint-disable-line import/no-extraneous-dependencies
+const { FileRef } = require('@now/build-utils'); // eslint-disable-line import/no-extraneous-dependencies
 
 describe('getNextConfig', () => {
   const workPath = path.join(__dirname, 'fixtures');

--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -52,6 +52,7 @@ async function nowDeploy (bodies, randomness) {
   }
 
   console.log('id', deploymentId);
+  console.log('deploymentUrl', `https://${deploymentUrl}`);
 
   for (let i = 0; i < 750; i += 1) {
     const { state } = await deploymentGet(deploymentId);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1364,27 +1364,16 @@
   dependencies:
     "@types/node" "*"
 
-"@types/next-server@*", "@types/next-server@^8.0.0":
-  version "8.1.2"
-  resolved "https://registry.yarnpkg.com/@types/next-server/-/next-server-8.1.2.tgz#64c64c74ff9975338447ea0174ca430165895bab"
-  integrity sha512-Fm4QhAxwDlC9AHiGy23Lhv7DeTTt1O1s7tnAsyVOLPjePmYXPZVbOCrxd2oRHZnIIYWw41JelLbq4hN1B5idlQ==
+"@types/next-server@8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@types/next-server/-/next-server-8.0.0.tgz#255ed9b0cf5a518b0137dd6a72a4f9aeddbbeb7d"
+  integrity sha512-TYWT510LScQJU6ACRqcnnK1IBdeZsXCOGgMvZrAgghQ6TXD1xE92qdTHh051WtXrcm9OjisZhI0Jx3i9PU3IuA==
   dependencies:
-    "@types/next" "*"
     "@types/node" "*"
     "@types/react" "*"
     "@types/react-loadable" "*"
 
-"@types/next@*":
-  version "8.0.6"
-  resolved "https://registry.yarnpkg.com/@types/next/-/next-8.0.6.tgz#e4ceb01069b82bfe20d98bb3ba2cb65eb5c77bdd"
-  integrity sha512-NEPE5PpZ0atyX08I5B06A94OaygoZkLyv4zsZ9OkxbaCe9tIbIYzNWIievY36zXtOFL44JS/MArUuVdAUK9kCQ==
-  dependencies:
-    "@types/next-server" "*"
-    "@types/node" "*"
-    "@types/node-fetch" "*"
-    "@types/react" "*"
-
-"@types/node-fetch@*", "@types/node-fetch@^2.1.6", "@types/node-fetch@^2.3.0":
+"@types/node-fetch@^2.1.6", "@types/node-fetch@^2.3.0":
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.3.7.tgz#b7212e895100f8642dbdab698472bab5f3c1d2f1"
   integrity sha512-+bKtuxhj/TYSSP1r4CZhfmyA0vm/aDRQNo7vbAgf6/cZajn0SAniGGST07yvI4Q+q169WTa2/x9gEHfJrkcALw==
@@ -1422,7 +1411,7 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
-"@types/resolve-from@^5.0.1":
+"@types/resolve-from@5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@types/resolve-from/-/resolve-from-5.0.1.tgz#2714eaa840c0472dcfa96ec3fb9d170dbf0b677d"
   integrity sha512-1G7n5Jtr5inoS1Ez2Y9Efedk9/wH6uGQslbfhGTOw9J42PCAwuyaDgQHW7fIq02+shwB02kM/w31W8gMxI8ORg==
@@ -1438,11 +1427,6 @@
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.0.0.tgz#86ba89f02a414e39c68d02b351872e4ed31bd773"
   integrity sha512-OO0srjOGH99a4LUN2its3+r6CBYcplhJ466yLqs+zvAWgphCpS8hYZEZ797tRDP/QKcqTdb/YCN6ifASoAWkrQ==
-
-"@types/semver@^6.0.0":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.0.1.tgz#a984b405c702fa5a7ec6abc56b37f2ba35ef5af6"
-  integrity sha512-ffCdcrEE5h8DqVxinQjo+2d1q+FV5z7iNtPofw3JsrltSoSVlOGaW0rY8XxtO9XukdTn8TaCGWmk2VFGhI70mg==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -1477,9 +1461,9 @@
     source-map "^0.6.1"
 
 "@types/webpack@*":
-  version "4.4.35"
-  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.4.35.tgz#b7088eb2d471d5645e5503d272783cafa753583b"
-  integrity sha512-kf+mn/+CB4HsFb+Rz0QBRlo8nNC9LFhwqeK5xxhd3FEPRWJv6MFVnljKV5ARac56+syO8vIhq+nGt860+3wx7A==
+  version "4.32.1"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.32.1.tgz#6e95010e806f808abd6551c112097ac09035aacf"
+  integrity sha512-9n38CBx9uga1FEAdTipnt0EkbKpsCJFh7xJb1LE65FFb/A6OOLFX022vYsGC1IyVCZ/GroNg9u/RMmlDxGcLIw==
   dependencies:
     "@types/anymatch" "*"
     "@types/node" "*"
@@ -3546,7 +3530,7 @@ get-pkg-repo@^1.0.0:
     parse-github-repo-url "^1.3.0"
     through2 "^2.0.0"
 
-get-port@5.0.0, get-port@^5.0.0:
+get-port@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.0.0.tgz#aa22b6b86fd926dd7884de3e23332c9f70c031a6"
   integrity sha512-imzMU0FjsZqNa6BqOjbbW6w5BivHIuQKopjpPqcnx0AVHJQKCxK1O+Ab3OrVXhrekqfVMjwA9ZYu062R+KcIsQ==
@@ -6665,7 +6649,7 @@ resolve-cwd@^2.0.0:
   dependencies:
     resolve-from "^3.0.0"
 
-resolve-from@*, resolve-from@^5.0.0:
+resolve-from@*, resolve-from@5.0.0, resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1135,11 +1135,6 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@now/node-bridge@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@now/node-bridge/-/node-bridge-1.2.2.tgz#b4740d8806227b8dd1d4d8481e21b3b30ad299b4"
-  integrity sha512-E5xqal3QRN8RvcQ4Q82vtg/hvWmQWaIYp2bJHd550Ps/kemGabcwAAQsP/TUM/4b5oYlOmjrfuYPq9AhMvFqkQ==
-
 "@now/php-bridge@^0.5.3":
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/@now/php-bridge/-/php-bridge-0.5.3.tgz#fe8cc02af247b323979347ebbb7090b547938694"


### PR DESCRIPTION
Related to #471

The changes:

- Copy `bridge.ts` source code, not just types (necessary to satisfy ncc)
- Remove dependency on `@now/node-bridge` (because previous step covers that)
- Move `dependencies` to `devDependencies` and pin them
- Change `prepublish` to `prepublishOnly` to avoid running during `yarn install`
- Run ncc on builder source code