### PR TITLE
[@now/next] Serverless Trace target for Next.js canary only

### DIFF
--- a/packages/now-next/src/create-serverless-config.ts
+++ b/packages/now-next/src/create-serverless-config.ts
@@ -47,7 +47,10 @@ export default async function createServerlessConfig(
   let target = 'serverless';
   if (nextVersion) {
     try {
-      if (semver.satisfies(nextVersion, `>=${ExperimentalTraceVersion}`)) {
+      if (
+        nextVersion.includes('canary') &&
+        semver.satisfies(nextVersion, `>=${ExperimentalTraceVersion}`)
+      ) {
         target = 'experimental-serverless-trace';
       }
     } catch (_ignored) {}


### PR DESCRIPTION
Next.js users should not be automatically opted into an experimental feature unless they're explicitly on a Next.js canary version.