### PR TITLE
[now-next] Always use node-file-trace if available

### DIFF
--- a/packages/now-next/src/create-serverless-config.ts
+++ b/packages/now-next/src/create-serverless-config.ts
@@ -47,10 +47,7 @@ export default async function createServerlessConfig(
   let target = 'serverless';
   if (nextVersion) {
     try {
-      if (
-        nextVersion.includes('canary') &&
-        semver.gte(nextVersion, ExperimentalTraceVersion)
-      ) {
+      if (semver.gte(nextVersion, ExperimentalTraceVersion)) {
         target = 'experimental-serverless-trace';
       }
     } catch (_ignored) {}


### PR DESCRIPTION
We've shipped this change to ZEIT.co so we feel confident in its ability to be the default.

Note for readers: this change is transparently applied by the Next.js builder to achieve faster and more accurate build results, akin to `next dev` behavior. 
You can continue to use `target: 'serverless'` during `next dev` until we make this the default in a future release of Next.js.