### PR TITLE
[WIP] [now-go] Use `debug()` from build-utils

### DIFF
--- a/packages/now-go/go-helpers.ts
+++ b/packages/now-go/go-helpers.ts
@@ -4,9 +4,8 @@ import fetch from 'node-fetch';
 import { mkdirp, pathExists } from 'fs-extra';
 import { dirname, join } from 'path';
 import { homedir } from 'os';
-import Debug from 'debug';
+import { debug } from '@now/build-utils';
 
-const debug = Debug('@now/go:go-helpers');
 const archMap = new Map([['x64', 'amd64'], ['x86', '386']]);
 const platformMap = new Map([['win32', 'windows']]);
 
@@ -148,7 +147,6 @@ export async function downloadGo(
       );
       const url = getGoUrl(version, platform, arch);
       debug('Downloading `go` URL: %o', url);
-      console.log('Downloading Go ...');
       const res = await fetch(url);
 
       if (!res.ok) {

--- a/packages/now-go/go-helpers.ts
+++ b/packages/now-go/go-helpers.ts
@@ -67,7 +67,7 @@ class GoWrapper {
   private execute(...args: string[]) {
     const { opts, env } = this;
     debug('Exec %o', `go ${args.join(' ')}`);
-    return execa('go', args, { stdio: 'inherit', ...opts, env });
+    return execa('go', args, { stdio: 'pipe', ...opts, env });
   }
 
   mod() {

--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -11,6 +11,7 @@ import {
   BuildOptions,
   shouldServe,
   Files,
+  debug,
 } from '@now/build-utils';
 
 import { createGo, getAnalyzedEntrypoint } from './go-helpers';
@@ -53,12 +54,12 @@ export async function build({
   meta = {} as BuildParamsMeta,
 }: BuildParamsType) {
   if (process.env.GIT_CREDENTIALS && !meta.isDev) {
-    console.log('Initialize Git credentials...');
+    debug('Initialize Git credentials...');
     await initPrivateGit(process.env.GIT_CREDENTIALS);
   }
 
   if (process.env.GO111MODULE) {
-    console.log(`\nManually assigning 'GO111MODULE' is not recommended.
+    debug(`\nManually assigning 'GO111MODULE' is not recommended.
 
 By default:
   - 'GO111MODULE=on' If entrypoint package name is not 'main'
@@ -69,7 +70,7 @@ Learn more: https://github.com/golang/go/wiki/Modules
 `);
   }
 
-  console.log('Downloading user files...');
+  debug('Downloading user files...');
   const entrypointArr = entrypoint.split(sep);
 
   let [goPath, outDir] = await Promise.all([
@@ -85,7 +86,7 @@ Learn more: https://github.com/golang/go/wiki/Modules
     downloadedFiles = await download(files, srcPath);
   }
 
-  console.log(`Parsing AST for "${entrypoint}"`);
+  debug(`Parsing AST for "${entrypoint}"`);
   let analyzed: string;
   try {
     let goModAbsPathDir = '';
@@ -99,7 +100,7 @@ Learn more: https://github.com/golang/go/wiki/Modules
       goModAbsPathDir
     );
   } catch (err) {
-    console.log(`Failed to parse AST for "${entrypoint}"`);
+    debug(`Failed to parse AST for "${entrypoint}"`);
     throw err;
   }
 
@@ -109,7 +110,7 @@ Learn more: https://github.com/golang/go/wiki/Modules
 Learn more: https://zeit.co/docs/v2/deployments/official-builders/go-now-go/#entrypoint
       `
     );
-    console.log(err.message);
+    debug(err.message);
     throw err;
   }
 
@@ -172,9 +173,7 @@ Learn more: https://zeit.co/docs/v2/deployments/official-builders/go-now-go/#ent
   }
 
   const handlerFunctionName = parsedAnalyzed.functionName;
-  console.log(
-    `Found exported function "${handlerFunctionName}" in "${entrypoint}"`
-  );
+  debug(`Found exported function "${handlerFunctionName}" in "${entrypoint}"`);
 
   if (!isGoModExist && 'vendor' in downloadedFiles) {
     throw new Error('`go.mod` is required to use a `vendor` directory.');
@@ -204,7 +203,7 @@ Learn more: https://zeit.co/docs/v2/deployments/official-builders/go-now-go/#ent
 
         await writeFile(join(entrypointDirname, 'go.mod'), defaultGoModContent);
       } catch (err) {
-        console.log(`failed to create default go.mod for ${packageName}`);
+        debug(`failed to create default go.mod for ${packageName}`);
         throw err;
       }
     }
@@ -281,7 +280,7 @@ Learn more: https://zeit.co/docs/v2/deployments/official-builders/go-now-go/#ent
         });
       }
     } catch (err) {
-      console.log('failed to move entry to package folder');
+      debug('failed to move entry to package folder');
       throw err;
     }
 
