### PR TITLE
[now-next] Fix dev-server bundle output

### DIFF
--- a/packages/now-next/build.sh
+++ b/packages/now-next/build.sh
@@ -5,7 +5,9 @@ bridge_defs="$(dirname $(pwd))/now-node-bridge/src/bridge.ts"
 
 cp -v "$bridge_defs" src/now__bridge.ts
 
-tsc
+ncc build src/dev-server.ts -o dist/dev
+mv dist/dev/index.js dist/dev-server.js
+rm -rf dist/dev
 
 ncc build src/index.ts -o dist/main
 mv dist/main/index.js dist/index.js

--- a/packages/now-next/build.sh
+++ b/packages/now-next/build.sh
@@ -5,6 +5,8 @@ bridge_defs="$(dirname $(pwd))/now-node-bridge/src/bridge.ts"
 
 cp -v "$bridge_defs" src/now__bridge.ts
 
+tsc
+
 ncc build src/dev-server.ts -o dist/dev
 mv dist/dev/index.js dist/dev-server.js
 rm -rf dist/dev

--- a/packages/now-next/test/unit/export.test.js
+++ b/packages/now-next/test/unit/export.test.js
@@ -1,0 +1,13 @@
+describe('export', () => {
+  it('should require by path main', async () => {
+    const main = require('@now/next');
+    expect(main).toBeDefined();
+  });
+
+  it('should require by path dev-server relative to index', async () => {
+    const index = require('@now/next/dist/index.js');
+    const server = require('@now/next/dist/dev-server.js');
+    expect(index).toBeDefined();
+    expect(server).toBeDefined();
+  });
+});


### PR DESCRIPTION
Fixes #845

Since `index.js` uses `child_process.fork()` to start the `dev-server.js` file, the dev server also needs to be its own bundle.

This regression was introduced in #832