### PR TITLE
[now-build-utils] Fix TS globbing for zero config

### DIFF
--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -20,7 +20,7 @@ const BUILDERS = new Map<string, Builder>([
 
 const API_BUILDERS: Builder[] = [
   { src: 'api/**/*.js', use: '@now/node', config },
-  { src: 'api/**/*.ts', use: '@now/node', config },
+  { src: 'api/**/*[!d].ts', use: '@now/node', config },
   { src: 'api/**/*.go', use: '@now/go', config },
   { src: 'api/**/*.py', use: '@now/python', config },
   { src: 'api/**/*.rb', use: '@now/ruby', config },

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -574,9 +574,13 @@ it('Test `detectRoutes`', async () => {
       'api/users/index.ts',
       'api/users/index.d.ts',
     ];
+
     const { builders } = await detectBuilders(files);
     const { defaultRoutes } = await detectRoutes(files, builders);
+
+    expect(builders.length).toBe(2);
     expect(builders[0].use).toBe('@now/node');
-    expect(defaultRoutes.length).toBe(2);
+    expect(builders[1].use).toBe('@now/node');
+    expect(defaultRoutes.length).toBe(3);
   }
 });

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -566,4 +566,17 @@ it('Test `detectRoutes`', async () => {
     expect(defaultRoutes[1].src).toBe('^/api/(date|date\\.js)$');
     expect(defaultRoutes[1].dest).toBe('/api/date.js');
   }
+
+  {
+    const files = [
+      'api/index.ts',
+      'api/index.d.ts',
+      'api/users/index.ts',
+      'api/users/index.d.ts',
+    ];
+    const { builders } = await detectBuilders(files);
+    const { defaultRoutes } = await detectRoutes(files, builders);
+    expect(builders[0].use).toBe('@now/node');
+    expect(defaultRoutes.length).toBe(2);
+  }
 });


### PR DESCRIPTION
We know that `.d.ts` files are never going to be lambdas so this PR will exclude them.

The reason is that `.d.ts` is a type declaration, it does not contain runtime code.