@@ -312,16 +311,16 @@ Learn more: https://zeit.co/docs/v2/deployments/official-builders/go-now-go/#ent
       }
     }
 
-    console.log('Tidy `go.mod` file...');
+    debug('Tidy `go.mod` file...');
     try {
       // ensure go.mod up-to-date
       await go.mod();
     } catch (err) {
-      console.log('failed to `go mod tidy`');
+      debug('failed to `go mod tidy`');
       throw err;
     }
 
-    console.log('Running `go build`...');
+    debug('Running `go build`...');
     const destPath = join(outDir, 'handler');
 
     try {
@@ -329,7 +328,7 @@ Learn more: https://zeit.co/docs/v2/deployments/official-builders/go-now-go/#ent
 
       await go.build(src, destPath, config.ldsflags);
     } catch (err) {
-      console.log('failed to `go build`');
+      debug('failed to `go build`');
       throw err;
     }
     if (meta.isDev) {
@@ -377,15 +376,15 @@ Learn more: https://zeit.co/docs/v2/deployments/official-builders/go-now-go/#ent
 
     // `go get` will look at `*.go` (note we set `cwd`), parse the `import`s
     // and download any packages that aren't part of the stdlib
-    console.log('Running `go get`...');
+    debug('Running `go get`...');
     try {
       await go.get();
     } catch (err) {
-      console.log('failed to `go get`');
+      debug('failed to `go get`');
       throw err;
     }
 
-    console.log('Running `go build`...');
+    debug('Running `go build`...');
     const destPath = join(outDir, 'handler');
     try {
       const src = [
@@ -394,7 +393,7 @@ Learn more: https://zeit.co/docs/v2/deployments/official-builders/go-now-go/#ent
       ];
       await go.build(src, destPath);
     } catch (err) {
-      console.log('failed to `go build`');
+      debug('failed to `go build`');
       throw err;
     }
   }

--- a/packages/now-go/package.json
+++ b/packages/now-go/package.json
@@ -20,14 +20,12 @@
     "util"
   ],
   "dependencies": {
-    "debug": "^4.1.1",
     "execa": "^1.0.0",
     "fs-extra": "^7.0.0",
     "node-fetch": "^2.2.1",
     "tar": "4.4.6"
   },
   "devDependencies": {
-    "@types/debug": "^4.1.3",
     "@types/execa": "^0.9.0",
     "@types/fs-extra": "^5.0.5",
     "@types/node-fetch": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1276,11 +1276,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/debug@^4.1.3":
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.4.tgz#56eec47706f0fd0b7c694eae2f3172e6b0b769da"
-  integrity sha512-D9MyoQFI7iP5VdpEyPZyjjqIJ8Y8EDNQFIFVLOmeg1rI1xiHOChyUPMPRUVfqFCerxfE+yS3vMyj37F6IdtOoQ==
-
 "@types/end-of-stream@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@types/end-of-stream/-/end-of-stream-1.4.0.tgz#4e73ac87d15b6cc89cdaf2d26a59f617c778cb07"


### PR DESCRIPTION
This PR use `debug()` from `build-utils` to handle all the output.