### PR TITLE
[now-build-utils] Fix require file path for legacy builders

### DIFF
--- a/packages/now-build-utils/fs/download.js
+++ b/packages/now-build-utils/fs/download.js
@@ -1,1 +1,1 @@
-module.exports = require('../dist/fs/download').default;
+module.exports = require('../dist/index').download;

--- a/packages/now-build-utils/fs/get-writable-directory.js
+++ b/packages/now-build-utils/fs/get-writable-directory.js
@@ -1,1 +1,1 @@
-module.exports = require('../dist/fs/get-writable-directory').default;
+module.exports = require('../dist/index').getWriteableDirectory;

--- a/packages/now-build-utils/fs/glob.js
+++ b/packages/now-build-utils/fs/glob.js
@@ -1,1 +1,1 @@
-module.exports = require('../dist/fs/glob').default;
+module.exports = require('../dist/index').glob;

--- a/packages/now-build-utils/fs/rename.js
+++ b/packages/now-build-utils/fs/rename.js
@@ -1,1 +1,1 @@
-module.exports = require('../dist/fs/rename').default;
+module.exports = require('../dist/index').rename;

--- a/packages/now-build-utils/fs/run-user-scripts.js
+++ b/packages/now-build-utils/fs/run-user-scripts.js
@@ -1,1 +1,1 @@
-module.exports = require('../dist/fs/run-user-scripts');
+module.exports = require('../dist/index');

--- a/packages/now-build-utils/fs/stream-to-buffer.js
+++ b/packages/now-build-utils/fs/stream-to-buffer.js
@@ -1,1 +1,1 @@
-module.exports = require('../dist/fs/stream-to-buffer').default;
+module.exports = require('../dist/index').streamToBuffer;

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -116,12 +116,34 @@ it('should match all semver ranges', () => {
   );
 });
 
-it('should support require by path', () => {
-  // This is necessary to support legacy/community builders
-  const { Lambda } = require('@now/build-utils/lambda.js');
-  const streamToBuffer = require('@now/build-utils/fs/stream-to-buffer.js');
-  expect(Lambda).toBe(require('@now/build-utils').Lambda);
-  expect(streamToBuffer).toBe(require('@now/build-utils').streamToBuffer);
+it('should support require by path for legacy builders', () => {
+  const index = require('@now/build-utils');
+
+  const download2 = require('@now/build-utils/fs/download.js');
+  const getWriteableDirectory2 = require('@now/build-utils/fs/get-writable-directory.js');
+  const glob2 = require('@now/build-utils/fs/glob.js');
+  const rename2 = require('@now/build-utils/fs/rename.js');
+  const {
+    runNpmInstall: runNpmInstall2,
+  } = require('@now/build-utils/fs/run-user-scripts.js');
+  const streamToBuffer2 = require('@now/build-utils/fs/stream-to-buffer.js');
+
+  const FileBlob2 = require('@now/build-utils/file-blob.js');
+  const FileFsRef2 = require('@now/build-utils/file-fs-ref.js');
+  const FileRef2 = require('@now/build-utils/file-ref.js');
+  const { Lambda: Lambda2 } = require('@now/build-utils/lambda.js');
+
+  expect(download2).toBe(index.download);
+  expect(getWriteableDirectory2).toBe(index.getWriteableDirectory);
+  expect(glob2).toBe(index.glob);
+  expect(rename2).toBe(index.rename);
+  expect(runNpmInstall2).toBe(index.runNpmInstall);
+  expect(streamToBuffer2).toBe(index.streamToBuffer);
+
+  expect(FileBlob2).toBe(index.FileBlob);
+  expect(FileFsRef2).toBe(index.FileFsRef);
+  expect(FileRef2).toBe(index.FileRef);
+  expect(Lambda2).toBe(index.Lambda);
 });
 
 // own fixtures

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -116,6 +116,14 @@ it('should match all semver ranges', () => {
   );
 });
 
+it('should support require by path', () => {
+  // This is necessary to support legacy/community builders
+  const { Lambda } = require('@now/build-utils/lambda.js');
+  const streamToBuffer = require('@now/build-utils/fs/stream-to-buffer.js');
+  expect(Lambda).toBe(require('@now/build-utils').Lambda);
+  expect(streamToBuffer).toBe(require('@now/build-utils').streamToBuffer);
+});
+
 // own fixtures
 
 const fixturesPath = path.resolve(__dirname, 'fixtures');


### PR DESCRIPTION
This fixes a regression from #820 affecting `@now/lambda` and other legacy builders that expect to be able to require a specific path.