### PR TITLE
Disable compression for Zips

### DIFF
--- a/packages/now-build-utils/src/lambda.ts
+++ b/packages/now-build-utils/src/lambda.ts
@@ -86,7 +86,7 @@ export async function createZip(files: Files): Promise<Buffer> {
   const zipBuffer = await new Promise<Buffer>((resolve, reject) => {
     for (const name of names) {
       const file = files[name];
-      const opts = { mode: file.mode, mtime };
+      const opts = { mode: file.mode, mtime, compress: false };
       const symlinkTarget = symlinkTargets.get(name);
       if (typeof symlinkTarget === 'string') {
         zipFile.addBuffer(Buffer.from(symlinkTarget, 'utf8'), name, opts);


### PR DESCRIPTION
This disables compression of the `.zip` for lambdas, making it more like `.tar`. This should help speed up builds. 😄 