### PR TITLE
[now-build-utils] Remove `@now/nuxt` from default builders

### DIFF
--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -16,7 +16,6 @@ const config: Config = { zeroConfig: true };
 // Static builders are special cased in `@now/static-build`
 const BUILDERS = new Map<string, Builder>([
   ['next', { src, use: '@now/next', config }],
-  ['nuxt', { src, use: '@now/nuxt', config }],
 ]);
 
 const API_BUILDERS: Builder[] = [

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -385,7 +385,7 @@ it('Test `detectBuilders`', async () => {
     const files = ['package.json', 'pages/index.js'];
 
     const { builders } = await detectBuilders(files, pkg);
-    expect(builders[0].use).toBe('@now/nuxt');
+    expect(builders[0].use).toBe('@now/static-build');
     expect(builders[0].src).toBe('package.json');
     expect(builders.length).toBe(1);
   }


### PR DESCRIPTION
 Remove `@now/nuxt` from zero-config default builders