### PR TITLE
Revert "Disable compression for Zips"

### DIFF
--- a/packages/now-build-utils/src/lambda.ts
+++ b/packages/now-build-utils/src/lambda.ts
@@ -86,7 +86,7 @@ export async function createZip(files: Files): Promise<Buffer> {
   const zipBuffer = await new Promise<Buffer>((resolve, reject) => {
     for (const name of names) {
       const file = files[name];
-      const opts = { mode: file.mode, mtime, compress: false };
+      const opts = { mode: file.mode, mtime };
       const symlinkTarget = symlinkTargets.get(name);
       if (typeof symlinkTarget === 'string') {
         zipFile.addBuffer(Buffer.from(symlinkTarget, 'utf8'), name, opts);


### PR DESCRIPTION
Reverts zeit/now-builders#901

This did not have a meaningful effect on the end-speed, it shaved about ~300ms of a 4s `createLambda` operation. It amounted to about 20s savings for `front`.

This is still "significant", but the whole operation still took 3.66 minutes instead of 4 minutes. 😄 

---

I do not feel strongly about keeping or reverting this, so I'll leave it to the PR reviewer to close this PR or revert the change!