### PR TITLE
[now-next] Join bundle require path manually

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -533,12 +533,12 @@ export const build = async ({
         const label = `Creating lambda for page: "${page}"...`;
         console.time(label);
 
-        const pageFileName = path.relative(workPath, pages[page].fsPath);
+        const pageFileName = path.normalize(
+          path.relative(workPath, pages[page].fsPath)
+        );
         const launcher = launcherData.replace(
           /__LAUNCHER_PAGE_PATH__/g,
-          JSON.stringify(
-            requiresTracing ? path.join('./', pageFileName) : './page'
-          )
+          JSON.stringify(requiresTracing ? `./${pageFileName}` : './page')
         );
         const launcherFiles = {
           'now__bridge.js': new FileFsRef({


### PR DESCRIPTION
Apparently `path.join` cannot prepend `./`, meaning:
```js
> path.join('./', 'foo') === 'foo'
true
```

This require **must** be relative -- it's not absolute. 

I have no clue how our integration tests were passing before this change, so we should probably figure out a test for this.