### PR TITLE
[now-static-build] Fix "TypeError: Cannot convert undefined or null to object"

### DIFF
--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -333,8 +333,14 @@ export async function build({
     const spawnOpts = getSpawnOptions(meta, nodeVersion);
     await runShellScript(path.join(workPath, entrypoint), [], spawnOpts);
     validateDistDir(distPath, meta.isDev, config);
+    
+    const output = await glob('**', distPath, mountpoint);
 
-    return glob('**', distPath, mountpoint);
+    return {
+      output,
+      routes: [],
+      watch: []
+    };
   }
 
   let message = `Build "src" is "${entrypoint}" but expected "package.json"`;


### PR DESCRIPTION
Closes https://github.com/srilq/euanmarten/issues/1.

Now dev builder expects object return type:
https://github.com/zeit/now-cli/blob/c5ef4b1dc585b7cb6bfd74135edb593961bd9d00/src/util/dev/builder.ts#L272

Using `.sh` build scripts with `now dev` currently results in the following error:

```
now dev --debug
> [debug] [2019-08-17T17:26:24.485Z] Found config in file /Users/sril/src/euanmarten/now.json
> [debug] [2019-08-17T17:26:24.501Z] Using Now CLI 16.1.1
> [debug] [2019-08-17T17:26:24.525Z] user supplied known subcommand
> Now CLI 16.1.1 dev (beta) — https://zeit.co/feedback/dev
> [debug] [2019-08-17T17:26:24.672Z] The yarn executable is already cached, not re-downloading
> [debug] [2019-08-17T17:26:24.675Z] Reading `package.json` file
> [debug] [2019-08-17T17:26:24.675Z] Reading `now.json` file
> [debug] [2019-08-17T17:26:24.682Z] Locating files /Users/sril/src/euanmarten
> [debug] [2019-08-17T17:26:24.683Z] Ignoring /Users/sril/src/euanmarten/.DS_Store
> [debug] [2019-08-17T17:26:24.683Z] Ignoring /Users/sril/src/euanmarten/.git
> [debug] [2019-08-17T17:26:24.684Z] Ignoring /Users/sril/src/euanmarten/.gitignore
> [debug] [2019-08-17T17:26:24.684Z] Ignoring /Users/sril/src/euanmarten/.next
> [debug] [2019-08-17T17:26:24.685Z] Ignoring /Users/sril/src/euanmarten/node_modules
> [debug] [2019-08-17T17:26:24.686Z] Ignoring /Users/sril/src/euanmarten/static/.DS_Store
> [debug] [2019-08-17T17:26:24.688Z] Ignoring /Users/sril/src/euanmarten/static/images/.DS_Store
> [debug] [2019-08-17T17:26:24.695Z] Locating files /Users/sril/src/euanmarten: 12.620ms
> [debug] [2019-08-17T17:26:24.707Z] No builders need to be installed
> [debug] [2019-08-17T17:26:24.764Z] Adding build match for "build-images.sh"
> Creating initial build
> Building @now/static-build:build-images.sh
> [debug] [2019-08-17T17:26:24.768Z] Using `@now/static-build@0.9.7`
> [debug] [2019-08-17T17:26:24.768Z] Creating build process for build-images.sh
Downloading user files...
Running build script "build-images.sh"
Found `engines` in `package.json`, selecting range: 10.x
> Error! Cannot convert undefined or null to object
> [debug] [2019-08-17T17:26:27.022Z] TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at Object.<anonymous> (/Users/sril/.nvm/versions/node/v10.16.0/lib/node_modules/now/dist/index.js:2:2810776)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/sril/.nvm/versions/node/v10.16.0/lib/node_modules/now/dist/index.js:2:2807181)
    at process._tickCallback (internal/process/next_tick.js:68:7)
> [debug] [2019-08-17T17:26:36.291Z] No builders were updated
```