### PR TITLE
[now-node][now-next] Bump node-file-trace to 0.2.7

### DIFF
--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -21,7 +21,7 @@
     "@types/next-server": "8.0.0",
     "@types/resolve-from": "5.0.1",
     "@types/semver": "6.0.0",
-    "@zeit/node-file-trace": "0.2.6",
+    "@zeit/node-file-trace": "0.2.7",
     "fs-extra": "7.0.0",
     "get-port": "5.0.0",
     "resolve-from": "5.0.0",

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -28,7 +28,7 @@
     "@types/etag": "1.8.0",
     "@types/test-listen": "1.1.0",
     "@zeit/ncc": "0.20.4",
-    "@zeit/node-file-trace": "0.2.6",
+    "@zeit/node-file-trace": "0.2.7",
     "content-type": "1.0.4",
     "cookie": "0.4.0",
     "etag": "1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1480,10 +1480,10 @@
   resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.20.4.tgz#00f0a25a88cac3712af4ba66561d9e281c6f05c9"
   integrity sha512-fmq+F/QxPec+k/zvT7HiVpk7oiGFseS6brfT/AYqmCUp6QFRK7vZf2Ref46MImsg/g2W3g5X6SRvGRmOAvEfdA==
 
-"@zeit/node-file-trace@0.2.6":
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/@zeit/node-file-trace/-/node-file-trace-0.2.6.tgz#0884bf7a7176f6aa865a40c8c8b95513d59ee463"
-  integrity sha512-b6OPed+EtVPMNdSdumBPIBFq0h6CgvVj7sa4Lmbq/KJu9KnOJ19Vu4YrJvSWRjgzP4SJqlQ4ya/HUXRP/LWVog==
+"@zeit/node-file-trace@0.2.7":
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/@zeit/node-file-trace/-/node-file-trace-0.2.7.tgz#af6efa0fd1753e70eff6f627581963c5f0a23b64"
+  integrity sha512-4y8fLbe6heqlsAcu8M1LbwNHLx11P8LSsdh5aYoz2PL2yAo70t47qPY74njM1NuIHqdWInKDx4bGc8fOsn7AdA==
   dependencies:
     acorn "^6.1.1"
     acorn-stage3 "^2.0.0"


### PR DESCRIPTION
Bump `@zeit/node-file-trace` to [0.2.7](https://github.com/zeit/node-file-trace/releases/tag/0.2.7) with support for Windows.

Related to #869