### PR TITLE
[now-build-utils][now-static-build] Fix spawn options for windows

### DIFF
--- a/packages/now-build-utils/src/fs/run-user-scripts.ts
+++ b/packages/now-build-utils/src/fs/run-user-scripts.ts
@@ -63,7 +63,7 @@ export function getSpawnOptions(
   nodeVersion: NodeVersion
 ): SpawnOptions {
   const opts = {
-    env: process.env,
+    env: process.env || {},
   };
 
   if (!meta.isDev) {

--- a/packages/now-build-utils/src/fs/run-user-scripts.ts
+++ b/packages/now-build-utils/src/fs/run-user-scripts.ts
@@ -63,11 +63,13 @@ export function getSpawnOptions(
   nodeVersion: NodeVersion
 ): SpawnOptions {
   const opts = {
-    env: { ...process.env },
+    env: process.env,
   };
 
   if (!meta.isDev) {
-    opts.env.PATH = `/node${nodeVersion.major}/bin:${opts.env.PATH}`;
+    opts.env.PATH = `/node${nodeVersion.major}/bin${path.delimiter}${
+      opts.env.PATH
+    }`;
   }
 
   return opts;

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -181,6 +181,11 @@ export async function build({
     const nodeVersion = await getNodeVersion(entrypointDir, minNodeRange);
     const spawnOpts = getSpawnOptions(meta, nodeVersion);
 
+    if (spawnOpts.env.PATH) {
+      const binstub = path.join(entrypointDir, 'node_modules', '.bin');
+      spawnOpts.env.PATH = `${binstub}${path.delimiter}${spawnOpts.env.PATH}`;
+    }
+
     await runNpmInstall(entrypointDir, ['--prefer-offline'], spawnOpts);
 
     if (meta.isDev && pkg.scripts && pkg.scripts[devScript]) {

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -181,7 +181,7 @@ export async function build({
     const nodeVersion = await getNodeVersion(entrypointDir, minNodeRange);
     const spawnOpts = getSpawnOptions(meta, nodeVersion);
 
-    if (spawnOpts.env.PATH) {
+    if (entrypointDir && spawnOpts.env && spawnOpts.env.PATH) {
       const binstub = path.join(entrypointDir, 'node_modules', '.bin');
       spawnOpts.env.PATH = `${binstub}${path.delimiter}${spawnOpts.env.PATH}`;
     }


### PR DESCRIPTION
This makes sure that `process.env` will be a reference and it will manually add `node_modules/.bin` to the PATH env, since it won't work on windows otherwise.

I'm not yet sure on why this is required, since this works just fine:

```
require('cross-spawn')('yarn', ['--cwd', process.cwd(), 'run', 'build'], { 'stdio': 'inherit', env: { ...process.env }, cwd: process.cwd() })
```

this should be the exact same thing the builder is doing