### PR TITLE
[now-build-utils] Fix 404 trailing slash for index files and add tests

### DIFF
--- a/packages/now-build-utils/src/detect-routes.ts
+++ b/packages/now-build-utils/src/detect-routes.ts
@@ -60,12 +60,15 @@ function createRouteFromPath(filePath: string): Route {
         const isIndex = fileName === 'index';
         const prefix = isIndex ? '\\/' : '';
 
-        const name1 = prefix + escapeName(fileName);
-        const name2 = prefix + escapeName(fileName) + escapeName(ext);
+        const names = [
+          prefix,
+          prefix + escapeName(fileName),
+          prefix + escapeName(fileName) + escapeName(ext),
+        ].filter(Boolean);
 
         // Either filename with extension, filename without extension
         // or nothing when the filename is `index`
-        return `(${name1}|${name2})${isIndex ? '?' : ''}`;
+        return `(${names.join('|')})${isIndex ? '?' : ''}`;
       }
 
       return segment;

--- a/packages/now-build-utils/src/detect-routes.ts
+++ b/packages/now-build-utils/src/detect-routes.ts
@@ -58,19 +58,27 @@ function createRouteFromPath(filePath: string): Route {
       } else if (isLast) {
         const { name: fileName, ext } = parsePath(segment);
         const isIndex = fileName === 'index';
+        const prefix = isIndex ? '\\/' : '';
+
+        const name1 = prefix + escapeName(fileName);
+        const name2 = prefix + escapeName(fileName) + escapeName(ext);
 
         // Either filename with extension, filename without extension
         // or nothing when the filename is `index`
-        return `(${escapeName(fileName)}|${escapeName(fileName)}${escapeName(
-          ext
-        )})${isIndex ? '?' : ''}`;
+        return `(${name1}|${name2})${isIndex ? '?' : ''}`;
       }
 
       return segment;
     }
   );
 
-  const src = `^/${srcParts.join('/')}$`;
+  const { name: fileName } = parsePath(filePath);
+  const isIndex = fileName === 'index';
+
+  const src = isIndex
+    ? `^/${srcParts.slice(0, -1).join('/')}${srcParts.slice(-1)[0]}$`
+    : `^/${srcParts.join('/')}$`;
+
   const dest = `/${filePath}${query.length ? '?' : ''}${query.join('&')}`;
 
   return { src, dest };

--- a/packages/now-build-utils/test/fixtures/01-zero-config-api/.gitignore
+++ b/packages/now-build-utils/test/fixtures/01-zero-config-api/.gitignore
@@ -1,0 +1,1 @@
+now.json

--- a/packages/now-build-utils/test/fixtures/01-zero-config-api/api/[endpoint].js
+++ b/packages/now-build-utils/test/fixtures/01-zero-config-api/api/[endpoint].js
@@ -1,0 +1,3 @@
+module.exports = (req, res) => {
+  res.end(req.query.endpoint);
+};

--- a/packages/now-build-utils/test/fixtures/01-zero-config-api/api/[endpoint]/[id].js
+++ b/packages/now-build-utils/test/fixtures/01-zero-config-api/api/[endpoint]/[id].js
@@ -1,0 +1,3 @@
+module.exports = (req, res) => {
+  res.end(`${req.query.endpoint}/${req.query.id}`);
+};

--- a/packages/now-build-utils/test/fixtures/01-zero-config-api/package.json
+++ b/packages/now-build-utils/test/fixtures/01-zero-config-api/package.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "build": "mkdir -p public && echo 'hello from index.txt' > public/index.txt"
+  }
+}

--- a/packages/now-build-utils/test/fixtures/02-zero-config-api/.gitignore
+++ b/packages/now-build-utils/test/fixtures/02-zero-config-api/.gitignore
@@ -1,0 +1,1 @@
+now.json

--- a/packages/now-build-utils/test/fixtures/02-zero-config-api/api/date.js
+++ b/packages/now-build-utils/test/fixtures/02-zero-config-api/api/date.js
@@ -1,0 +1,3 @@
+module.exports = (req, res) => {
+  res.end('hello from api/date.js');
+};

--- a/packages/now-build-utils/test/fixtures/02-zero-config-api/api/date/index.js
+++ b/packages/now-build-utils/test/fixtures/02-zero-config-api/api/date/index.js
@@ -1,0 +1,3 @@
+module.exports = (req, res) => {
+  res.end('hello from api/date/index.js');
+};

--- a/packages/now-build-utils/test/fixtures/02-zero-config-api/api/index.js
+++ b/packages/now-build-utils/test/fixtures/02-zero-config-api/api/index.js
@@ -1,0 +1,3 @@
+module.exports = (req, res) => {
+  res.end('hello from api/index.js');
+};

