### PR TITLE
[WIP] [now-php] [now-cgi] Use `debug()` from build-utils

### DIFF
--- a/packages/now-cgi/index.js
+++ b/packages/now-cgi/index.js
@@ -5,14 +5,14 @@ const glob = require('@now/build-utils/fs/glob'); // eslint-disable-line import/
 const download = require('@now/build-utils/fs/download'); // eslint-disable-line import/no-extraneous-dependencies
 const { createLambda } = require('@now/build-utils/lambda'); // eslint-disable-line import/no-extraneous-dependencies
 const getWritableDirectory = require('@now/build-utils/fs/get-writable-directory'); // eslint-disable-line import/no-extraneous-dependencies
-const { shouldServe } = require('@now/build-utils'); // eslint-disable-line import/no-extraneous-dependencies
+const { shouldServe, debug } = require('@now/build-utils'); // eslint-disable-line import/no-extraneous-dependencies
 
 exports.analyze = ({ files, entrypoint }) => files[entrypoint].digest;
 
 exports.build = async ({
   workPath, files, entrypoint, meta,
 }) => {
-  console.log('downloading files...');
+  debug('downloading files...');
   const outDir = await getWritableDirectory();
 
   await download(files, workPath, meta);

--- a/packages/now-php/index.js
+++ b/packages/now-php/index.js
@@ -4,6 +4,7 @@ const {
   glob,
   download,
   shouldServe,
+  debug,
 } = require('@now/build-utils'); // eslint-disable-line import/no-extraneous-dependencies
 const path = require('path');
 const { getFiles } = require('@now/php-bridge');
@@ -31,7 +32,7 @@ exports.build = async ({
     // Backwards compatibility
     includedFiles = downloadedFiles;
   }
-  console.log('Included files:', Object.keys(includedFiles));
+  debug('Included files:', Object.keys(includedFiles));
 
   const userFiles = rename(includedFiles, name => path.join('user', name));
   const bridgeFiles = await getFiles();


### PR DESCRIPTION
This PR use `debug()` from `build-utils` to handle all the output.