### PR TITLE
[now-static-build] Fix dev server detection

### DIFF
--- a/packages/now-static-build/package.json
+++ b/packages/now-static-build/package.json
@@ -21,10 +21,8 @@
     "@types/promise-timeout": "1.3.0",
     "cross-spawn": "6.0.5",
     "get-port": "5.0.0",
+    "is-port-reachable": "2.0.1",
     "promise-timeout": "1.3.0",
     "typescript": "3.5.2"
-  },
-  "dependencies": {
-    "is-port-reachable": "2.0.1"
   }
 }

--- a/packages/now-static-build/package.json
+++ b/packages/now-static-build/package.json
@@ -23,5 +23,8 @@
     "get-port": "5.0.0",
     "promise-timeout": "1.3.0",
     "typescript": "3.5.2"
+  },
+  "dependencies": {
+    "is-port-reachable": "2.0.1"
   }
 }

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -17,6 +17,7 @@ import {
   BuildOptions,
   Config,
 } from '@now/build-utils';
+import isPortReachable from 'is-port-reachable';
 
 interface PackageJson {
   scripts?: {
@@ -231,12 +232,9 @@ export async function build({
         try {
           await timeout(
             new Promise(resolve => {
-              const checkForPort = (data: string) => {
-                // Check the logs for the URL being printed with the port number
-                // (i.e. `http://localhost:47521`).
-                if (data.indexOf(`:${devPort}`) !== -1) {
-                  resolve();
-                }
+              const checkForPort = () => {
+                // Check is the devPort is reachable
+                isPortReachable(devPort).then(resolve);
               };
               if (child.stdout) {
                 child.stdout.on('data', checkForPort);

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -233,7 +233,6 @@ export async function build({
           await timeout(
             new Promise(resolve => {
               const checkForPort = () => {
-                // Check is the devPort is reachable
                 isPortReachable(devPort).then(resolve);
               };
               if (child.stdout) {

--- a/packages/now-static-build/src/typings.d.ts
+++ b/packages/now-static-build/src/typings.d.ts
@@ -1,0 +1,1 @@
+declare module 'is-port-reachable';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4207,6 +4207,11 @@ is-plain-object@^3.0.0:
   dependencies:
     isobject "^4.0.0"
 
+is-port-reachable@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-port-reachable/-/is-port-reachable-2.0.1.tgz#e0778d0733beac1ade3ba72a5fe77db50a59926b"
+  integrity sha512-SqU55C5gkitgOhl2ccd2v23MbkbcOFa5e4aPo8h8VGqOifh7iDwG44bQBWGW/lZulTjl9AWIKP0NiUWpa+TtWA==
+
 is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"


### PR DESCRIPTION
In some cases, ie: CRA apps with warnings, the devPort is not printed therefore `now dev` reaches the timeout when trying to detect the dev server by reading the logs/console.

This a is a try to improve the dev server detection by using `is-port-reachable` instead of reading the logs printed by the app.

I'm not sure how to run `now dev` integration tests from this project, I would also like to add a warning in the create-react-app integration test to prove that it works.

If you can just tell me how, I've tried to run tests in local but got 2 issues.

- it doesn't download `hugo` when running `now dev` integration test in local.
- run `yarn test`in the root directory of this project gives me 429 too many requests and I'm rate limited.

Fixes #914