### PR TITLE
[now-go] Update link to docs

### DIFF
--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -106,7 +106,7 @@ Learn more: https://github.com/golang/go/wiki/Modules
   if (!analyzed) {
     const err = new Error(
       `Could not find an exported function in "${entrypoint}"
-Learn more: https://zeit.co/docs/v2/deployments/official-builders/go-now-go/#entrypoint
+Learn more: https://zeit.co/docs/v2/advanced/builders/#go
       `
     );
     console.log(err.message);


### PR DESCRIPTION
This PR update link to docs when `analyzer` couldn't parse the `entrypoint`.