### PR TITLE
[now-next] add `resolve-from` to dependencies

### DIFF
--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -17,13 +17,15 @@
   "files": [
     "dist"
   ],
+  "dependencies": {
+    "resolve-from": "5.0.0"
+  },
   "devDependencies": {
     "@types/next-server": "8.0.0",
     "@types/resolve-from": "5.0.1",
     "@types/semver": "6.0.0",
     "fs-extra": "7.0.0",
     "get-port": "5.0.0",
-    "resolve-from": "5.0.0",
     "semver": "6.1.1",
     "typescript": "3.5.2"
   }


### PR DESCRIPTION
When using @now/next 0.5.7 in `now dev` resolve-from is missing and building gets stuck

Error:

```
internal/modules/cjs/loader.js:583
    throw err;
    ^

Error: Cannot find module 'resolve-from'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
    at Function.Module._load (internal/modules/cjs/loader.js:507:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:22:18)
    at Object.<anonymous> (/Users/nikgraf/Library/Caches/co.zeit.now/dev/builders/node_modules/@now/next/dist/dev-server.js:6:40)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
```