### PR TITLE
[docs] Add versioning documentation

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,40 @@
+# Publishing to npm
+
+Always publish to the Canary Channel as soon as a PR is merged into the `canary` branch.
+
+```
+yarn publish-canary
+```
+
+Publish the Stable Channel weekly.
+
+- Cherry pick each commit from `canary` to `master` branch
+- Verify that you are _in-sync_ with canary (with the exception of the `version` line in `package.json`)
+- Deploy the modified Builders
+
+```
+# View differences excluding "Publish" commits
+git checkout canary && git pull
+git log --pretty=format:"$ad- %s [%an]" | grep -v Publish > ~/Desktop/canary.txt
+git checkout master && git pull
+git log --pretty=format:"$ad- %s [%an]" | grep -v Publish > ~/Desktop/master.txt
+diff ~/Desktop/canary.txt ~/Desktop/master.txt
+
+# Cherry pick all PRs from canary into master ...
+git cherry-pick <PR501_COMMIT_SHA>
+git cherry-pick <PR502_COMMIT_SHA>
+git cherry-pick <PR503_COMMIT_SHA>
+git cherry-pick <PR504_COMMIT_SHA>
+
+# Verify the only difference is "version" in package.json
+git diff origin/canary
+
+# Ship it
+yarn publish-stable
+```
+
+After running this publish step, GitHub Actions will take care of publishing the modified Builder packages to npm.
+
+If for some reason GitHub Actions fails to publish the npm package, you may do so
+manually by running `npm publish` from the package directory. Make sure to
+use `npm publish --tag canary` if you are publishing a canary release!

