### PR TITLE
[now-static-build] Allow setting the `tag` for zero-config builders

### DIFF
--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -22,12 +22,9 @@ const BUILDERS = new Map<string, Builder>([
 const API_BUILDERS: Builder[] = [
   { src: 'api/**/*.js', use: '@now/node', config },
   { src: 'api/**/*.ts', use: '@now/node', config },
-  { src: 'api/**/*.rs', use: '@now/rust', config },
   { src: 'api/**/*.go', use: '@now/go', config },
-  { src: 'api/**/*.php', use: '@now/php', config },
   { src: 'api/**/*.py', use: '@now/python', config },
   { src: 'api/**/*.rb', use: '@now/ruby', config },
-  { src: 'api/**/*.sh', use: '@now/bash', config },
 ];
 
 const MISSING_BUILD_SCRIPT_ERROR: ErrorResponse = {

--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -155,7 +155,7 @@ export async function detectBuilders(
       builders = builders.map((builder: Builder) => {
         // @now/static has no canary builder
         if (builder.use !== '@now/static') {
-          builder.use === `${builder.use}@${tag}`;
+          builder.use = `${builder.use}@${tag}`;
         }
 
         return builder;

--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -6,6 +6,10 @@ interface ErrorResponse {
   message: string;
 }
 
+interface Options {
+  tag?: 'canary' | 'latest';
+}
+
 const src: string = 'package.json';
 const config: Config = { zeroConfig: true };
 
@@ -101,7 +105,8 @@ async function detectApiBuilders(files: string[]): Promise<Builder[]> {
 // to determine what builders to use
 export async function detectBuilders(
   files: string[],
-  pkg?: PackageJson | undefined | null
+  pkg?: PackageJson | undefined | null,
+  options?: Options
 ): Promise<{
   builders: Builder[] | null;
   errors: ErrorResponse[] | null;
@@ -109,7 +114,7 @@ export async function detectBuilders(
   const errors: ErrorResponse[] = [];
 
   // Detect all builders for the `api` directory before anything else
-  const builders = await detectApiBuilders(files);
+  let builders = await detectApiBuilders(files);
 
   if (pkg && hasBuildScript(pkg)) {
     builders.push(await detectBuilder(pkg));
@@ -142,6 +147,22 @@ export async function detectBuilders(
             config,
           }))
       );
+    }
+  }
+
+  // Change the tag for the builders
+  if (builders && builders.length) {
+    const tag = options && options.tag;
+
+    if (tag) {
+      builders = builders.map((builder: Builder) => {
+        // @now/static has no canary builder
+        if (builder.use !== '@now/static') {
+          builder.use === `${builder.use}@${tag}`;
+        }
+
+        return builder;
+      });
     }
   }
 

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -397,6 +397,25 @@ it('Test `detectBuilders`', async () => {
     expect(builders).toBe(null);
     expect(errors).toBe(null);
   }
+
+  {
+    // package.json + api + canary
+    const pkg = {
+      scripts: { build: 'next build' },
+      dependencies: { next: '9.0.0' },
+    };
+    const files = [
+      'pages/index.js',
+      'api/[endpoint].js',
+      'api/[endpoint]/[id].js',
+    ];
+
+    const { builders } = await detectBuilders(files, pkg, { tag: 'canary' });
+    expect(builders[0].use).toBe('@now/node@canary');
+    expect(builders[1].use).toBe('@now/node@canary');
+    expect(builders[2].use).toBe('@now/next@canary');
+    expect(builders.length).toBe(3);
+  }
 });
 
 it('Test `detectRoutes`', async () => {


### PR DESCRIPTION
We want to be able to set the version tag (`canary` or `latest`) for zero-config.

This further removes builders that we don't want to include for zero-config by default.