### PR TITLE
[now-build-utils] Fix TS globbing for zero config

### DIFF
--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -20,7 +20,7 @@ const BUILDERS = new Map<string, Builder>([
 
 const API_BUILDERS: Builder[] = [
   { src: 'api/**/*.js', use: '@now/node', config },
-  { src: 'api/**/*[!d].ts', use: '@now/node', config },
+  { src: 'api/**/*.ts', use: '@now/node', config },
   { src: 'api/**/*.go', use: '@now/go', config },
   { src: 'api/**/*.py', use: '@now/python', config },
   { src: 'api/**/*.rb', use: '@now/ruby', config },
@@ -63,6 +63,10 @@ export function ignoreApiFilter(file: string) {
   }
 
   if (file.includes('/_')) {
+    return false;
+  }
+
+  if (file.endsWith('.d.ts')) {
     return false;
   }
 

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -573,14 +573,18 @@ it('Test `detectRoutes`', async () => {
       'api/index.d.ts',
       'api/users/index.ts',
       'api/users/index.d.ts',
+      'api/food.ts',
+      'api/ts/gold.ts',
     ];
 
     const { builders } = await detectBuilders(files);
     const { defaultRoutes } = await detectRoutes(files, builders);
 
-    expect(builders.length).toBe(2);
+    expect(builders.length).toBe(4);
     expect(builders[0].use).toBe('@now/node');
     expect(builders[1].use).toBe('@now/node');
-    expect(defaultRoutes.length).toBe(3);
+    expect(builders[2].use).toBe('@now/node');
+    expect(builders[3].use).toBe('@now/node');
+    expect(defaultRoutes.length).toBe(5);
   }
 });

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -576,7 +576,6 @@ it('Test `detectRoutes`', async () => {
       'api/food.ts',
       'api/ts/gold.ts',
     ];
-
     const { builders } = await detectBuilders(files);
     const { defaultRoutes } = await detectRoutes(files, builders);
 


### PR DESCRIPTION
A follow up to #885

We know that `.d.ts` files are never going to be lambdas so this PR will exclude them.

The reason is that `.d.ts` is a type declaration, it does not contain runtime code.

This PR makes sure that `food.ts` will become a lambda.