### PR TITLE
[now-node] Fix windows typescript entrypoint bug

### DIFF
--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -239,7 +239,12 @@ async function compile(
       }
     }
     // Rename .ts -> .js (except for entry)
-    if (path !== entrypoint && tsCompiled.has(path)) {
+    // There is a bug on Windows where entrypoint uses forward slashes
+    // and workPath uses backslashes so we use resolve before comparing.
+    if (
+      resolve(workPath, path) !== resolve(workPath, entrypoint) &&
+      tsCompiled.has(path)
+    ) {
       preparedFiles[
         path.slice(0, -3 - Number(path.endsWith('x'))) + '.js'
       ] = entry;


### PR DESCRIPTION
Fixes #869 

This was a strange bug to track down and this does not address the root cause which likely needs to be fixed in `now-cli`.

When running `now dev` on Windows, the `build({ workPath, entrypoint })` function is invoked with inconsistent path separators. For example:


- entrypoint: `zeit/api/api-handler.ts`
- workPath: `C:\Users\styfle\Code\zeit-now-ts-debugging`


Most of the time this isn't a problem, but in one case, there was a strict string comparison that was failing so I used `path.resolve()` to convert both to absolute paths before comparing.