### PR TITLE
[now-build-utils] Fix 404 for index routes

### DIFF
--- a/packages/now-build-utils/src/detect-routes.ts
+++ b/packages/now-build-utils/src/detect-routes.ts
@@ -2,6 +2,16 @@ import { Route, Builder } from './types';
 import { parse as parsePath } from 'path';
 import { ignoreApiFilter, sortFiles } from './detect-builders';
 
+function escapeName(name: string) {
+  const special = '[]^$.|?*+()'.split('');
+
+  for (const char of special) {
+    name = name.replace(new RegExp(`\\${char}`, 'g'), `\\${char}`);
+  }
+
+  return name;
+}
+
 function joinPath(...segments: string[]) {
   const joinedPath = segments.join('/');
   return joinedPath.replace(/\/{2,}/g, '/');
@@ -46,8 +56,14 @@ function createRouteFromPath(filePath: string): Route {
         query.push(`${name}=$${counter++}`);
         return `([^\\/]+)`;
       } else if (isLast) {
-        const { name: fileName } = parsePath(segment);
-        return fileName;
+        const { name: fileName, ext } = parsePath(segment);
+        const isIndex = fileName === 'index';
+
+        // Either filename with extension, filename without extension
+        // or nothing when the filename is `index`
+        return `(${escapeName(fileName)}|${escapeName(fileName)}${escapeName(
+          ext
+        )})${isIndex ? '?' : ''}`;
       }
 
       return segment;

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -486,6 +486,15 @@ it('Test `detectRoutes`', async () => {
   }
 
   {
+    const files = ['api/date/index.js', 'api/date/index.go'];
+
+    const { builders } = await detectBuilders(files);
+    const { defaultRoutes, error } = await detectRoutes(files, builders);
+    expect(defaultRoutes).toBe(null);
+    expect(error.code).toBe('conflicting_file_path');
+  }
+
+  {
     const files = ['api/[endpoint].js', 'api/[endpoint]/[id].js'];
 
     const { builders } = await detectBuilders(files);
@@ -530,5 +539,31 @@ it('Test `detectRoutes`', async () => {
     const { defaultRoutes } = await detectRoutes(files, builders);
 
     expect(defaultRoutes.length).toBe(1);
+  }
+
+  {
+    const files = ['api/date/index.js', 'api/date.js'];
+
+    const { builders } = await detectBuilders(files);
+    const { defaultRoutes } = await detectRoutes(files, builders);
+
+    expect(defaultRoutes.length).toBe(3);
+    expect(defaultRoutes[0].src).toBe('^/api/date/(index|index\\.js)?$');
+    expect(defaultRoutes[0].dest).toBe('/api/date/index.js');
+    expect(defaultRoutes[1].src).toBe('^/api/(date|date\\.js)$');
+    expect(defaultRoutes[1].dest).toBe('/api/date.js');
+  }
+
+  {
+    const files = ['api/date.js', 'api/[date]/index.js'];
+
+    const { builders } = await detectBuilders(files);
+    const { defaultRoutes } = await detectRoutes(files, builders);
+
+    expect(defaultRoutes.length).toBe(3);
+    expect(defaultRoutes[0].src).toBe('^/api/([^\\/]+)/(index|index\\.js)?$');
+    expect(defaultRoutes[0].dest).toBe('/api/[date]/index.js?date=$1');
+    expect(defaultRoutes[1].src).toBe('^/api/(date|date\\.js)$');
+    expect(defaultRoutes[1].dest).toBe('/api/date.js');
   }
 });


### PR DESCRIPTION
This allows us to disable the directory listing but still support all routes that could be used.

For example, `index`, `index.js` or no name at all, since it is index.

Fixes #881