### PR TITLE
[now-node] Bump node-file-trace to 0.2.6

### DIFF
--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -28,7 +28,7 @@
     "@types/etag": "1.8.0",
     "@types/test-listen": "1.1.0",
     "@zeit/ncc": "0.20.4",
-    "@zeit/node-file-trace": "0.2.5",
+    "@zeit/node-file-trace": "0.2.6",
     "content-type": "1.0.4",
     "cookie": "0.4.0",
     "etag": "1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1499,10 +1499,10 @@
   resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.20.4.tgz#00f0a25a88cac3712af4ba66561d9e281c6f05c9"
   integrity sha512-fmq+F/QxPec+k/zvT7HiVpk7oiGFseS6brfT/AYqmCUp6QFRK7vZf2Ref46MImsg/g2W3g5X6SRvGRmOAvEfdA==
 
-"@zeit/node-file-trace@0.2.5":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@zeit/node-file-trace/-/node-file-trace-0.2.5.tgz#be69738b89fa084dfc51454ec4e0089d25888ef6"
-  integrity sha512-K7BNYZg19PQFzA3CpaPvjCc/sE0vgUMsVn4f1LurDk/e9aizjmrZCKPQpsGhEhGGR/jtPPMqBLhWVQM3k/trKQ==
+"@zeit/node-file-trace@0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@zeit/node-file-trace/-/node-file-trace-0.2.6.tgz#0884bf7a7176f6aa865a40c8c8b95513d59ee463"
+  integrity sha512-b6OPed+EtVPMNdSdumBPIBFq0h6CgvVj7sa4Lmbq/KJu9KnOJ19Vu4YrJvSWRjgzP4SJqlQ4ya/HUXRP/LWVog==
   dependencies:
     acorn "^6.1.1"
     acorn-stage3 "^2.0.0"


### PR DESCRIPTION
Bumps `@zeit/node-file-trace` to version [0.2.6](https://github.com/zeit/node-file-trace/releases/tag/0.2.6)

Fixes #855