### PR TITLE
Upgrade `@zeit/node-file-trace` to `0.2.11`

### DIFF
--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -21,7 +21,7 @@
     "@types/next-server": "8.0.0",
     "@types/resolve-from": "5.0.1",
     "@types/semver": "6.0.0",
-    "@zeit/node-file-trace": "0.2.10",
+    "@zeit/node-file-trace": "0.2.11",
     "fs-extra": "7.0.0",
     "get-port": "5.0.0",
     "resolve-from": "5.0.0",

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -28,7 +28,7 @@
     "@types/etag": "1.8.0",
     "@types/test-listen": "1.1.0",
     "@zeit/ncc": "0.20.4",
-    "@zeit/node-file-trace": "0.2.10",
+    "@zeit/node-file-trace": "0.2.11",
     "content-type": "1.0.4",
     "cookie": "0.4.0",
     "etag": "1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1480,10 +1480,10 @@
   resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.20.4.tgz#00f0a25a88cac3712af4ba66561d9e281c6f05c9"
   integrity sha512-fmq+F/QxPec+k/zvT7HiVpk7oiGFseS6brfT/AYqmCUp6QFRK7vZf2Ref46MImsg/g2W3g5X6SRvGRmOAvEfdA==
 
-"@zeit/node-file-trace@0.2.10":
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/@zeit/node-file-trace/-/node-file-trace-0.2.10.tgz#b732b8b9a6aeb6d47590ee69d2ea669765b5b705"
-  integrity sha512-5Bfd7i22shzgXEw2jEI8Hd0b7HEh2XsVrr37RjFP0R8OPQcx0Hc4xWW0dSbu29v3G906xeXLM6+PjGscZVVcAQ==
+"@zeit/node-file-trace@0.2.11":
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/@zeit/node-file-trace/-/node-file-trace-0.2.11.tgz#e8ed920ebf24ccf4913ab3aa3bec6443eb9689d9"
+  integrity sha512-Tdw7999gRFcuWZVIChMNLG01qAZ5PhnKbD3777/dCTTrz6/loc+G90utETkR1/qOZZ7/Dsz8DKWMtd+M8fvkiA==
   dependencies:
     acorn "^6.1.1"
     acorn-stage3 "^2.0.0"


### PR DESCRIPTION
This adds support for webpack-emitted source code, specifically for use in Next.js.