--- a/README.md
+++ b/README.md
@@ -2,77 +2,18 @@
 
 This is a monorepo containing the [Official Builders](https://zeit.co/docs/v2/advanced/builders) provided by the ZEIT team.
 
-## Channels
+## Versioning and advanced usage
 
-There are two Channels:
+See [VERSIONING.md](VERSIONING.md).
 
-| Channel | Git Branch                                                    | npm dist-tag | use example        |
-| ------- | ------------------------------------------------------------- | ------------ | ------------------ |
-| Canary  | [canary](https://github.com/zeit/now-builders/commits/canary) | `@canary`    | `@now/node@canary` |
-| Stable  | [master](https://github.com/zeit/now-builders/commits/master) | `@latest`    | `@now/node@latest` |
+## Publishing to npm
 
-All PRs should be submitted to the `canary` branch.
-
-Once a PR is merged into the `canary` branch, it should be published to npm immediately using the Canary Channel.
-
-### Builder Versioning
-
-Since Builders are published to [npmjs.com](https://npmjs.com), this makes versioning works the same for Builders as it does for any npm package. The `use` statement in [now.json](https://zeit.co/docs/v2/advanced/configuration#builds) has a similar syntax to `npm install`.
-
-The following are valid examples [@now/node](https://www.npmjs.com/package/@now/node?activeTab=versions):
-
-- `@now/node`
-- `@now/node@0.7.3`
-- `@now/node@canary`
-- `@now/node@0.7.2-canary.2`
-
-We always recommend using the latest version by leaving off the dist-tag suffix, `@now/node` for example.
-
-### Publishing to npm
-
-For the Canary Channel, publish the modified Builders to npm with the following:
-
-```
-yarn publish-canary
-```
-
-For the Stable Channel, you must do the following:
-
-- Cherry pick each commit from canary to master
-- Verify that you are _in-sync_ with canary (with the exception of the `version` line in `package.json`)
-- Deploy the modified Builders
-
-```
-# View differences excluding "Publish" commits
-git checkout canary && git pull
-git log --pretty=format:"$ad- %s [%an]" | grep -v Publish > ~/Desktop/canary.txt
-git checkout master && git pull
-git log --pretty=format:"$ad- %s [%an]" | grep -v Publish > ~/Desktop/master.txt
-diff ~/Desktop/canary.txt ~/Desktop/master.txt
-
-# Cherry pick all PRs from canary into master ...
-git cherry-pick <PR501_COMMIT_SHA>
-git cherry-pick <PR502_COMMIT_SHA>
-git cherry-pick <PR503_COMMIT_SHA>
-git cherry-pick <PR504_COMMIT_SHA>
-
-# Verify the only difference is "version" in package.json
-git diff origin/canary
-
-# Ship it
-yarn publish-stable
-```
-
-After running this publish step, GitHub Actions will take care of publishing the modified Builder packages to npm.
-
-If for some reason GitHub Actions fails to publish the npm package, you may do so
-manually by running `npm publish` from the package directory. Make sure to
-use `npm publish --tag canary` if you are publishing a canary release!
+See [PUBLISHING.md](PUBLISHING.md).
 
 ## Contributing
 
-See the [Contribution guidelines for this project](CONTRIBUTING.md), it also contains guidance on interpreting tests failures.
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## Creating Your Own Builder
+### Creating Your Own Builder
 
-To create your own Builder, see [the Builder's Developer Reference](DEVELOPING_A_BUILDER.md).
+See [DEVELOPING_A_BUILDER.md](DEVELOPING_A_BUILDER.md).

--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ All PRs should be submitted to the `canary` branch.
 
 Once a PR is merged into the `canary` branch, it should be published to npm immediately using the Canary Channel.
 
+### Builder Versioning
+
+Since Builders are published to [npmjs.com](https://npmjs.com), this makes versioning works the same for Builders as it does for any npm package. The `use` statement in [now.json](https://zeit.co/docs/v2/advanced/configuration#builds) has a similar syntax to `npm install`.
+
+The following are valid examples [@now/node](https://www.npmjs.com/package/@now/node?activeTab=versions):
+
+- `@now/node`
+- `@now/node@0.7.3`
+- `@now/node@canary`
+- `@now/node@0.7.2-canary.2`
+
+We always recommend using the latest version by leaving off the dist-tag suffix, `@now/node` for example.
+
 ### Publishing to npm
 
 For the Canary Channel, publish the modified Builders to npm with the following:
@@ -56,10 +69,10 @@ If for some reason GitHub Actions fails to publish the npm package, you may do s
 manually by running `npm publish` from the package directory. Make sure to
 use `npm publish --tag canary` if you are publishing a canary release!
 
-### Contributing
+## Contributing
 
 See the [Contribution guidelines for this project](CONTRIBUTING.md), it also contains guidance on interpreting tests failures.
 
-### Creating Your Own Builder
+## Creating Your Own Builder
 
 To create your own Builder, see [the Builder's Developer Reference](DEVELOPING_A_BUILDER.md).

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,25 @@
+# Versioning
+
+Builders are released to two different channels.
+
+## Channels
+
+| Channel | Git Branch                                                    | npm dist-tag | use example        |
+| ------- | ------------------------------------------------------------- | ------------ | ------------------ |
+| Canary  | [canary](https://github.com/zeit/now-builders/commits/canary) | `@canary`    | `@now/node@canary` |
+| Stable  | [master](https://github.com/zeit/now-builders/commits/master) | `@latest`    | `@now/node@latest` |
+
+All PRs are submitted to the `canary` branch. Once a PR is merged into the `canary` branch, it should be published to npm immediately using the Canary Channel.
+
+## Version Selection
+
+Since Builders are published to [npmjs.com](https://npmjs.com), this makes versioning works the same for Builders as it does for any npm package. The `use` statement in [now.json](https://zeit.co/docs/v2/advanced/configuration#builds) has a similar syntax to `npm install`.
+
+The following are valid examples [@now/node](https://www.npmjs.com/package/@now/node?activeTab=versions):
+
+- `@now/node`
+- `@now/node@0.7.3`
+- `@now/node@canary`
+- `@now/node@0.7.2-canary.2`
+
+We always recommend using the latest version by leaving off the dist-tag suffix, `@now/node` for example.


### PR DESCRIPTION
Moving versioning section from docs to the builder repo https://github.com/zeit/docs/pull/871