--- a/packages/now-build-utils/test/fixtures/02-zero-config-api/package.json
+++ b/packages/now-build-utils/test/fixtures/02-zero-config-api/package.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "build": "mkdir -p public && echo 'hello from index.txt' > public/index.txt"
+  }
+}

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -680,8 +680,17 @@ it('Test `detectBuilders` and `detectRoutes` with `index` files', async () => {
       status: 200,
     },
     {
-      path: '/api/date',
+      path: '/api/date.js',
       mustContain: 'hello from api/date.js',
+      status: 200,
+    },
+    {
+      // Someone might expect this to be `date.js`,
+      // but I doubt that there is any case were both
+      // `date/index.js` and `date.js` exists,
+      // so it is not special cased
+      path: '/api/date',
+      mustContain: 'hello from api/date/index.js',
       status: 200,
     },
     {

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -615,6 +615,16 @@ it('Test `detectBuilders` and `detectRoutes`', async () => {
       status: 200,
     },
     {
+      path: '/api/team/zeit',
+      mustContain: 'team/zeit',
+      status: 200,
+    },
+    {
+      path: '/api/user/myself',
+      mustContain: 'user/myself',
+      status: 200,
+    },
+    {
       path: '/api/not-okay/',
       status: 404,
     },

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -553,7 +553,9 @@ it('Test `detectRoutes`', async () => {
     const { defaultRoutes } = await detectRoutes(files, builders);
 
     expect(defaultRoutes.length).toBe(3);
-    expect(defaultRoutes[0].src).toBe('^/api/date(\\/index|\\/index\\.js)?$');
+    expect(defaultRoutes[0].src).toBe(
+      '^/api/date(\\/|\\/index|\\/index\\.js)?$',
+    );
     expect(defaultRoutes[0].dest).toBe('/api/date/index.js');
     expect(defaultRoutes[1].src).toBe('^/api/(date|date\\.js)$');
     expect(defaultRoutes[1].dest).toBe('/api/date.js');
@@ -567,7 +569,7 @@ it('Test `detectRoutes`', async () => {
 
     expect(defaultRoutes.length).toBe(3);
     expect(defaultRoutes[0].src).toBe(
-      '^/api/([^\\/]+)(\\/index|\\/index\\.js)?$',
+      '^/api/([^\\/]+)(\\/|\\/index|\\/index\\.js)?$',
     );
     expect(defaultRoutes[0].dest).toBe('/api/[date]/index.js?date=$1');
     expect(defaultRoutes[1].src).toBe('^/api/(date|date\\.js)$');

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -4,21 +4,21 @@ const fs = require('fs-extra');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const execa = require('execa');
 const assert = require('assert');
+const { createZip } = require('../dist/lambda');
 const {
   glob, download, detectBuilders, detectRoutes,
 } = require('../');
-const { createZip } = require('../dist/lambda');
 const {
   getSupportedNodeVersion,
   defaultSelection,
 } = require('../dist/fs/node-version');
-
 const {
   packAndDeploy,
   testDeployment,
-} = require('../../../test/lib/deployment/test-deployment.js');
+} = require('../../../test/lib/deployment/test-deployment');
 
 jest.setTimeout(4 * 60 * 1000);
+
 const builderUrl = '@canary';
 let buildUtilsUrl;
 
@@ -152,6 +152,11 @@ const fixturesPath = path.resolve(__dirname, 'fixtures');
 
 // eslint-disable-next-line no-restricted-syntax
 for (const fixture of fs.readdirSync(fixturesPath)) {
+  if (fixture.includes('zero-config')) {
+    // Those have separate tests
+    continue; // eslint-disable-line no-continue
+  }
+
   // eslint-disable-next-line no-loop-func
   it(`should build ${fixture}`, async () => {
     await expect(
@@ -548,7 +553,7 @@ it('Test `detectRoutes`', async () => {
     const { defaultRoutes } = await detectRoutes(files, builders);
 
     expect(defaultRoutes.length).toBe(3);
-    expect(defaultRoutes[0].src).toBe('^/api/date/(index|index\\.js)?$');
+    expect(defaultRoutes[0].src).toBe('^/api/date(\\/index|\\/index\\.js)?$');
     expect(defaultRoutes[0].dest).toBe('/api/date/index.js');
     expect(defaultRoutes[1].src).toBe('^/api/(date|date\\.js)$');
     expect(defaultRoutes[1].dest).toBe('/api/date.js');
@@ -561,7 +566,9 @@ it('Test `detectRoutes`', async () => {
     const { defaultRoutes } = await detectRoutes(files, builders);
 
     expect(defaultRoutes.length).toBe(3);
-    expect(defaultRoutes[0].src).toBe('^/api/([^\\/]+)/(index|index\\.js)?$');
+    expect(defaultRoutes[0].src).toBe(
+      '^/api/([^\\/]+)(\\/index|\\/index\\.js)?$',
+    );
     expect(defaultRoutes[0].dest).toBe('/api/[date]/index.js?date=$1');
     expect(defaultRoutes[1].src).toBe('^/api/(date|date\\.js)$');
     expect(defaultRoutes[1].dest).toBe('/api/date.js');
@@ -586,4 +593,128 @@ it('Test `detectRoutes`', async () => {
     expect(builders[3].use).toBe('@now/node');
     expect(defaultRoutes.length).toBe(5);
   }
+});
+
+it('Test `detectBuilders` and `detectRoutes`', async () => {
+  const fixture = path.join(__dirname, 'fixtures', '01-zero-config-api');
+  const pkg = await fs.readJSON(path.join(fixture, 'package.json'));
+  const fileList = await glob('**', fixture);
+  const files = Object.keys(fileList);
+
+  const probes = [
+    {
+      path: '/api/my-endpoint',
+      mustContain: 'my-endpoint',
+      status: 200,
+    },
+    {
+      path: '/api/other-endpoint',
+      mustContain: 'other-endpoint',
+      status: 200,
+    },
+    {
+      path: '/api/not-okay/',
+      status: 404,
+    },
+    {
+      path: '/api',
+      status: 404,
+    },
+    {
+      path: '/api/',
+      status: 404,
+    },
+    {
+      path: '/',
+      mustContain: 'hello from index.txt',
+    },
+  ];
+
+  const { builders } = await detectBuilders(files, pkg);
+  const { defaultRoutes } = await detectRoutes(files, builders);
+
+  const nowConfig = { builds: builders, routes: defaultRoutes, probes };
+  await fs.writeFile(
+    path.join(fixture, 'now.json'),
+    JSON.stringify(nowConfig, null, 2),
+  );
+
+  const deployment = await testDeployment(
+    { builderUrl, buildUtilsUrl },
+    fixture,
+  );
+  expect(deployment).toBeDefined();
+});
+
+it('Test `detectBuilders` and `detectRoutes` with `index` files', async () => {
+  const fixture = path.join(__dirname, 'fixtures', '02-zero-config-api');
+  const pkg = await fs.readJSON(path.join(fixture, 'package.json'));
+  const fileList = await glob('**', fixture);
+  const files = Object.keys(fileList);
+
+  const probes = [
+    {
+      path: '/api/not-okay',
+      status: 404,
+    },
+    {
+      path: '/api',
+      mustContain: 'hello from api/index.js',
+      status: 200,
+    },
+    {
+      path: '/api/',
+      mustContain: 'hello from api/index.js',
+      status: 200,
+    },
+    {
+      path: '/api/index',
+      mustContain: 'hello from api/index.js',
+      status: 200,
+    },
+    {
+      path: '/api/index.js',
+      mustContain: 'hello from api/index.js',
+      status: 200,
+    },
+    {
+      path: '/api/date',
+      mustContain: 'hello from api/date.js',
+      status: 200,
+    },
+    {
+      path: '/api/date/',
+      mustContain: 'hello from api/date/index.js',
+      status: 200,
+    },
+    {
+      path: '/api/date/index',
+      mustContain: 'hello from api/date/index.js',
+      status: 200,
+    },
+    {
+      path: '/api/date/index.js',
+      mustContain: 'hello from api/date/index.js',
+      status: 200,
+    },
+    {
+      path: '/',
+      mustContain: 'hello from index.txt',
+    },
+  ];
+
+  const { builders } = await detectBuilders(files, pkg);
+  const { defaultRoutes } = await detectRoutes(files, builders);
+
+  const nowConfig = { builds: builders, routes: defaultRoutes, probes };
+  await fs.writeFile(
+    path.join(fixture, 'now.json'),
+    JSON.stringify(nowConfig, null, 2),
+  );
+
+  const deployment = await testDeployment(
+    { builderUrl, buildUtilsUrl },
+    fixture,
+  );
+  expect(deployment).toBeDefined();
 });

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -90,6 +90,16 @@ async function testDeployment (
     const { text, resp } = await fetchDeploymentUrl(probeUrl, fetchOpts);
     console.log('finished testing', JSON.stringify(probe));
 
+    if (probe.status) {
+      if (probe.status !== resp.status) {
+        throw new Error(
+          `Fetched page ${probeUrl} does not return the status ${
+            probe.status
+          } Instead it has ${resp.status}`
+        );
+      }
+    }
+
     if (probe.mustContain) {
       if (!text.includes(probe.mustContain)) {
         await fs.writeFile(path.join(__dirname, 'failed-page.txt'), text);

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -150,14 +150,10 @@ async function nowDeployIndexTgz (file) {
 }
 
 async function fetchDeploymentUrl (url, opts) {
-  for (let i = 0; i < 500; i += 1) {
+  for (let i = 0; i < 50; i += 1) {
     const resp = await fetch(url, opts);
     const text = await resp.text();
-    if (
-      text
-      && !text.includes('Join Free')
-      && !text.includes('The page could not be found')
-    ) {
+    if (text && !text.includes('Join Free')) {
       return { resp, text };
     }
 

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -127,7 +127,7 @@ async function testDeployment (
           );
         }
       });
-    } else {
+    } else if (!probe.status) {
       assert(false, 'probe must have a test condition');
     }
   }


### PR DESCRIPTION
Fix 404 trailing slash for index files and add tests.

This makes sure that routes like `/api/date` return a 200 instead of a 404 when the source is `/api/date/index.js`.

It further updates the unit tests and adds integration tests to test those cases.